### PR TITLE
Centralize adapter search logic in service layer

### DIFF
--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -1,5 +1,7 @@
 """Tests for the service layer."""
 
+from datetime import datetime, timedelta, timezone
+
 from backend.models.adapters import Adapter
 from backend.schemas.adapters import AdapterCreate
 
@@ -51,6 +53,77 @@ class TestAdapterService:
         assert len(active_adapters) == 2
         assert active_adapters[0].name == "adapter1"
         assert active_adapters[1].name == "adapter2"
+
+    def test_search_adapters_filters_and_pagination(self, adapter_service, db_session):
+        """Service search applies filters, sorting, and pagination."""
+
+        now = datetime.now(timezone.utc)
+        adapters = [
+            Adapter(
+                name="Alpha",
+                active=True,
+                tags=["fantasy", "portrait"],
+                primary_file_size_kb=150,
+                file_path="/tmp/a",
+                created_at=now - timedelta(days=3),
+                updated_at=now - timedelta(days=2),
+            ),
+            Adapter(
+                name="Beta",
+                active=False,
+                tags=["sci-fi"],
+                primary_file_size_kb=50,
+                file_path="/tmp/b",
+                created_at=now - timedelta(days=2),
+                updated_at=now - timedelta(days=1),
+            ),
+            Adapter(
+                name="Gamma",
+                active=True,
+                tags=["fantasy"],
+                primary_file_size_kb=300,
+                file_path="/tmp/c",
+                created_at=now - timedelta(days=1),
+                updated_at=now - timedelta(hours=1),
+            ),
+        ]
+        db_session.add_all(adapters)
+        db_session.commit()
+
+        # Filtering by search term, tag, and active state
+        first_page = adapter_service.search_adapters(
+            search="a",
+            active_only=True,
+            tags=["fantasy"],
+            sort="file_size",
+            page=1,
+            per_page=1,
+        )
+
+        assert first_page.total == 2
+        assert first_page.pages == 2
+        assert first_page.items[0].name == "Gamma"
+
+        second_page = adapter_service.search_adapters(
+            search="a",
+            active_only=True,
+            tags=["fantasy"],
+            sort="file_size",
+            page=2,
+            per_page=1,
+        )
+
+        assert second_page.page == 2
+        assert second_page.per_page == 1
+        assert second_page.items[0].name == "Alpha"
+
+        # Sorting by updated_at should return most recently updated first
+        updated_order = adapter_service.search_adapters(sort="updated_at", per_page=5)
+        assert [adapter.name for adapter in updated_order.items[:3]] == [
+            "Gamma",
+            "Beta",
+            "Alpha",
+        ]
 
 
 class TestDeliveryService:


### PR DESCRIPTION
## Summary
- add an `AdapterSearchResult` DTO and a `search_adapters` helper to `AdapterService` to encapsulate filtering, sorting, and pagination
- update the adapters list endpoint to delegate to the service layer and serialize its results
- extend service-layer unit tests to cover adapter searching with filters, ordering, and pagination

## Testing
- pytest tests/test_services.py


------
https://chatgpt.com/codex/tasks/task_e_68d035bd9a388329a2cdfb04a13df9eb