### PR TITLE
Add TypeScript typing to mobile navigation components

### DIFF
--- a/app/frontend/src/components/HelloWorld.vue
+++ b/app/frontend/src/components/HelloWorld.vue
@@ -6,8 +6,9 @@
   
 </template>
 
-<script setup>
+<script setup lang="ts">
 import { ref } from 'vue';
-const message = ref('This is our first Vue island.');
+
+const message = ref<string>('This is our first Vue island.');
 </script>
 

--- a/app/frontend/src/components/MobileNav.vue
+++ b/app/frontend/src/components/MobileNav.vue
@@ -82,12 +82,25 @@
   
 </template>
 
-<script setup>
+<script setup lang="ts">
 import { ref, onMounted, onBeforeUnmount } from 'vue';
 
-const isOpen = ref(false);
+type NavIcon =
+  | 'dashboard'
+  | 'grid'
+  | 'spark'
+  | 'compose'
+  | 'wand'
+  | 'admin'
+  | 'bars';
 
-const items = [
+interface NavItem {
+  path: string;
+  label: string;
+  icon: NavIcon;
+}
+
+const NAV_ITEMS: ReadonlyArray<NavItem> = [
   { path: '/', label: 'Dashboard', icon: 'dashboard' },
   { path: '/loras', label: 'LoRAs', icon: 'grid' },
   { path: '/recommendations', label: 'Recommendations', icon: 'spark' },
@@ -98,25 +111,42 @@ const items = [
   { path: '/import-export', label: 'Import/Export', icon: 'grid' },
 ];
 
-const toggleMenu = () => { isOpen.value = !isOpen.value; };
-const closeMenu = () => { isOpen.value = false; };
+const isOpen = ref<boolean>(false);
+const items = NAV_ITEMS;
 
-const isActive = (path) => {
-  try {
-    return (window?.location?.pathname || '').replace(/\/+$/, '') === path;
-  } catch { return false; }
+const toggleMenu = (): void => {
+  isOpen.value = !isOpen.value;
 };
 
-const onKeydown = (e) => {
-  if (e.key === 'Escape') closeMenu();
+const closeMenu = (): void => {
+  isOpen.value = false;
 };
 
-onMounted(() => {
-  document.addEventListener('keydown', onKeydown);
+const isActive = (path: string): boolean => {
+  if (typeof window === 'undefined') {
+    return false;
+  }
+
+  const currentPath = window.location?.pathname ?? '';
+  return currentPath.replace(/\/+$/, '') === path;
+};
+
+const onKeydown = (event: KeyboardEvent): void => {
+  if (event.key === 'Escape') {
+    closeMenu();
+  }
+};
+
+onMounted((): void => {
+  if (typeof window !== 'undefined') {
+    window.addEventListener('keydown', onKeydown);
+  }
 });
 
-onBeforeUnmount(() => {
-  document.removeEventListener('keydown', onKeydown);
+onBeforeUnmount((): void => {
+  if (typeof window !== 'undefined') {
+    window.removeEventListener('keydown', onKeydown);
+  }
 });
 </script>
 


### PR DESCRIPTION
## Summary
- enable TypeScript in the MobileNav and HelloWorld Vue components
- define typed navigation metadata and DOM event handlers for the mobile menu
- guard browser globals to keep the menu safe for SSR usage

## Testing
- pnpm run type-check

------
https://chatgpt.com/codex/tasks/task_e_68cf8d8d7694832980b560e2a84c5dcb