### PR TITLE
Refactor LoRA gallery components to TypeScript

### DIFF
--- a/app/frontend/src/types/lora.ts
+++ b/app/frontend/src/types/lora.ts
@@ -105,6 +105,20 @@ export interface AdapterListResponse {
   per_page: number;
 }
 
+export type LoraListItem = Omit<AdapterRead, 'weight' | 'tags'> & {
+  tags?: AdapterRead['tags'];
+  /** Optional preview image resolved on the client side. */
+  preview_image?: string | null;
+  /** Weight slider value, defaults to adapter weight when missing. */
+  weight?: AdapterRead['weight'];
+  /** Quality score surfaced by the UI layer. */
+  quality_score?: number | null;
+  /** Optional adapter type surfaced only in the gallery UI. */
+  type?: string | null;
+};
+
+export type GalleryLora = LoraListItem;
+
 export interface AdapterListQuery {
   page?: number;
   perPage?: number;
@@ -151,4 +165,13 @@ export interface LoraGalleryState {
   availableTags: string[];
   showAllTags: boolean;
   selection: LoraGallerySelectionState;
+}
+
+export type LoraUpdateType = 'weight' | 'active';
+
+export interface LoraUpdatePayload {
+  id: string;
+  type: LoraUpdateType;
+  weight?: number;
+  active?: boolean;
 }


### PR DESCRIPTION
## Summary
- convert the LoRA gallery and card components to TypeScript with typed props, emits, and UI guards
- add typed LoRA list interfaces and extend the service layer with useApi-based helpers for card actions
- update the gallery state management to use the new types and stricter view-mode handling

## Testing
- pnpm run type-check

------
https://chatgpt.com/codex/tasks/task_e_68cf99681a588329a8bf2a3e12b23b07