### PR TITLE
Refactor service container dependency injection

### DIFF
--- a/backend/api/v1/websocket.py
+++ b/backend/api/v1/websocket.py
@@ -1,10 +1,9 @@
 """WebSocket router for real-time progress monitoring."""
 
 from fastapi import APIRouter, Depends, WebSocket
-from sqlmodel import Session
 
-from backend.core.database import get_session
-from backend.services import create_service_container
+from backend.core.dependencies import get_service_container
+from backend.services import ServiceContainer
 
 router = APIRouter()
 
@@ -12,7 +11,7 @@ router = APIRouter()
 @router.websocket("/ws/progress")
 async def websocket_progress_endpoint(
     websocket: WebSocket,
-    db: Session = Depends(get_session),
+    container: ServiceContainer = Depends(get_service_container),
 ):
     """WebSocket endpoint for real-time generation progress monitoring.
     
@@ -44,5 +43,4 @@ async def websocket_progress_endpoint(
     }
     ```
     """
-    container = create_service_container(db)
     await container.websocket.handle_connection(websocket)

--- a/backend/core/dependencies.py
+++ b/backend/core/dependencies.py
@@ -11,19 +11,25 @@ from backend.services.deliveries import DeliveryService
 from backend.services.recommendations import RecommendationService
 
 
-def get_adapter_service(
+def get_service_container(
     db_session: Session = Depends(get_session),  # noqa: B008 - FastAPI DI
+) -> ServiceContainer:
+    """Return a service container tied to the current database session."""
+
+    return ServiceContainer(db_session)
+
+
+def get_adapter_service(
+    container: ServiceContainer = Depends(get_service_container),  # noqa: B008 - FastAPI DI
 ) -> AdapterService:
     """Return an AdapterService instance."""
-    container = ServiceContainer(db_session)
     return container.adapters
 
 
 def get_delivery_service(
-    db_session: Session = Depends(get_session),  # noqa: B008 - FastAPI DI
+    container: ServiceContainer = Depends(get_service_container),  # noqa: B008 - FastAPI DI
 ) -> DeliveryService:
     """Return a DeliveryService instance."""
-    container = ServiceContainer(db_session)
     return container.deliveries
 
 


### PR DESCRIPTION
## Summary
- add a dedicated `get_service_container` FastAPI dependency that reuses the session-scoped `ServiceContainer`
- update the generation, deliveries, compose, and websocket routers to receive the container via dependency injection instead of manual construction
- ensure background tasks still resolve services by instantiating `ServiceContainer` directly when outside of DI

## Testing
- `pytest tests/test_generation_jobs.py tests/test_main.py`


------
https://chatgpt.com/codex/tasks/task_e_68d033d6e0d0832980b8e6f763e2f019