### PR TITLE
Refactor PromptComposer with typed generation service

### DIFF
--- a/app/frontend/src/services/generationService.ts
+++ b/app/frontend/src/services/generationService.ts
@@ -1,0 +1,38 @@
+import type { CompositionEntry, SDNextGenerationParams, SDNextGenerationResult } from '@/types';
+import { postJson } from '@/utils/api';
+
+export type GenerationParamOverrides =
+  & Pick<SDNextGenerationParams, 'prompt'>
+  & Partial<Omit<SDNextGenerationParams, 'prompt'>>;
+
+export type GenerationRequestBody = SDNextGenerationParams & {
+  loras?: CompositionEntry[];
+};
+
+export const createGenerationParams = (
+  overrides: GenerationParamOverrides,
+): SDNextGenerationParams => ({
+  prompt: overrides.prompt,
+  negative_prompt: overrides.negative_prompt ?? null,
+  steps: overrides.steps ?? 20,
+  sampler_name: overrides.sampler_name ?? 'DPM++ 2M',
+  cfg_scale: overrides.cfg_scale ?? 7.0,
+  width: overrides.width ?? 512,
+  height: overrides.height ?? 512,
+  seed: overrides.seed ?? -1,
+  batch_size: overrides.batch_size ?? 1,
+  n_iter: overrides.n_iter ?? 1,
+  denoising_strength: overrides.denoising_strength ?? null,
+});
+
+export const requestGeneration = async (
+  payload: GenerationRequestBody,
+): Promise<SDNextGenerationResult | null> => {
+  const { data } = await postJson<SDNextGenerationResult, GenerationRequestBody>(
+    '/api/v1/generation/generate',
+    payload,
+    { credentials: 'same-origin' },
+  );
+  return data;
+};
+

--- a/app/frontend/src/types/index.ts
+++ b/app/frontend/src/types/index.ts
@@ -5,3 +5,4 @@ export * from './generation';
 export * from './recommendations';
 export * from './api';
 export * from './system';
+export * from './promptComposer';

--- a/app/frontend/src/types/promptComposer.ts
+++ b/app/frontend/src/types/promptComposer.ts
@@ -1,0 +1,21 @@
+import type { AdapterRead } from './lora';
+
+export interface AdapterSummary {
+  id: AdapterRead['id'];
+  name: AdapterRead['name'];
+  description?: AdapterRead['description'];
+  active: boolean;
+}
+
+export interface CompositionEntry {
+  id: AdapterRead['id'];
+  name: AdapterRead['name'];
+  weight: number;
+}
+
+export interface SavedComposition {
+  items: CompositionEntry[];
+  base: string;
+  neg: string;
+}
+


### PR DESCRIPTION
## Summary
- migrate PromptComposer.vue to the TypeScript `<script setup>` syntax with typed refs, watchers, and storage helpers
- add a generation service wrapper that posts `SDNextGenerationParams` payloads to `/api/v1/generation/generate`
- introduce reusable prompt composer types and export them via the shared type barrel

## Testing
- pnpm run type-check

------
https://chatgpt.com/codex/tasks/task_e_68cf9bc2adbc83299f0309d8a39cb015