### PR TITLE
Refactor system status components to use typed script setup

### DIFF
--- a/app/frontend/src/components/SystemStatusCardDetailed.vue
+++ b/app/frontend/src/components/SystemStatusCardDetailed.vue
@@ -26,35 +26,24 @@
   </div>
 </template>
 
-<script setup>
-defineProps({
-  gpuStatusClass: {
-    type: [String, Object, Array],
-    default: '',
-  },
-  gpuStatusLabel: {
-    type: String,
-    default: 'Unknown',
-  },
-  queueJobsLabel: {
-    type: String,
-    default: '0 jobs',
-  },
-  hasMemoryData: {
-    type: Boolean,
-    default: false,
-  },
-  memoryUsage: {
-    type: String,
-    default: 'N/A',
-  },
-  memoryPercent: {
-    type: Number,
-    default: 0,
-  },
-  lastUpdatedLabel: {
-    type: String,
-    default: 'Never',
-  },
+<script setup lang="ts">
+import type { SystemStatusCardDetailedProps } from '@/types';
+
+const {
+  gpuStatusClass,
+  gpuStatusLabel,
+  queueJobsLabel,
+  hasMemoryData,
+  memoryUsage,
+  memoryPercent,
+  lastUpdatedLabel,
+} = withDefaults(defineProps<SystemStatusCardDetailedProps>(), {
+  gpuStatusClass: '',
+  gpuStatusLabel: 'Unknown',
+  queueJobsLabel: '0 jobs',
+  hasMemoryData: false,
+  memoryUsage: 'N/A',
+  memoryPercent: 0,
+  lastUpdatedLabel: 'Never',
 });
 </script>

--- a/app/frontend/src/components/SystemStatusCardSimple.vue
+++ b/app/frontend/src/components/SystemStatusCardSimple.vue
@@ -22,31 +22,22 @@
   </div>
 </template>
 
-<script setup>
-defineProps({
-  gpuStatusClass: {
-    type: [String, Object, Array],
-    default: '',
-  },
-  gpuStatusLabel: {
-    type: String,
-    default: 'Unknown',
-  },
-  queueLength: {
-    type: [Number, String],
-    default: 0,
-  },
-  memoryUsage: {
-    type: String,
-    default: 'N/A',
-  },
-  statusIcon: {
-    type: String,
-    default: '',
-  },
-  statusLabel: {
-    type: String,
-    default: 'Unknown',
-  },
+<script setup lang="ts">
+import type { SystemStatusCardSimpleProps } from '@/types';
+
+const {
+  gpuStatusClass,
+  gpuStatusLabel,
+  queueLength,
+  memoryUsage,
+  statusIcon,
+  statusLabel,
+} = withDefaults(defineProps<SystemStatusCardSimpleProps>(), {
+  gpuStatusClass: '',
+  gpuStatusLabel: 'Unknown',
+  queueLength: 0,
+  memoryUsage: 'N/A',
+  statusIcon: '',
+  statusLabel: 'Unknown',
 });
 </script>

--- a/app/frontend/src/services/systemService.ts
+++ b/app/frontend/src/services/systemService.ts
@@ -53,3 +53,106 @@ export const emptyMetricsSnapshot = (): SystemMetricsSnapshot => ({
   disk_total: 0,
   gpus: [],
 });
+
+const SIZE_UNITS: Record<string, number> = {
+  B: 1,
+  KB: 1024,
+  MB: 1024 ** 2,
+  GB: 1024 ** 3,
+  TB: 1024 ** 4,
+};
+
+const clampPercentage = (value: number): number => {
+  if (!Number.isFinite(value)) {
+    return 0;
+  }
+  return Math.min(100, Math.max(0, Math.round(value)));
+};
+
+const toBytes = (match: RegExpMatchArray): number => {
+  const value = Number.parseFloat(match[1] ?? '0');
+  if (!Number.isFinite(value) || value <= 0) {
+    return 0;
+  }
+  const unit = (match[2] ?? 'B').toUpperCase();
+  const multiplier = SIZE_UNITS[unit] ?? 1;
+  return value * multiplier;
+};
+
+const parseUsageString = (input?: string | null): { used: number; total: number } | null => {
+  if (!input) {
+    return null;
+  }
+
+  const matches = Array.from(input.matchAll(/(\d+(?:\.\d+)?)\s*(B|KB|MB|GB|TB)/gi));
+  if (!matches.length) {
+    return null;
+  }
+
+  const used = toBytes(matches[0]);
+  const total = matches[1] ? toBytes(matches[1]) : used;
+
+  if (!Number.isFinite(used) || used < 0) {
+    return null;
+  }
+
+  return {
+    used,
+    total: Number.isFinite(total) && total > 0 ? total : used,
+  };
+};
+
+const parsePercentage = (input?: string | null): number | null => {
+  if (!input) {
+    return null;
+  }
+
+  const match = input.match(/(\d+(?:\.\d+)?)\s*%/);
+  if (!match) {
+    return null;
+  }
+
+  const value = Number.parseFloat(match[1] ?? '0');
+  return Number.isFinite(value) ? value : null;
+};
+
+export const deriveMetricsFromDashboard = (
+  summary?: DashboardStatsSummary | null,
+): SystemMetricsSnapshot => {
+  const snapshot = emptyMetricsSnapshot();
+  if (!summary) {
+    return snapshot;
+  }
+
+  const health = summary.system_health ?? {};
+
+  const memoryUsage = parseUsageString(health.gpu_memory);
+  if (memoryUsage) {
+    snapshot.memory_used = memoryUsage.used;
+    snapshot.memory_total = memoryUsage.total;
+    snapshot.memory_percent = memoryUsage.total
+      ? clampPercentage((memoryUsage.used / memoryUsage.total) * 100)
+      : 0;
+  } else {
+    const memoryPercent = parsePercentage(health.gpu_memory);
+    if (memoryPercent != null) {
+      snapshot.memory_percent = clampPercentage(memoryPercent);
+    }
+  }
+
+  const diskUsage = parseUsageString(health.storage_usage);
+  if (diskUsage) {
+    snapshot.disk_used = diskUsage.used;
+    snapshot.disk_total = diskUsage.total;
+    snapshot.disk_percent = diskUsage.total
+      ? clampPercentage((diskUsage.used / diskUsage.total) * 100)
+      : snapshot.disk_percent;
+  } else {
+    const diskPercent = parsePercentage(health.storage_usage);
+    if (diskPercent != null) {
+      snapshot.disk_percent = clampPercentage(diskPercent);
+    }
+  }
+
+  return snapshot;
+};

--- a/app/frontend/src/types/system.ts
+++ b/app/frontend/src/types/system.ts
@@ -4,6 +4,46 @@
 
 import type { SystemStatusState } from './app';
 
+export type StatusClassBinding = string | string[] | Record<string, boolean>;
+
+export type StatusLabel = string;
+
+export interface SystemStatusCardDetailedProps {
+  gpuStatusClass?: StatusClassBinding;
+  gpuStatusLabel?: StatusLabel;
+  queueJobsLabel?: string;
+  hasMemoryData?: boolean;
+  memoryUsage?: string;
+  memoryPercent?: number;
+  lastUpdatedLabel?: string;
+}
+
+export interface SystemStatusCardSimpleProps {
+  gpuStatusClass?: StatusClassBinding;
+  gpuStatusLabel?: StatusLabel;
+  queueLength?: number | string;
+  memoryUsage?: string;
+  statusIcon?: string;
+  statusLabel?: StatusLabel;
+}
+
+export type SystemStatusLevel = 'healthy' | 'warning' | 'error' | 'unknown';
+
+export interface SystemStatusOverview {
+  overall: SystemStatusLevel;
+  last_check: string;
+}
+
+export interface SystemResourceStatsSummary {
+  uptime: string;
+  active_workers: number;
+  total_workers: number;
+  database_size: number;
+  total_records: number;
+  gpu_memory_used: string;
+  gpu_memory_total: string;
+}
+
 export interface GpuTelemetry {
   id: string | number;
   name: string;


### PR DESCRIPTION
## Summary
- convert SystemStatusCardDetailed and SystemStatusCardSimple to `<script setup lang="ts">` with shared typed props
- extend system metrics types and service helpers to derive snapshots from dashboard responses
- refactor SystemStatusPanel and SystemAdminStatusCard to use the typed helpers, stricter status evaluation, and safer UI bindings

## Testing
- pnpm run type-check

------
https://chatgpt.com/codex/tasks/task_e_68cf861a142c8329aeb6bc33f48c2f0f