### PR TITLE
feat(frontend): add typed API result handling

### DIFF
--- a/app/frontend/src/components/GenerationStudio.vue
+++ b/app/frontend/src/components/GenerationStudio.vue
@@ -432,7 +432,7 @@
 import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
 import { storeToRefs } from 'pinia'
 
-import { useApi } from '@/composables/useApi'
+import { useActiveJobsApi, useRecentResultsApi, useSystemStatusApi } from '@/composables/apiClients'
 import { useAppStore } from '@/stores/app'
 
 // Reactive state
@@ -463,9 +463,9 @@ const pollInterval = ref(null)
 const isConnected = ref(false)
 
 // API composables
-const { fetchData: loadSystemStatus } = useApi('/api/v1/system/status')
-const { fetchData: loadActiveJobsData } = useApi('/api/v1/generation/jobs/active')
-const { fetchData: loadRecentResultsData } = useApi(() => {
+const { fetchData: loadSystemStatus } = useSystemStatusApi()
+const { fetchData: loadActiveJobsData } = useActiveJobsApi()
+const { fetchData: loadRecentResultsData } = useRecentResultsApi(() => {
   const limit = showHistory.value ? 50 : 10
   return `/api/v1/generation/results?limit=${limit}`
 })

--- a/app/frontend/src/components/PromptComposer.vue
+++ b/app/frontend/src/components/PromptComposer.vue
@@ -128,7 +128,7 @@
 
 <script setup>
 import { computed, onMounted, ref, watch } from 'vue';
-import { useApi } from '@/composables/useApi';
+import { useAdapterListApi } from '@/composables/apiClients';
 
 const STORAGE_KEY = 'prompt-composer-composition';
 const lastSaved = ref(null);
@@ -137,7 +137,7 @@ const lastSaved = ref(null);
 const loras = ref([]);
 const searchTerm = ref('');
 const activeOnly = ref(false);
-const { data, error, isLoading, fetchData: loadLoras } = useApi('/api/v1/adapters?per_page=200&page=1', { credentials: 'same-origin' });
+const { data, error, isLoading, fetchData: loadLoras } = useAdapterListApi('/api/v1/adapters?per_page=200&page=1');
 
 // Composition
 const activeLoras = ref([]);

--- a/app/frontend/src/components/RecommendationsPanel.vue
+++ b/app/frontend/src/components/RecommendationsPanel.vue
@@ -114,7 +114,7 @@
 
 <script setup>
 import { ref, computed, onMounted, watch } from 'vue';
-import { useApi } from '@/composables/useApi';
+import { useAdapterListApi, useRecommendationApi } from '@/composables/apiClients';
 
 // State
 const loras = ref([]);
@@ -136,7 +136,7 @@ const fmtScore = (v) => (v == null ? '-' : Number(v).toFixed(3));
 
 // Data loading via composables
 const lorasUrl = '/api/v1/adapters?per_page=100&page=1';
-const { data: lorasData, error: lorasErr, isLoading: lorasLoading, fetchData: loadLoras } = useApi(lorasUrl, { credentials: 'same-origin' });
+const { data: lorasData, error: lorasErr, isLoading: lorasLoading, fetchData: loadLoras } = useAdapterListApi(lorasUrl);
 
 const fetchLoras = async () => {
   isLoadingLoras.value = true;
@@ -170,7 +170,7 @@ const buildSimilarUrl = () => {
   return `${base}?${params.toString()}`;
 };
 
-const { data: recsData, error: recsErrObj, isLoading: recsLoading, fetchData: loadRecs } = useApi(() => buildSimilarUrl(), { credentials: 'same-origin' });
+const { data: recsData, error: recsErrObj, isLoading: recsLoading, fetchData: loadRecs } = useRecommendationApi(() => buildSimilarUrl());
 
 const fetchRecommendations = async () => {
   if (!selectedLoraId.value) return;

--- a/app/frontend/src/composables/apiClients.ts
+++ b/app/frontend/src/composables/apiClients.ts
@@ -1,0 +1,47 @@
+import type { MaybeRefOrGetter } from 'vue';
+
+import { useApi } from './useApi';
+import type {
+  AdapterListResponse,
+  AdapterRead,
+  GenerationJob,
+  GenerationResult,
+  RecommendationResponse,
+  SystemStatusState,
+} from '@/types';
+
+type AdapterListResult = AdapterListResponse | AdapterRead[];
+
+type SystemStatusResponse = Partial<SystemStatusState> & Record<string, unknown>;
+
+export type DashboardStatsResponse = {
+  stats?: Record<string, unknown>;
+  system_health?: Record<string, unknown>;
+  [key: string]: unknown;
+};
+
+const withCredentials = (init: RequestInit = {}): RequestInit => ({
+  credentials: 'same-origin',
+  ...init,
+});
+
+export const useAdapterListApi = (
+  url: MaybeRefOrGetter<string>,
+  init: RequestInit = {},
+) => useApi<AdapterListResult>(url, withCredentials(init));
+
+export const useRecommendationApi = (
+  url: MaybeRefOrGetter<string>,
+  init: RequestInit = {},
+) => useApi<RecommendationResponse>(url, withCredentials(init));
+
+export const useDashboardStatsApi = () => useApi<DashboardStatsResponse>('/api/v1/dashboard/stats');
+
+export const useSystemStatusApi = () => useApi<SystemStatusResponse>('/api/v1/system/status');
+
+export const useActiveJobsApi = () => useApi<Partial<GenerationJob>[]>('/api/v1/generation/jobs/active');
+
+export const useRecentResultsApi = (
+  url: MaybeRefOrGetter<string>,
+  init: RequestInit = {},
+) => useApi<GenerationResult[]>(url, withCredentials(init));

--- a/app/frontend/src/composables/useApi.ts
+++ b/app/frontend/src/composables/useApi.ts
@@ -1,74 +1,267 @@
-import { MaybeRefOrGetter, Ref, ref, unref } from 'vue';
+import { ref, unref } from 'vue';
+import type { MaybeRefOrGetter, Ref } from 'vue';
 
-interface ApiResponseMeta {
-  ok: boolean;
-  status: number;
-  headers?: Headers;
-}
+import type { ApiResult, ApiResponseMeta, FetchDataOptions, UseApiConfig } from '@/types/api';
+import { ApiError } from '@/types/api';
 
-export function useApi<T = unknown>(url: MaybeRefOrGetter<string>, defaultOptions: RequestInit = {}) {
-  const data = ref<T | null>(null) as Ref<T | null>;
-  const error = ref<unknown>(null);
-  const isLoading = ref(false);
-  const lastResponse = ref<ApiResponseMeta | null>(null);
+const parseJsonOrText = async <TPayload>(response: Response): Promise<TPayload> => {
+  const contentType = response.headers?.get?.('content-type')?.toLowerCase() ?? '';
+  if (contentType.includes('json')) {
+    return (await response.json()) as TPayload;
+  }
+  const text = await response.text();
+  return text as unknown as TPayload;
+};
 
-  const resolveUrl = (): string => {
-    try {
-      const resolved = typeof url === 'function' ? (url as () => string)() : unref(url);
-      return typeof resolved === 'string' ? resolved : '';
-    } catch (err) {
-      if (import.meta.env.DEV) {
-        console.warn('Failed to resolve API URL', err);
+const extractDetailString = (payload: unknown): string | undefined => {
+  if (payload == null) {
+    return undefined;
+  }
+  if (typeof payload === 'string') {
+    const trimmed = payload.trim();
+    return trimmed.length > 0 ? trimmed : undefined;
+  }
+  if (Array.isArray(payload)) {
+    for (const entry of payload) {
+      const extracted = extractDetailString(entry);
+      if (extracted) {
+        return extracted;
       }
-      return '';
     }
+    return undefined;
+  }
+  if (typeof payload === 'object') {
+    const record = payload as Record<string, unknown>;
+    const detailLike = record.detail ?? record.message ?? record.error ?? record.errors;
+    if (typeof detailLike === 'string') {
+      const trimmed = detailLike.trim();
+      return trimmed.length > 0 ? trimmed : undefined;
+    }
+    if (Array.isArray(detailLike)) {
+      return extractDetailString(detailLike);
+    }
+  }
+  return undefined;
+};
+
+const deriveErrorMessage = (payload: unknown, response: Response): string => {
+  const extracted = extractDetailString(payload);
+  if (extracted) {
+    return extracted;
+  }
+  const statusText = response.statusText?.trim?.();
+  if (statusText) {
+    return statusText;
+  }
+  return `Request failed with status ${response.status}`;
+};
+
+const createMetaFromResponse = (response: Response): ApiResponseMeta => ({
+  ok: response.ok,
+  status: response.status,
+  statusText: response.statusText ?? '',
+  url: response.url ?? '',
+  headers: response.headers,
+});
+
+const isFetchOptions = <TData, TError>(value: unknown): value is FetchDataOptions<TData, TError> => {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+  return 'parseResponse' in value || 'parseError' in value || 'init' in value;
+};
+
+const normalizeOptions = <TData, TError>(
+  arg?: RequestInit | FetchDataOptions<TData, TError>,
+): FetchDataOptions<TData, TError> => {
+  if (!arg) {
+    return {};
+  }
+  if (isFetchOptions<TData, TError>(arg)) {
+    return arg;
+  }
+  return { init: arg };
+};
+
+const resolveUrlValue = (url: MaybeRefOrGetter<string>): string => {
+  try {
+    const resolved = typeof url === 'function' ? (url as () => string)() : unref(url);
+    return typeof resolved === 'string' ? resolved : '';
+  } catch (err) {
+    if (import.meta.env.DEV) {
+      console.warn('Failed to resolve API URL', err);
+    }
+    return '';
+  }
+};
+
+const fallbackMeta = (url: string, overrides: Partial<ApiResponseMeta> = {}): ApiResponseMeta => ({
+  ok: overrides.ok ?? false,
+  status: overrides.status ?? 0,
+  statusText: overrides.statusText ?? '',
+  url: overrides.url ?? url,
+  headers: overrides.headers ?? new Headers(),
+});
+
+/**
+ * Typed wrapper around the Fetch API that exposes reactive state and helpers.
+ *
+ * @example Basic JSON usage
+ * ```ts
+ * import type { AdapterListResponse } from '@/types';
+ *
+ * const { data, fetchData } = useApi<AdapterListResponse>('/api/v1/adapters');
+ * await fetchData();
+ * console.log(data.value?.items.length);
+ * ```
+ *
+ * @example Custom parser for non-JSON payloads
+ * ```ts
+ * const { fetchData } = useApi<Blob>('/api/v1/reports/latest', {}, {
+ *   parseResponse: (response) => response.blob(),
+ * });
+ * const reportBlob = await fetchData();
+ * ```
+ */
+export function useApi<TData, TError = unknown>(
+  url: MaybeRefOrGetter<string>,
+  defaultOptions: RequestInit = {},
+  config: UseApiConfig<TData, TError> = {},
+): UseApiReturn<TData, TError> {
+  const result = ref<ApiResult<TData, TError> | null>(null);
+  const isLoading = ref(false);
+  const data = ref<TData | null>(null);
+  const error = ref<ApiError<TError> | null>(null);
+  const meta = ref<ApiResponseMeta | null>(null);
+
+  const applyState = (patch: Partial<ApiResult<TData, TError>>) => {
+    const current: ApiResult<TData, TError> = {
+      data: data.value,
+      error: error.value,
+      meta: meta.value,
+    };
+
+    const dataValue =
+      Object.prototype.hasOwnProperty.call(patch, 'data')
+        ? ((patch.data ?? null) as TData | null)
+        : current.data ?? null;
+    const errorValue =
+      Object.prototype.hasOwnProperty.call(patch, 'error')
+        ? ((patch.error ?? null) as ApiError<TError> | null)
+        : current.error ?? null;
+    const metaValue =
+      Object.prototype.hasOwnProperty.call(patch, 'meta')
+        ? ((patch.meta ?? null) as ApiResponseMeta | null)
+        : current.meta ?? null;
+
+    data.value = dataValue;
+    error.value = errorValue;
+    meta.value = metaValue;
+    result.value = {
+      data: data.value,
+      error: error.value,
+      meta: meta.value,
+    };
   };
 
-  const fetchData = async (init: RequestInit = {}) => {
-    const targetUrl = resolveUrl();
+  const fetchData = async (
+    arg?: RequestInit | FetchDataOptions<TData, TError>,
+  ): Promise<TData> => {
+    const targetUrl = resolveUrlValue(url);
     if (!targetUrl) {
       throw new Error('Invalid API URL');
     }
 
     isLoading.value = true;
-    error.value = null;
+    applyState({ error: null });
+
+    const options = normalizeOptions(arg);
+    const parseResponse = options.parseResponse ?? config.parseResponse ?? ((response: Response) => parseJsonOrText<TData>(response));
+    const parseError = options.parseError ?? config.parseError ?? ((response: Response) => parseJsonOrText<TError>(response));
 
     try {
-      const response = await fetch(targetUrl, { credentials: 'same-origin', ...defaultOptions, ...init });
-      lastResponse.value = {
-        ok: response.ok,
-        status: response.status,
-        headers: response.headers,
-      };
+      const response = await fetch(targetUrl, {
+        credentials: 'same-origin',
+        ...defaultOptions,
+        ...options.init,
+      });
+
+      const metaInfo = createMetaFromResponse(response);
+      applyState({ meta: metaInfo });
 
       if (!response.ok) {
-        const message = await response.text();
-        throw new Error(message || `Request failed with status ${response.status}`);
+        let payload: TError | undefined;
+        try {
+          payload = await parseError(response);
+        } catch (parseErr) {
+          if (import.meta.env.DEV) {
+            console.warn('Failed to parse API error payload', parseErr);
+          }
+        }
+
+        const apiError = new ApiError<TError>({
+          message: deriveErrorMessage(payload, response),
+          status: response.status,
+          statusText: response.statusText,
+          payload,
+          meta: metaInfo,
+          response,
+        });
+        applyState({ error: apiError, data: null, meta: metaInfo });
+        throw apiError;
       }
 
-      const contentType = typeof response.headers?.get === 'function'
-        ? response.headers.get('content-type') ?? ''
-        : '';
-      if (contentType.includes('application/json')) {
-        data.value = (await response.json()) as T;
-      } else {
-        data.value = (await response.text()) as unknown as T;
-      }
+      const parsed = await parseResponse(response);
+      applyState({ data: parsed, error: null });
+      return parsed;
     } catch (err) {
-      error.value = err;
-      if (!lastResponse.value) {
-        lastResponse.value = {
-          ok: false,
-          status: err instanceof Response ? err.status : 0,
-        };
+      if (err instanceof ApiError) {
+        if (!meta.value) {
+          applyState({ meta: err.meta });
+        }
+        applyState({ error: err, data: null });
+        throw err;
       }
-      throw err;
+
+      const responseLike = err instanceof Response ? err : undefined;
+      const metaInfo = responseLike
+        ? createMetaFromResponse(responseLike)
+        : meta.value ?? fallbackMeta(targetUrl);
+
+      const message = err instanceof Error ? err.message : 'Unknown error';
+      const apiError = new ApiError<TError>({
+        message: message || 'Network error',
+        status: metaInfo.status,
+        statusText: metaInfo.statusText,
+        meta: metaInfo,
+        response: responseLike,
+        cause: err instanceof Error ? err : undefined,
+      });
+
+      applyState({ meta: metaInfo, error: apiError, data: null });
+      throw apiError;
     } finally {
       isLoading.value = false;
     }
   };
 
-  return { data, error, isLoading, fetchData, lastResponse };
+  return {
+    data,
+    error,
+    isLoading,
+    fetchData,
+    meta,
+    lastResponse: meta,
+    result,
+  } as UseApiReturn<TData, TError>;
 }
 
-export type UseApiReturn<T> = ReturnType<typeof useApi<T>>;
+export interface UseApiReturn<TData, TError = unknown> {
+  data: Ref<TData | null>;
+  error: Ref<ApiError<TError> | null>;
+  isLoading: Ref<boolean>;
+  fetchData: (arg?: RequestInit | FetchDataOptions<TData, TError>) => Promise<TData>;
+  meta: Ref<ApiResponseMeta | null>;
+  lastResponse: Ref<ApiResponseMeta | null>;
+  result: Ref<ApiResult<TData, TError> | null>;
+}

--- a/app/frontend/src/types/api.ts
+++ b/app/frontend/src/types/api.ts
@@ -1,0 +1,64 @@
+/**
+ * Shared API helper types used by composables and services.
+ */
+
+/** Metadata describing the last HTTP response returned by an API call. */
+export interface ApiResponseMeta {
+  ok: boolean;
+  status: number;
+  statusText: string;
+  url: string;
+  headers: Headers;
+}
+
+/** Function signature for transforming a fetch Response into typed data. */
+export type ResponseParser<T> = (response: Response) => Promise<T>;
+
+/** Optional configuration supplied when creating a useApi instance. */
+export interface UseApiConfig<TData, TError> {
+  parseResponse?: ResponseParser<TData>;
+  parseError?: ResponseParser<TError>;
+}
+
+/** Options accepted by fetchData for overriding request/parse behaviour. */
+export interface FetchDataOptions<TData, TError> extends UseApiConfig<TData, TError> {
+  init?: RequestInit;
+}
+
+interface ApiErrorInit<TPayload> {
+  message: string;
+  status: number;
+  statusText?: string;
+  payload?: TPayload;
+  meta: ApiResponseMeta;
+  response?: Response;
+  cause?: unknown;
+}
+
+/**
+ * Normalised error thrown by the API composables.
+ */
+export class ApiError<TPayload = unknown> extends Error {
+  readonly status: number;
+  readonly statusText: string;
+  readonly payload?: TPayload;
+  readonly meta: ApiResponseMeta;
+  readonly response?: Response;
+
+  constructor(init: ApiErrorInit<TPayload>) {
+    super(init.message, init.cause ? { cause: init.cause } : undefined);
+    this.name = 'ApiError';
+    this.status = init.status;
+    this.statusText = init.statusText ?? '';
+    this.payload = init.payload;
+    this.meta = init.meta;
+    this.response = init.response;
+  }
+}
+
+/** Structured result object returned by API composables. */
+export interface ApiResult<TData = unknown, TError = unknown> {
+  data: TData | null;
+  error: ApiError<TError> | null;
+  meta: ApiResponseMeta | null;
+}

--- a/app/frontend/src/types/index.ts
+++ b/app/frontend/src/types/index.ts
@@ -3,3 +3,4 @@ export * from './lora';
 export * from './deliveries';
 export * from './generation';
 export * from './recommendations';
+export * from './api';


### PR DESCRIPTION
## Summary
- add ApiResult/ApiError types for structured frontend API results
- update useApi to expose typed metadata, allow custom parsers, and surface ApiError instances
- create typed API client helpers and update key components to use them

## Testing
- npm run type-check

------
https://chatgpt.com/codex/tasks/task_e_68cf65fb1d888329a83148037d6b4614