### PR TITLE
Add Vue navigation shell and theme handling

### DIFF
--- a/app/frontend/src/App.vue
+++ b/app/frontend/src/App.vue
@@ -1,26 +1,40 @@
 <template>
   <div class="app-shell min-h-screen bg-slate-50 text-slate-900">
+    <a class="skip-link" href="#main-content">Skip to main content</a>
+    <a class="skip-link" href="#navigation">Skip to navigation</a>
+
     <MobileNav />
-    <div class="mx-auto flex w-full max-w-7xl flex-col gap-6 px-4 pb-10 pt-6">
-      <header class="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
-        <div>
-          <h1 class="text-3xl font-semibold tracking-tight text-slate-900">LoRA Manager</h1>
-          <p class="text-sm text-slate-600">
-            Monitor system status, manage jobs, and explore recommendations.
-          </p>
-        </div>
-      </header>
-      <main class="flex-1">
+    <MainNavigation />
+
+    <main id="main-content" class="main-content" tabindex="-1">
+      <div class="content-wrapper px-4 pb-12 pt-8">
+        <header class="flex flex-col gap-2 pb-4 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <h1 class="text-3xl font-semibold tracking-tight text-slate-900">LoRA Manager</h1>
+            <p class="text-sm text-slate-600">
+              Monitor system status, manage jobs, and explore recommendations.
+            </p>
+          </div>
+          <div class="hidden items-center gap-2 sm:flex">
+            <RouterLink class="btn btn-secondary btn-sm" to="/loras">Browse LoRAs</RouterLink>
+            <RouterLink class="btn btn-primary btn-sm" to="/generate">Open Generation Studio</RouterLink>
+          </div>
+        </header>
+
         <RouterView />
-      </main>
-    </div>
+      </div>
+    </main>
+
+    <AppFooter />
     <Notifications />
   </div>
 </template>
 
 <script setup lang="ts">
-import { RouterView } from 'vue-router';
+import { RouterLink, RouterView } from 'vue-router';
 
+import AppFooter from '@/components/AppFooter.vue';
+import MainNavigation from '@/components/MainNavigation.vue';
 import MobileNav from '@/components/MobileNav.vue';
 import Notifications from '@/components/Notifications.vue';
 </script>

--- a/app/frontend/src/components/AppFooter.vue
+++ b/app/frontend/src/components/AppFooter.vue
@@ -1,0 +1,18 @@
+<template>
+  <footer class="main-footer border-t border-slate-200 bg-white/90 py-6">
+    <div class="nav-container flex flex-col gap-2 text-sm text-slate-500 sm:flex-row sm:items-center sm:justify-between">
+      <p class="footer-text m-0">
+        LoRA Manager — AI-Powered LoRA Management System
+      </p>
+      <div class="flex flex-wrap items-center gap-3">
+        <RouterLink class="hover:text-slate-700" to="/offline">Offline Mode</RouterLink>
+        <a class="hover:text-slate-700" href="https://github.com" target="_blank" rel="noreferrer">GitHub</a>
+        <a class="hover:text-slate-700" href="mailto:support@example.com">Support</a>
+      </div>
+    </div>
+  </footer>
+</template>
+
+<script setup lang="ts">
+import { RouterLink } from 'vue-router';
+</script>

--- a/app/frontend/src/components/MainNavigation.vue
+++ b/app/frontend/src/components/MainNavigation.vue
@@ -1,0 +1,202 @@
+<template>
+  <nav
+    id="navigation"
+    class="main-nav hidden lg:block"
+    role="navigation"
+    aria-label="Main navigation"
+  >
+    <div class="nav-container">
+      <div class="nav-header">
+        <RouterLink
+          to="/"
+          class="nav-title flex items-center gap-2 text-slate-900"
+          aria-label="Go to dashboard"
+        >
+          <svg class="h-8 w-8" viewBox="0 0 24 24" fill="none" stroke="currentColor">
+            <path d="M12 2L2 7l10 5 10-5-10-5Z" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+            <path d="M2 17l10 5 10-5" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+            <path d="M2 12l10 5 10-5" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+          </svg>
+          <span>LoRA Manager</span>
+        </RouterLink>
+        <span class="hidden text-sm text-gray-500 xl:inline">
+          Manage LoRAs · catalog · recommendations · generation
+        </span>
+        <div class="nav-actions flex items-center gap-2">
+          <form class="hidden items-center gap-2 md:flex" role="search" @submit.prevent="handleSearch">
+            <label class="sr-only" for="global-search">Search LoRAs</label>
+            <input
+              id="global-search"
+              v-model="searchQuery"
+              type="search"
+              placeholder="Search LoRAs, tags, models..."
+              class="form-input w-56"
+              autocomplete="off"
+            />
+            <button class="btn btn-secondary btn-icon" type="submit" :disabled="!canSearch">
+              <svg class="h-5 w-5" viewBox="0 0 24 24" fill="none" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m21 21-6-6m2-5a7 7 0 1 1-14 0 7 7 0 0 1 14 0Z" />
+              </svg>
+              <span class="sr-only">Submit search</span>
+            </button>
+          </form>
+
+          <button
+            class="btn btn-secondary btn-icon"
+            type="button"
+            :aria-label="themeToggleLabel"
+            @click="toggleTheme"
+          >
+            <svg v-if="currentTheme === 'dark'" class="h-5 w-5" viewBox="0 0 24 24" fill="none" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79Z" />
+            </svg>
+            <svg v-else class="h-5 w-5" viewBox="0 0 24 24" fill="none" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 3v2m0 14v2m9-9h-2M7 12H5m15.364 6.364-1.414-1.414M7.05 7.05 5.636 5.636m12.728 0-1.414 1.414M7.05 16.95l-1.414 1.414M16 12a4 4 0 1 1-8 0 4 4 0 0 1 8 0Z" />
+            </svg>
+            <span class="sr-only">Toggle theme</span>
+          </button>
+
+          <RouterLink to="/account" class="btn btn-icon" aria-label="Account">
+            <svg class="h-6 w-6" viewBox="0 0 24 24" fill="none" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 12a4 4 0 1 0 0-8 4 4 0 0 0 0 8ZM4 20a8 8 0 0 1 16 0" />
+            </svg>
+          </RouterLink>
+        </div>
+      </div>
+
+      <div class="nav-links hidden items-center gap-1 lg:flex">
+        <RouterLink
+          v-for="item in items"
+          :key="item.path"
+          :to="item.path"
+          class="nav-link"
+          :class="{ active: currentPath === item.path }"
+        >
+          <span class="inline-flex items-center gap-2">
+            <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor">
+              <path
+                v-if="item.icon === 'dashboard'"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                d="M3 12V7a2 2 0 0 1 2-2h3l2-2h4l2 2h3a2 2 0 0 1 2 2v5"
+              />
+              <path
+                v-else-if="item.icon === 'grid'"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                d="M4 6h7v7H4zM13 6h7v7h-7zM4 15h7v7H4zM13 15h7v7h-7z"
+              />
+              <path
+                v-else-if="item.icon === 'spark'"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                d="m5 3 7 7-7 7m8-12 6 6-6 6"
+              />
+              <path
+                v-else-if="item.icon === 'compose'"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                d="M11 5H6a2 2 0 0 0-2 2v11a2 2 0 0 0 2 2h11a2 2 0 0 0 2-2v-5M15 3l6 6M8 13h4"
+              />
+              <path
+                v-else-if="item.icon === 'wand'"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                d="m15 7-1 4-4 1 1-4 4-1ZM3 21l6-6"
+              />
+              <path
+                v-else-if="item.icon === 'admin'"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                d="M12 12a4 4 0 1 0-4-4 4 4 0 0 0 4 4Zm-8 8a8 8 0 0 1 16 0"
+              />
+              <path
+                v-else-if="item.icon === 'bars'"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                d="M9 19v-6a2 2 0 0 0-2-2H5a2 2 0 0 0-2 2v6m8 0V9a2 2 0 0 1 2-2h2a2 2 0 0 1 2 2v10"
+              />
+              <path v-else stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
+            </svg>
+            {{ item.label }}
+          </span>
+        </RouterLink>
+      </div>
+    </div>
+  </nav>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from 'vue';
+import { useRoute, useRouter, RouterLink } from 'vue-router';
+
+import { useAppStore } from '@/stores/app';
+import { useTheme } from '@/composables/useTheme';
+
+interface NavItem {
+  path: string;
+  label: string;
+  icon:
+    | 'dashboard'
+    | 'grid'
+    | 'spark'
+    | 'compose'
+    | 'wand'
+    | 'admin'
+    | 'bars';
+}
+
+const NAV_ITEMS: readonly NavItem[] = [
+  { path: '/', label: 'Dashboard', icon: 'dashboard' },
+  { path: '/loras', label: 'LoRAs', icon: 'grid' },
+  { path: '/recommendations', label: 'Recommendations', icon: 'spark' },
+  { path: '/compose', label: 'Compose', icon: 'compose' },
+  { path: '/generate', label: 'Generate', icon: 'wand' },
+  { path: '/admin', label: 'Admin', icon: 'admin' },
+  { path: '/analytics', label: 'Analytics', icon: 'bars' },
+  { path: '/import-export', label: 'Import/Export', icon: 'grid' },
+];
+
+const appStore = useAppStore();
+const router = useRouter();
+const route = useRoute();
+const { currentTheme, toggleTheme } = useTheme();
+
+const searchQuery = ref('');
+const items = NAV_ITEMS;
+
+const currentPath = computed(() => route.path.replace(/\/+$/, '') || '/');
+const canSearch = computed(() => searchQuery.value.trim().length > 1);
+
+const themeToggleLabel = computed(() =>
+  currentTheme.value === 'dark' ? 'Switch to light theme' : 'Switch to dark theme'
+);
+
+const handleSearch = () => {
+  if (!canSearch.value) {
+    return;
+  }
+
+  const query = searchQuery.value.trim();
+  searchQuery.value = '';
+
+  router.push({ name: 'loras', query: { q: query } }).catch(() => {
+    router.push('/loras');
+  });
+
+  appStore.addNotification(`Searching for "${query}"`, 'info', 2500);
+};
+</script>
+
+<style scoped>
+.nav-actions {
+  display: flex;
+}
+</style>

--- a/app/frontend/src/components/MobileNav.vue
+++ b/app/frontend/src/components/MobileNav.vue
@@ -1,6 +1,5 @@
 <template>
   <div class="mobile-nav-root">
-    <!-- Mobile Navigation Toggle -->
     <button
       class="mobile-nav-toggle lg:hidden touch-target"
       :class="{ 'mobile-safe-top': true }"
@@ -20,14 +19,8 @@
       <span class="sr-only">{{ isOpen ? 'Close menu' : 'Open menu' }}</span>
     </button>
 
-    <!-- Mobile Navigation Overlay -->
-    <div
-      v-show="isOpen"
-      @click="closeMenu"
-      class="mobile-nav-overlay"
-    />
+    <div v-show="isOpen" @click="closeMenu" class="mobile-nav-overlay" />
 
-    <!-- Mobile Navigation Menu -->
     <nav
       class="mobile-nav-menu"
       id="mobile-navigation"
@@ -38,11 +31,7 @@
     >
       <div class="mobile-nav-header mobile-safe-top">
         <h2 class="text-lg font-semibold text-white">LoRA Manager</h2>
-        <button
-          @click="closeMenu"
-          class="mobile-nav-close touch-target"
-          aria-label="Close navigation menu"
-        >
+        <button @click="closeMenu" class="mobile-nav-close touch-target" aria-label="Close navigation menu">
           <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
           </svg>
@@ -50,49 +39,84 @@
       </div>
 
       <div class="mobile-nav-links">
-        <a
+        <RouterLink
           v-for="item in items"
           :key="item.path"
-          :href="item.path"
-          @click="closeMenu"
+          :to="item.path"
           class="mobile-nav-link"
-          :class="{ 'active': isActive(item.path) }"
+          :class="{ active: currentPath === item.path }"
+          @click="closeMenu"
         >
           <span class="inline-flex items-center">
             <svg class="w-5 h-5 mr-3 inline" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path v-if="item.icon === 'dashboard'" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 12l2-2m0 0l7-7 7 7M13 5v6a2 2 0 002 2h6" />
-              <path v-else-if="item.icon === 'grid'" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h7v7H4V6zm9 0h7v7h-7V6zM4 15h7v7H4v-7zm9 0h7v7h-7v-7z" />
-              <path v-else-if="item.icon === 'spark'" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 3l7 7-7 7M13 5l6 6-6 6" />
-              <path v-else-if="item.icon === 'compose'" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5M15 3l6 6M8 13h4" />
-              <path v-else-if="item.icon === 'wand'" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 7l-1 4-4 1 1-4 4-1zM3 21l6-6" />
-              <path v-else-if="item.icon === 'admin'" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 12c2.21 0 4-1.79 4-4S14.21 4 12 4 8 5.79 8 8s1.79 4 4 4z M4 20a8 8 0 0116 0" />
-              <path v-else-if="item.icon === 'bars'" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6m8 0V9a2 2 0 012-2h2a2 2 0 012 2v10" />
+              <path
+                v-if="item.icon === 'dashboard'"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                d="M3 12l2-2m0 0 7-7 7 7M13 5v6a2 2 0 0 0 2 2h6"
+              />
+              <path
+                v-else-if="item.icon === 'grid'"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                d="M4 6h7v7H4V6zm9 0h7v7h-7V6zM4 15h7v7H4v-7zm9 0h7v7h-7v-7z"
+              />
+              <path
+                v-else-if="item.icon === 'spark'"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                d="M5 3l7 7-7 7m8-12 6 6-6 6"
+              />
+              <path
+                v-else-if="item.icon === 'compose'"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                d="M11 5H6a2 2 0 0 0-2 2v11a2 2 0 0 0 2 2h11a2 2 0 0 0 2-2v-5M15 3l6 6M8 13h4"
+              />
+              <path
+                v-else-if="item.icon === 'wand'"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                d="m15 7-1 4-4 1 1-4 4-1ZM3 21l6-6"
+              />
+              <path
+                v-else-if="item.icon === 'admin'"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                d="M12 12c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zM4 20a8 8 0 0 1 16 0"
+              />
+              <path
+                v-else-if="item.icon === 'bars'"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                d="M9 19v-6a2 2 0 0 0-2-2H5a2 2 0 0 0-2 2v6m8 0V9a2 2 0 0 1 2-2h2a2 2 0 0 1 2 2v10"
+              />
               <path v-else stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
             </svg>
             {{ item.label }}
           </span>
-        </a>
+        </RouterLink>
       </div>
 
-      <div class="p-4 border-t border-gray-200 mobile-safe-bottom">
-        <div class="text-xs text-gray-500">LoRA Manager v2.1</div>
+      <div class="mobile-safe-bottom border-t border-gray-200 p-4 text-xs text-gray-500">
+        LoRA Manager v2.1
       </div>
     </nav>
   </div>
-  
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted, onBeforeUnmount } from 'vue';
+import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue';
+import { RouterLink, useRoute } from 'vue-router';
 
-type NavIcon =
-  | 'dashboard'
-  | 'grid'
-  | 'spark'
-  | 'compose'
-  | 'wand'
-  | 'admin'
-  | 'bars';
+type NavIcon = 'dashboard' | 'grid' | 'spark' | 'compose' | 'wand' | 'admin' | 'bars';
 
 interface NavItem {
   path: string;
@@ -100,7 +124,7 @@ interface NavItem {
   icon: NavIcon;
 }
 
-const NAV_ITEMS: ReadonlyArray<NavItem> = [
+const NAV_ITEMS: readonly NavItem[] = [
   { path: '/', label: 'Dashboard', icon: 'dashboard' },
   { path: '/loras', label: 'LoRAs', icon: 'grid' },
   { path: '/recommendations', label: 'Recommendations', icon: 'spark' },
@@ -111,39 +135,40 @@ const NAV_ITEMS: ReadonlyArray<NavItem> = [
   { path: '/import-export', label: 'Import/Export', icon: 'grid' },
 ];
 
-const isOpen = ref<boolean>(false);
+const isOpen = ref(false);
 const items = NAV_ITEMS;
+const route = useRoute();
 
-const toggleMenu = (): void => {
+const currentPath = computed(() => route.path.replace(/\/+$/, '') || '/');
+
+const toggleMenu = () => {
   isOpen.value = !isOpen.value;
 };
 
-const closeMenu = (): void => {
+const closeMenu = () => {
   isOpen.value = false;
 };
 
-const isActive = (path: string): boolean => {
-  if (typeof window === 'undefined') {
-    return false;
-  }
-
-  const currentPath = window.location?.pathname ?? '';
-  return currentPath.replace(/\/+$/, '') === path;
-};
-
-const onKeydown = (event: KeyboardEvent): void => {
+const onKeydown = (event: KeyboardEvent) => {
   if (event.key === 'Escape') {
     closeMenu();
   }
 };
 
-onMounted((): void => {
+watch(
+  () => route.fullPath,
+  () => {
+    closeMenu();
+  }
+);
+
+onMounted(() => {
   if (typeof window !== 'undefined') {
     window.addEventListener('keydown', onKeydown);
   }
 });
 
-onBeforeUnmount((): void => {
+onBeforeUnmount(() => {
   if (typeof window !== 'undefined') {
     window.removeEventListener('keydown', onKeydown);
   }
@@ -151,5 +176,5 @@ onBeforeUnmount((): void => {
 </script>
 
 <style scoped>
-/* Rely on existing app styles; no overrides here */
+/* No component-scoped overrides required */
 </style>

--- a/app/frontend/src/composables/useTheme.ts
+++ b/app/frontend/src/composables/useTheme.ts
@@ -1,0 +1,92 @@
+import { computed, watch } from 'vue';
+import { storeToRefs } from 'pinia';
+
+import { useAppStore } from '@/stores/app';
+
+type ThemePreference = 'light' | 'dark';
+
+const THEME_STORAGE_KEY = 'lora-manager-theme';
+let themeInitialized = false;
+
+const applyThemeToDocument = (theme: ThemePreference) => {
+  if (typeof document === 'undefined') {
+    return;
+  }
+
+  const root = document.documentElement;
+  const body = document.body;
+
+  root.dataset.theme = theme;
+  root.classList.toggle('theme-dark', theme === 'dark');
+  root.classList.toggle('theme-light', theme === 'light');
+
+  if (body) {
+    body.dataset.theme = theme;
+    body.classList.toggle('theme-dark', theme === 'dark');
+    body.classList.toggle('theme-light', theme === 'light');
+  }
+};
+
+const resolveStoredTheme = (): ThemePreference | null => {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+
+  const stored = window.localStorage?.getItem(
+    THEME_STORAGE_KEY
+  ) as ThemePreference | null;
+
+  if (stored === 'light' || stored === 'dark') {
+    return stored;
+  }
+
+  if (window.matchMedia?.('(prefers-color-scheme: dark)').matches) {
+    return 'dark';
+  }
+
+  return null;
+};
+
+export const useTheme = () => {
+  const appStore = useAppStore();
+  const { preferences } = storeToRefs(appStore);
+
+  if (!themeInitialized) {
+    themeInitialized = true;
+    const initialTheme = resolveStoredTheme();
+    if (initialTheme) {
+      appStore.setPreferences({ theme: initialTheme });
+    }
+  }
+
+  const currentTheme = computed<ThemePreference>(() =>
+    preferences.value.theme === 'dark' ? 'dark' : 'light'
+  );
+
+  const setTheme = (theme: ThemePreference) => {
+    appStore.setPreferences({ theme });
+  };
+
+  const toggleTheme = () => {
+    setTheme(currentTheme.value === 'dark' ? 'light' : 'dark');
+  };
+
+  watch(
+    currentTheme,
+    (theme) => {
+      applyThemeToDocument(theme);
+      if (typeof window !== 'undefined') {
+        window.localStorage?.setItem(THEME_STORAGE_KEY, theme);
+      }
+    },
+    { immediate: true }
+  );
+
+  return {
+    currentTheme,
+    setTheme,
+    toggleTheme,
+  };
+};
+
+export type UseThemeReturn = ReturnType<typeof useTheme>;


### PR DESCRIPTION
## Summary
- introduce a reusable MainNavigation component with search, theme toggle, and route integration
- add AppFooter and reorganize App.vue to mirror the old base layout and skip links
- implement a shared useTheme composable and update the mobile nav to use Vue Router links

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d01f76ca688329bed8a13fd82c33e4