### PR TITLE
feat(frontend): add shared types for backend schemas

### DIFF
--- a/app/frontend/src/components/JobQueue.vue
+++ b/app/frontend/src/components/JobQueue.vue
@@ -78,7 +78,9 @@
 import { computed, onMounted, onUnmounted, ref } from 'vue';
 import { storeToRefs } from 'pinia';
 
-import { GenerationJob, useAppStore } from '@/stores/app';
+import { useAppStore } from '@/stores/app';
+
+import type { GenerationJob } from '@/types';
 
 interface Props {
   title?: string;

--- a/app/frontend/src/components/Notifications.vue
+++ b/app/frontend/src/components/Notifications.vue
@@ -42,7 +42,9 @@
 import { ref, watch } from 'vue';
 import { storeToRefs } from 'pinia';
 
-import { NotificationType, useAppStore } from '@/stores/app';
+import { useAppStore } from '@/stores/app';
+
+import type { NotificationType } from '@/types';
 
 const appStore = useAppStore();
 const { notifications } = storeToRefs(appStore);

--- a/app/frontend/src/composables/useNotifications.ts
+++ b/app/frontend/src/composables/useNotifications.ts
@@ -1,6 +1,8 @@
 import { storeToRefs } from 'pinia';
 
-import { NotificationType, useAppStore } from '@/stores/app';
+import { useAppStore } from '@/stores/app';
+
+import type { NotificationType } from '@/types';
 
 export function useNotifications() {
   const appStore = useAppStore();

--- a/app/frontend/src/composables/useSystemStatus.ts
+++ b/app/frontend/src/composables/useSystemStatus.ts
@@ -1,7 +1,9 @@
 import { computed, onBeforeUnmount, onMounted, ref } from 'vue';
 import { storeToRefs } from 'pinia';
 
-import { SystemStatusState, useAppStore } from '@/stores/app';
+import { useAppStore } from '@/stores/app';
+
+import type { SystemStatusState } from '@/types';
 import { useSettingsStore } from '@/stores/settings';
 
 const DEFAULT_STATUS: SystemStatusState = {

--- a/app/frontend/src/stores/app.ts
+++ b/app/frontend/src/stores/app.ts
@@ -1,61 +1,13 @@
 import { defineStore } from 'pinia';
 
-export type SystemStatusState = {
-  gpu_available: boolean;
-  queue_length: number;
-  status: string;
-  gpu_status: string;
-  memory_used: number;
-  memory_total: number;
-};
-
-export type JobStatus =
-  | 'running'
-  | 'completed'
-  | 'failed'
-  | 'cancelled'
-  | 'queued'
-  | 'starting'
-  | 'processing'
-  | string;
-
-export interface GenerationJob {
-  id: string;
-  jobId?: string;
-  name?: string;
-  prompt?: string;
-  status: JobStatus;
-  progress: number;
-  message?: string;
-  startTime: string;
-  params?: Record<string, unknown> & {
-    width?: number;
-    height?: number;
-    steps?: number;
-  };
-  [key: string]: unknown;
-}
-
-export interface GenerationResult {
-  id: string | number;
-  [key: string]: unknown;
-}
-
-export type NotificationType = 'info' | 'success' | 'error' | 'warning';
-
-export interface NotificationEntry {
-  id: number;
-  message: string;
-  type: NotificationType;
-  timestamp: string;
-}
-
-export interface UserPreferences {
-  autoSave: boolean;
-  notifications: boolean;
-  theme: string;
-  [key: string]: unknown;
-}
+import type {
+  GenerationJob,
+  GenerationResult,
+  NotificationEntry,
+  NotificationType,
+  SystemStatusState,
+  UserPreferences,
+} from '@/types';
 
 interface AppState {
   systemStatus: SystemStatusState;

--- a/app/frontend/src/stores/settings.ts
+++ b/app/frontend/src/stores/settings.ts
@@ -1,10 +1,6 @@
 import { defineStore } from 'pinia';
 
-export interface FrontendRuntimeSettings {
-  backendUrl: string;
-  backendApiKey?: string | null;
-  [key: string]: unknown;
-}
+import type { FrontendRuntimeSettings } from '@/types';
 
 interface SettingsState {
   settings: FrontendRuntimeSettings | null;

--- a/app/frontend/src/types/app.ts
+++ b/app/frontend/src/types/app.ts
@@ -1,0 +1,66 @@
+/**
+ * Shared application-level types used by Pinia stores and components.
+ */
+
+export interface SystemStatusState {
+  gpu_available: boolean;
+  queue_length: number;
+  status: string;
+  gpu_status: string;
+  memory_used: number;
+  memory_total: number;
+}
+
+export type JobStatus =
+  | 'running'
+  | 'completed'
+  | 'failed'
+  | 'cancelled'
+  | 'queued'
+  | 'starting'
+  | 'processing'
+  | string;
+
+export interface GenerationJob {
+  id: string;
+  jobId?: string;
+  name?: string;
+  prompt?: string;
+  status: JobStatus;
+  progress: number;
+  message?: string;
+  startTime: string;
+  params?: Record<string, unknown> & {
+    width?: number;
+    height?: number;
+    steps?: number;
+  };
+  [key: string]: unknown;
+}
+
+export interface GenerationResult {
+  id: string | number;
+  [key: string]: unknown;
+}
+
+export type NotificationType = 'info' | 'success' | 'error' | 'warning';
+
+export interface NotificationEntry {
+  id: number;
+  message: string;
+  type: NotificationType;
+  timestamp: string;
+}
+
+export interface UserPreferences {
+  autoSave: boolean;
+  notifications: boolean;
+  theme: string;
+  [key: string]: unknown;
+}
+
+export interface FrontendRuntimeSettings {
+  backendUrl: string;
+  backendApiKey?: string | null;
+  [key: string]: unknown;
+}

--- a/app/frontend/src/types/deliveries.ts
+++ b/app/frontend/src/types/deliveries.ts
@@ -1,0 +1,70 @@
+/**
+ * Type definitions mirroring backend/schemas/deliveries.py.
+ */
+
+export interface ComposeDeliveryHTTP {
+  host: string;
+  port?: number | null;
+  path?: string | null;
+}
+
+export interface ComposeDeliveryCLI {
+  template?: string | null;
+}
+
+export interface ComposeDelivery {
+  mode: string;
+  http?: ComposeDeliveryHTTP | null;
+  cli?: ComposeDeliveryCLI | null;
+}
+
+export interface ComposeDeliveryInfo {
+  id: string;
+  status: string;
+}
+
+export interface ComposeResponse {
+  prompt: string;
+  tokens: string[];
+  delivery?: ComposeDeliveryInfo | null;
+}
+
+export interface ComposeRequest {
+  prefix?: string | null;
+  suffix?: string | null;
+  delivery?: ComposeDelivery | null;
+}
+
+export interface DeliveryCreate {
+  prompt: string;
+  mode: string;
+  /**
+   * Backend accepts arbitrary parameter dictionaries for different delivery engines.
+   * TODO: tighten this definition when concrete parameter schemas are published.
+   */
+  params?: Record<string, unknown> | null;
+}
+
+export interface DeliveryRead {
+  id: string;
+  prompt: string;
+  mode: string;
+  params: Record<string, unknown>;
+  /**
+   * Delivery result varies per delivery type (image URLs, metadata, errors, ...).
+   * TODO: introduce discriminated unions once backend standardises result payloads.
+   */
+  result?: unknown;
+  status: string;
+  created_at: string;
+  started_at?: string | null;
+  finished_at?: string | null;
+}
+
+export interface DeliveryWrapper {
+  delivery: DeliveryRead;
+}
+
+export interface DeliveryCreateResponse {
+  delivery_id: string;
+}

--- a/app/frontend/src/types/generation.ts
+++ b/app/frontend/src/types/generation.ts
@@ -1,0 +1,81 @@
+/**
+ * Type definitions mirroring backend/schemas/generation.py.
+ */
+
+export interface SDNextGenerationParams {
+  prompt: string;
+  negative_prompt?: string | null;
+  steps: number;
+  sampler_name: string;
+  cfg_scale: number;
+  width: number;
+  height: number;
+  seed: number;
+  batch_size: number;
+  n_iter: number;
+  denoising_strength?: number | null;
+}
+
+export interface ComposeDeliverySDNext {
+  generation_params: SDNextGenerationParams;
+  mode?: string;
+  save_images?: boolean;
+  return_format?: string;
+}
+
+export interface SDNextDeliveryParams {
+  generation_params: SDNextGenerationParams;
+  /** One of "immediate" or "deferred". */
+  mode?: string;
+  save_images?: boolean;
+  /** One of "base64", "url", or "file_path". */
+  return_format?: string;
+}
+
+export interface SDNextGenerationResult {
+  job_id: string;
+  /** "pending", "running", "completed", or "failed". */
+  status: string;
+  /** Base64 strings, URLs, or filesystem paths depending on delivery parameters. */
+  images?: string[] | null;
+  /** 0.0–1.0 progress indicator. */
+  progress?: number | null;
+  error_message?: string | null;
+  /**
+   * Backend emits engine-specific metadata here.
+   * TODO: update once generation_info payload is formalised.
+   */
+  generation_info?: Record<string, unknown> | null;
+}
+
+export interface ProgressUpdate {
+  job_id: string;
+  progress: number;
+  status: string;
+  current_step?: number | null;
+  total_steps?: number | null;
+  eta_seconds?: number | null;
+  /** Base64 encoded preview image when available. */
+  preview_image?: string | null;
+  error_message?: string | null;
+}
+
+export interface GenerationStarted {
+  job_id: string;
+  params: SDNextGenerationParams;
+  estimated_duration?: number | null;
+}
+
+export interface GenerationComplete {
+  job_id: string;
+  /** "completed" or "failed". */
+  status: string;
+  images?: string[] | null;
+  error_message?: string | null;
+  total_duration?: number | null;
+  /**
+   * Backend emits engine-specific metadata here.
+   * TODO: align once generation_info gains a stable contract.
+   */
+  generation_info?: Record<string, unknown> | null;
+}

--- a/app/frontend/src/types/index.ts
+++ b/app/frontend/src/types/index.ts
@@ -1,0 +1,5 @@
+export * from './app';
+export * from './lora';
+export * from './deliveries';
+export * from './generation';
+export * from './recommendations';

--- a/app/frontend/src/types/lora.ts
+++ b/app/frontend/src/types/lora.ts
@@ -1,0 +1,105 @@
+/**
+ * Type definitions mirroring backend/schemas/adapters.py.
+ */
+
+/** Request payload for creating a new adapter. */
+export interface AdapterCreate {
+  name: string;
+  version?: string | null;
+  canonical_version_name?: string | null;
+  description?: string | null;
+  author_username?: string | null;
+  visibility?: string | null;
+  published_at?: string | null;
+  tags?: string[] | null;
+  trained_words?: string[] | null;
+  triggers?: string[] | null;
+  file_path: string;
+  weight?: number | null;
+  active?: boolean | null;
+  ordinal?: number | null;
+  primary_file_name?: string | null;
+  primary_file_size_kb?: number | null;
+  primary_file_sha256?: string | null;
+  primary_file_download_url?: string | null;
+  primary_file_local_path?: string | null;
+  supports_generation?: boolean | null;
+  sd_version?: string | null;
+  nsfw_level?: number | null;
+  activation_text?: string | null;
+  /**
+   * Backend stores arbitrary ingestion metrics here.
+   * TODO: replace with a structured shape when the API contract stabilises.
+   */
+  stats?: Record<string, unknown> | null;
+  /**
+   * Backend stores adapter-specific metadata here.
+   * TODO: document concrete keys once the backend schema stops evolving.
+   */
+  extra?: Record<string, unknown> | null;
+  json_file_path?: string | null;
+  json_file_mtime?: string | null;
+  json_file_size?: number | null;
+  last_ingested_at?: string | null;
+}
+
+/** Public adapter representation returned by the API. */
+export interface AdapterRead {
+  id: string;
+  name: string;
+  version?: string | null;
+  canonical_version_name?: string | null;
+  description?: string | null;
+  author_username?: string | null;
+  visibility: string;
+  published_at?: string | null;
+  tags: string[];
+  trained_words: string[];
+  triggers: string[];
+  file_path: string;
+  weight: number;
+  active: boolean;
+  ordinal?: number | null;
+  archetype?: string | null;
+  archetype_confidence?: number | null;
+  primary_file_name?: string | null;
+  primary_file_size_kb?: number | null;
+  primary_file_sha256?: string | null;
+  primary_file_download_url?: string | null;
+  primary_file_local_path?: string | null;
+  supports_generation: boolean;
+  sd_version?: string | null;
+  nsfw_level: number;
+  activation_text?: string | null;
+  /**
+   * Adapter usage statistics emitted by the backend.
+   * TODO: keep this in sync with future stats schema updates.
+   */
+  stats?: Record<string, unknown> | null;
+  /**
+   * Additional metadata supplied by the backend.
+   * TODO: replace with specific keys when the API solidifies.
+   */
+  extra?: Record<string, unknown> | null;
+  json_file_path?: string | null;
+  json_file_mtime?: string | null;
+  json_file_size?: number | null;
+  last_ingested_at?: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+/** Wrapper used by endpoints that return a single adapter. */
+export interface AdapterWrapper {
+  adapter: AdapterRead;
+}
+
+/** Paginated list response for adapter queries. */
+export interface AdapterListResponse {
+  items: AdapterRead[];
+  total: number;
+  filtered: number;
+  page: number;
+  pages: number;
+  per_page: number;
+}

--- a/app/frontend/src/types/recommendations.ts
+++ b/app/frontend/src/types/recommendations.ts
@@ -1,0 +1,126 @@
+/**
+ * Type definitions mirroring backend/schemas/recommendations.py.
+ */
+
+export interface RecommendationRequest {
+  target_lora_id?: string | null;
+  prompt?: string | null;
+  active_loras?: string[];
+  limit?: number;
+  include_explanations?: boolean;
+  weights?: Record<string, number> | null;
+  /**
+   * Filter structure is backend-defined and may evolve.
+   * TODO: sync with backend filter schema when documented.
+   */
+  filters?: Record<string, unknown> | null;
+}
+
+export interface RecommendationItem {
+  lora_id: string;
+  lora_name: string;
+  lora_description?: string | null;
+  similarity_score: number;
+  final_score: number;
+  explanation: string;
+  semantic_similarity?: number | null;
+  artistic_similarity?: number | null;
+  technical_similarity?: number | null;
+  quality_boost?: number | null;
+  popularity_boost?: number | null;
+  recency_boost?: number | null;
+  /**
+   * Recommendation engine attaches contextual metadata here.
+   * TODO: capture specific keys when backend payload stabilises.
+   */
+  metadata?: Record<string, unknown> | null;
+}
+
+export interface RecommendationResponse {
+  target_lora_id?: string | null;
+  prompt?: string | null;
+  recommendations: RecommendationItem[];
+  total_candidates: number;
+  processing_time_ms: number;
+  /**
+   * Backend emits configuration details for debugging.
+   * TODO: document expected shape and replace with strong types.
+   */
+  recommendation_config: Record<string, unknown>;
+  generated_at: string;
+}
+
+export interface PromptRecommendationRequest {
+  prompt: string;
+  active_loras?: string[];
+  limit?: number;
+  include_explanations?: boolean;
+  style_preference?: string | null;
+  technical_requirements?: Record<string, unknown> | null;
+}
+
+export interface SimilarityRequest {
+  target_lora_id: string;
+  limit?: number;
+  include_explanations?: boolean;
+  similarity_threshold?: number;
+  diversify_results?: boolean;
+}
+
+export type UserFeedbackType = 'positive' | 'negative' | 'activated' | 'ignored' | 'dismissed';
+
+export interface UserFeedbackRequest {
+  session_id: string;
+  recommended_lora_id: string;
+  feedback_type: UserFeedbackType;
+  feedback_reason?: string | null;
+  implicit_signal?: boolean;
+}
+
+export type UserPreferenceType = 'archetype' | 'style' | 'technical' | 'author' | 'tag';
+
+export interface UserPreferenceRequest {
+  preference_type: UserPreferenceType;
+  preference_value: string;
+  confidence: number;
+  explicit?: boolean;
+}
+
+export interface RecommendationStats {
+  total_loras: number;
+  loras_with_embeddings: number;
+  embedding_coverage: number;
+  avg_recommendation_time_ms: number;
+  cache_hit_rate: number;
+  total_sessions: number;
+  user_preferences_count: number;
+  feedback_count: number;
+  model_memory_usage_gb: number;
+  last_index_update: string;
+}
+
+export interface EmbeddingStatus {
+  adapter_id: string;
+  has_semantic_embedding: boolean;
+  has_artistic_embedding: boolean;
+  has_technical_embedding: boolean;
+  has_extracted_features: boolean;
+  last_computed?: string | null;
+  needs_recomputation?: boolean;
+}
+
+export interface BatchEmbeddingRequest {
+  adapter_ids?: string[];
+  force_recompute?: boolean;
+  compute_all?: boolean;
+  batch_size?: number;
+}
+
+export interface BatchEmbeddingResponse {
+  processed_count: number;
+  skipped_count: number;
+  error_count: number;
+  processing_time_seconds: number;
+  errors: Array<Record<string, string>>;
+  completed_at: string;
+}


### PR DESCRIPTION
## Summary
- add a frontend types module that mirrors key backend adapter, delivery, generation, and recommendation schemas
- centralize Pinia notification, job, system status, and runtime setting types so they can be imported from a single barrel file
- update stores and composables to consume the shared type exports for consistent typing across the app

## Testing
- npm run type-check

------
https://chatgpt.com/codex/tasks/task_e_68cf647f44788329909f9446b8345cc7