### PR TITLE
refactor: centralize API typing and add composable tests

### DIFF
--- a/app/frontend/src/composables/useApi.ts
+++ b/app/frontend/src/composables/useApi.ts
@@ -1,44 +1,10 @@
 import { MaybeRefOrGetter, Ref, ref, unref } from 'vue';
 
-export interface ApiResponseMeta {
-  ok: boolean;
-  status: number;
-  statusText: string;
-  headers?: Headers;
-  url?: string;
-}
+import type { ApiResponseMeta } from '@/types';
+import { ApiError } from '@/types';
 
-export interface ApiErrorInit<TError> {
-  message: string;
-  status: number;
-  statusText: string;
-  payload: TError | null;
-  meta: ApiResponseMeta;
-  response: Response;
-}
-
-export class ApiError<TError = unknown> extends Error {
-  public readonly status: number;
-
-  public readonly statusText: string;
-
-  public readonly payload: TError | null;
-
-  public readonly meta: ApiResponseMeta;
-
-  public readonly response: Response;
-
-  constructor(init: ApiErrorInit<TError>) {
-    super(init.message);
-    this.name = 'ApiError';
-    this.status = init.status;
-    this.statusText = init.statusText;
-    this.payload = init.payload;
-    this.meta = init.meta;
-    this.response = init.response;
-    Object.setPrototypeOf(this, new.target.prototype);
-  }
-}
+export type { ApiResponseMeta } from '@/types';
+export { ApiError } from '@/types';
 
 export function useApi<T = unknown, TError = unknown>(
   url: MaybeRefOrGetter<string>,

--- a/tests/vue/MobileNav.spec.js
+++ b/tests/vue/MobileNav.spec.js
@@ -1,6 +1,41 @@
 import { mount } from '@vue/test-utils';
-import { nextTick } from 'vue';
+import { defineComponent, h, nextTick } from 'vue';
+import { vi } from 'vitest';
 import MobileNav from '../../app/frontend/src/components/MobileNav.vue';
+
+vi.mock('vue-router', () => ({
+  RouterLink: defineComponent({
+    name: 'RouterLink',
+    inheritAttrs: false,
+    props: {
+      to: { type: [String, Object], required: true },
+    },
+    setup(props, { slots, attrs }) {
+      return () => {
+        const target = props.to;
+        let href = '#';
+        if (typeof target === 'string') {
+          href = target;
+        } else if (target && typeof target === 'object' && 'path' in target && typeof target.path === 'string') {
+          href = target.path;
+        }
+        const children = typeof slots.default === 'function' ? slots.default() : [];
+        return h('a', { ...attrs, href }, children);
+      };
+    },
+  }),
+  useRoute: () => ({
+    path: typeof window !== 'undefined' ? window.location.pathname ?? '/' : '/',
+    fullPath: typeof window !== 'undefined' ? window.location.pathname ?? '/' : '/',
+    params: {},
+    query: {},
+    hash: '',
+    name: undefined,
+    matched: [],
+    redirectedFrom: undefined,
+    meta: {},
+  }),
+}));
 
 const flush = async () => {
   await Promise.resolve();

--- a/tests/vue/loraService.spec.ts
+++ b/tests/vue/loraService.spec.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+
+import { buildAdapterListQuery, fetchAdapters } from '@/services/loraService';
+import type { AdapterListResponse } from '@/types';
+
+const originalFetch = global.fetch;
+
+afterEach(() => {
+  if (originalFetch) {
+    global.fetch = originalFetch;
+  }
+  vi.clearAllMocks();
+});
+
+describe('loraService', () => {
+  it('serialises adapter list query parameters', () => {
+    const query = buildAdapterListQuery({
+      page: 2,
+      perPage: 25,
+      search: 'anime',
+      active: true,
+      tags: ['fantasy', 'style'],
+      sort: 'created_at_desc',
+    });
+
+    expect(query).toBe('?page=2&per_page=25&search=anime&active=true&tags=fantasy%2Cstyle&sort=created_at_desc');
+  });
+
+  it('fetches adapters using the typed API composable', async () => {
+    const payload: AdapterListResponse = {
+      items: [
+        {
+          id: 'adapter-1',
+          name: 'Adapter One',
+          version: '1.0',
+          canonical_version_name: 'v1',
+          description: 'First adapter',
+          author_username: 'tester',
+          visibility: 'Public',
+          published_at: '2024-01-01T00:00:00Z',
+          tags: ['fantasy'],
+          trained_words: ['magic'],
+          triggers: ['spark'],
+          file_path: '/weights/adapter-1.safetensors',
+          weight: 0.8,
+          active: true,
+          ordinal: 1,
+          archetype: null,
+          archetype_confidence: null,
+          primary_file_name: 'adapter-1.safetensors',
+          primary_file_size_kb: 1024,
+          primary_file_sha256: 'abc123',
+          primary_file_download_url: 'https://example.com',
+          primary_file_local_path: '/tmp/adapter-1.safetensors',
+          supports_generation: true,
+          sd_version: '1.5',
+          nsfw_level: 0,
+          activation_text: 'activate',
+          stats: { usage_count: 10 },
+          extra: { preview_image: 'preview.png' },
+          json_file_path: '/json/adapter-1.json',
+          json_file_mtime: '2024-01-01T00:00:00Z',
+          json_file_size: 2048,
+          last_ingested_at: '2024-01-01T00:00:00Z',
+          created_at: '2024-01-01T00:00:00Z',
+          updated_at: '2024-01-02T00:00:00Z',
+        },
+      ],
+      total: 1,
+      filtered: 1,
+      page: 1,
+      pages: 1,
+      per_page: 10,
+    };
+
+    const response = {
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      headers: new Headers({ 'Content-Type': 'application/json' }),
+      url: '/api/v1/adapters',
+      json: vi.fn().mockResolvedValue(payload),
+      text: vi.fn(),
+    } as unknown as Response;
+
+    const fetchMock = vi.fn().mockResolvedValue(response) as unknown as typeof fetch;
+    global.fetch = fetchMock;
+
+    const result = await fetchAdapters('/api/v1', { page: 1, perPage: 10, search: 'Adapter', active: true, tags: ['fantasy'] });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/v1/adapters?page=1&per_page=10&search=Adapter&active=true&tags=fantasy',
+      expect.objectContaining({ credentials: 'same-origin' }),
+    );
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({ id: 'adapter-1', name: 'Adapter One', active: true, tags: ['fantasy'] });
+  });
+});

--- a/tests/vue/useApi.spec.ts
+++ b/tests/vue/useApi.spec.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+
+import { useApi, ApiError } from '@/composables/useApi';
+
+const originalFetch = global.fetch;
+
+const createJsonResponse = <T>(
+  payload: T,
+  init: Partial<Response> & { status?: number; statusText?: string; ok?: boolean; url?: string } = {},
+) => {
+  const headers = new Headers(init.headers as HeadersInit | undefined);
+  if (!headers.has('Content-Type')) {
+    headers.set('Content-Type', 'application/json');
+  }
+  return {
+    ok: init.ok ?? true,
+    status: init.status ?? 200,
+    statusText: init.statusText ?? 'OK',
+    headers,
+    url: init.url ?? '/api/test',
+    json: vi.fn().mockResolvedValue(payload),
+    text: vi.fn().mockResolvedValue(JSON.stringify(payload)),
+  } as unknown as Response;
+};
+
+afterEach(() => {
+  if (originalFetch) {
+    global.fetch = originalFetch;
+  }
+  vi.clearAllMocks();
+});
+
+describe('useApi composable', () => {
+  it('parses JSON payloads and stores metadata for successful responses', async () => {
+    const payload = { message: 'ok', value: 42 };
+    const response = createJsonResponse(payload, { url: '/api/test', status: 200, statusText: 'OK' });
+
+    const fetchMock = vi.fn().mockResolvedValue(response) as unknown as typeof fetch;
+    global.fetch = fetchMock;
+
+    const { fetchData, data, lastResponse, error, isLoading } = useApi<typeof payload>('/api/test');
+
+    const result = await fetchData();
+
+    expect(result).toEqual(payload);
+    expect(data.value).toEqual(payload);
+    expect(lastResponse.value).toMatchObject({ ok: true, status: 200, statusText: 'OK', url: '/api/test' });
+    expect(error.value).toBeNull();
+    expect(isLoading.value).toBe(false);
+    expect(fetchMock).toHaveBeenCalledWith('/api/test', expect.objectContaining({ credentials: 'same-origin' }));
+  });
+
+  it('throws an ApiError and stores the payload when the response is not ok', async () => {
+    const payload = { detail: 'Something went wrong' };
+    const response = createJsonResponse(payload, { ok: false, status: 500, statusText: 'Internal Server Error', url: '/api/fail' });
+
+    const fetchMock = vi.fn().mockResolvedValue(response) as unknown as typeof fetch;
+    global.fetch = fetchMock;
+
+    const { fetchData, error, lastResponse } = useApi<typeof payload, typeof payload>('/api/fail');
+
+    await expect(fetchData()).rejects.toBeInstanceOf(ApiError);
+
+    expect(error.value).toBeInstanceOf(ApiError);
+    const apiError = error.value as ApiError<typeof payload>;
+    expect(apiError.status).toBe(500);
+    expect(apiError.payload).toEqual(payload);
+    expect(apiError.message).toContain('Something went wrong');
+    expect(lastResponse.value).toMatchObject({ ok: false, status: 500, statusText: 'Internal Server Error', url: '/api/fail' });
+  });
+});


### PR DESCRIPTION
## Summary
- centralize API response and error typing in the shared types module and reuse them from the `useApi` composable
- add vitest coverage for the `useApi` composable and `loraService`, including a deterministic vue-router stub for MobileNav specs
- ensure MobileNav tests run against a lightweight RouterLink mock that mirrors window-based routing

## Testing
- npm run test:unit:vue

------
https://chatgpt.com/codex/tasks/task_e_68d021a2db248329882ca495cdfd7b70