### PR TITLE
Fix RQ job path for delivery worker

### DIFF
--- a/backend/api/v1/deliveries.py
+++ b/backend/api/v1/deliveries.py
@@ -36,7 +36,7 @@ async def create_delivery(
         try:
             from backend.workers.tasks import q
             # enqueue with delivery id
-            q.enqueue("app.workers.tasks.process_delivery", dj.id)
+            q.enqueue("backend.workers.tasks.process_delivery", dj.id)
         except Exception:
             # fallback to BackgroundTasks
             background_tasks.add_task(

--- a/docs/contract.md
+++ b/docs/contract.md
@@ -271,7 +271,7 @@ All endpoints are prefixed with `/api`.
 
 ## ✅ Worker and background tasks (IMPLEMENTED)
 
-- ✅ **Redis + RQ integration** for background job processing (app/workers/)
+- ✅ **Redis + RQ integration** for background job processing (backend/workers/)
 - ✅ **DeliveryJob table** with comprehensive status tracking and performance indexes
 - ✅ **Structured job lifecycle** with status updates (pending → running → succeeded/failed)
 - ✅ **Worker process** with proper error handling and result persistence


### PR DESCRIPTION
## Summary
- update the RQ enqueue call in the deliveries API to reference backend.workers.tasks.process_delivery
- align documentation with the backend.workers task module path
- confirmed docker-compose worker commands remain compatible with the updated module path

## Testing
- pytest tests/test_worker.py

------
https://chatgpt.com/codex/tasks/task_e_68cf4c17ada08329968f87f44944822c