### PR TITLE
Refine generation history typing and services

### DIFF
--- a/app/frontend/src/types/generation.ts
+++ b/app/frontend/src/types/generation.ts
@@ -75,7 +75,7 @@ export interface GenerationLoraReference {
   extra?: Record<string, unknown> | null;
 }
 
-export interface GenerationHistoryEntry {
+export interface GenerationHistoryResult {
   id: string | number;
   job_id?: string | null;
   prompt: string;
@@ -103,6 +103,8 @@ export interface GenerationHistoryEntry {
   [key: string]: unknown;
 }
 
+export type GenerationHistoryEntry = GenerationHistoryResult;
+
 export interface GenerationHistoryPageInfo {
   page?: number;
   page_size?: number;
@@ -113,11 +115,23 @@ export interface GenerationHistoryPageInfo {
   previous_page?: number | null;
 }
 
-export interface GenerationHistoryResponse extends GenerationHistoryPageInfo {
-  results: GenerationHistoryEntry[];
+export interface GenerationHistoryStats {
+  total_results: number;
+  avg_rating: number;
+  total_favorites: number;
+  total_size: number;
 }
 
-export type GenerationHistoryPayload = GenerationHistoryEntry[] | GenerationHistoryResponse;
+export interface GenerationHistoryResponse extends GenerationHistoryPageInfo {
+  results: GenerationHistoryResult[];
+  stats?: GenerationHistoryStats;
+}
+
+export type GenerationHistoryPayload = GenerationHistoryResult[] | GenerationHistoryResponse;
+
+export interface GenerationHistoryListResponse extends GenerationHistoryResponse {}
+
+export type GenerationHistoryListPayload = GenerationHistoryResult[] | GenerationHistoryListResponse;
 
 export interface GenerationHistoryQuery {
   page?: number;


### PR DESCRIPTION
## Summary
- add strongly typed generation history payloads and stats definitions
- overhaul the history service to provide typed helpers for listing, rating, favorites, deletion, exports, and downloads
- update the generation history component to leverage the typed service, refine reactive state, and guard filtering logic

## Testing
- pnpm run type-check

------
https://chatgpt.com/codex/tasks/task_e_68d01343ddd88329a4989da99f3b0a29