### PR TITLE
Refactor delivery scheduling around queue abstraction

### DIFF
--- a/backend/api/v1/deliveries.py
+++ b/backend/api/v1/deliveries.py
@@ -1,25 +1,17 @@
 """HTTP routes for creating and querying delivery jobs."""
 
-import asyncio
-import os
-
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException
 
-from backend.core.database import get_session_context
 from backend.core.dependencies import get_service_container
-from backend.delivery import get_delivery_backend, get_generation_backend
 from backend.schemas import (
     DeliveryCreate,
     DeliveryCreateResponse,
     DeliveryRead,
     DeliveryWrapper,
-    SDNextGenerationParams,
 )
 from backend.services import ServiceContainer
 
 router = APIRouter()
-
-REDIS_URL = os.getenv("REDIS_URL", None)
 
 
 @router.post("/deliveries", status_code=201, response_model=DeliveryCreateResponse)
@@ -29,33 +21,14 @@ async def create_delivery(
     services: ServiceContainer = Depends(get_service_container),
 ):
     """Create a delivery job and either enqueue it or schedule a background task."""
-    dj = services.deliveries.create_job(delivery.prompt, delivery.mode, delivery.params or {})
-    
-    if REDIS_URL:
-        try:
-            from backend.workers.tasks import q
-            # enqueue with delivery id
-            q.enqueue("backend.workers.tasks.process_delivery", dj.id)
-        except Exception:
-            # fallback to BackgroundTasks
-            background_tasks.add_task(
-                _process_delivery_fallback,
-                dj.id,
-                delivery.prompt,
-                delivery.mode,
-                delivery.params or {},
-            )
-    else:
-        # no redis configured, run via BackgroundTasks as before
-        background_tasks.add_task(
-            _process_delivery_fallback,
-            dj.id,
-            delivery.prompt,
-            delivery.mode,
-            delivery.params or {},
-        )
+    job = services.deliveries.schedule_job(
+        delivery.prompt,
+        delivery.mode,
+        delivery.params or {},
+        background_tasks=background_tasks,
+    )
 
-    return DeliveryCreateResponse(delivery_id=dj.id)
+    return DeliveryCreateResponse(delivery_id=job.id)
 
 
 @router.get("/deliveries/{delivery_id}", response_model=DeliveryWrapper)
@@ -83,61 +56,3 @@ def get_delivery(
     )
     
     return DeliveryWrapper(delivery=delivery_read)
-
-
-def _process_delivery_fallback(job_id: str, prompt: str, mode: str, params: dict) -> None:
-    """Fallback delivery processing when Redis is not available."""
-    asyncio.run(_process_delivery_fallback_async(job_id, prompt, mode, params))
-
-
-async def _process_delivery_fallback_async(job_id: str, prompt: str, mode: str, params: dict) -> None:
-    try:
-        with get_session_context() as session:
-            services = ServiceContainer(session)
-            services.deliveries.update_job_status(job_id, "running")
-
-        # Process based on mode
-        if mode == "http":
-            backend = get_delivery_backend("http")
-            result = await backend.deliver(prompt, params)
-        elif mode == "cli":
-            backend = get_delivery_backend("cli")
-            result = await backend.deliver(prompt, params)
-        elif mode == "sdnext":
-            backend = get_generation_backend("sdnext")
-
-            # Extract generation parameters
-            gen_params_dict = params.get("generation_params", {})
-            gen_params_dict["prompt"] = prompt
-
-            try:
-                gen_params = SDNextGenerationParams(**gen_params_dict)
-                full_params = {
-                    "generation_params": gen_params.model_dump(),
-                    "mode": params.get("mode", "immediate"),
-                    "save_images": params.get("save_images", True),
-                    "return_format": params.get("return_format", "base64"),
-                }
-                result_obj = await backend.generate_image(prompt, full_params)
-                result = result_obj.model_dump()
-            except Exception as exc:  # pragma: no cover - defensive branch
-                result = {"status": "failed", "error": str(exc)}
-        else:
-            result = {"status": "error", "detail": f"unknown mode: {mode}"}
-
-        # Update job with result
-        with get_session_context() as session:
-            services = ServiceContainer(session)
-            if result.get("status") in ("ok", "completed", 200):
-                services.deliveries.update_job_status(job_id, "succeeded", result)
-            else:
-                services.deliveries.update_job_status(job_id, "failed", result)
-
-    except Exception as exc:  # pragma: no cover - background logging path
-        with get_session_context() as session:
-            services = ServiceContainer(session)
-            services.deliveries.update_job_status(
-                job_id,
-                "failed",
-                {"error": str(exc)},
-            )

--- a/backend/services/deliveries.py
+++ b/backend/services/deliveries.py
@@ -1,40 +1,105 @@
-"""Delivery service for managing delivery jobs."""
+"""Delivery service for managing delivery jobs and execution."""
 
+from __future__ import annotations
+
+import asyncio
 import json
-from typing import Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
+from fastapi import BackgroundTasks
 from sqlmodel import Session, select
 
 from backend.models import DeliveryJob
+
+if TYPE_CHECKING:  # pragma: no cover - used for type checking only
+    from .queue import QueueBackend
+
+_SUCCESS_STATUSES = {"ok", "completed", 200}
 
 
 class DeliveryService:
     """Service for delivery job operations."""
 
-    def __init__(self, db_session: Session):
-        """Initialize DeliveryService with a DB session.
-        
-        Args:
-            db_session: Database session
+    def __init__(
+        self,
+        db_session: Session,
+        queue_backend: Optional["QueueBackend"] = None,
+        fallback_queue_backend: Optional["QueueBackend"] = None,
+    ) -> None:
+        """Initialize DeliveryService with a DB session."""
 
-        """
         self.db_session = db_session
+        self._queue_backend = queue_backend
+        self._fallback_queue_backend = fallback_queue_backend
 
-    def create_job(self, prompt: str, mode: str, params: Optional[Dict] = None) -> DeliveryJob:
-        """Create and persist a DeliveryJob record.
-        
-        Args:
-            prompt: The prompt to deliver
-            mode: Delivery mode (http, cli, sdnext, etc.)
-            params: Mode-specific parameters
-            
-        Returns:
-            Created DeliveryJob instance
+    def set_queue_backends(
+        self,
+        queue_backend: Optional["QueueBackend"],
+        fallback_queue_backend: Optional["QueueBackend"],
+    ) -> None:
+        """Configure queue backends after initialization."""
 
-        """
+        self._queue_backend = queue_backend
+        self._fallback_queue_backend = fallback_queue_backend
+
+    def schedule_job(
+        self,
+        prompt: str,
+        mode: str,
+        params: Optional[Dict[str, Any]] = None,
+        background_tasks: Optional[BackgroundTasks] = None,
+        **enqueue_kwargs: Any,
+    ) -> DeliveryJob:
+        """Create a delivery job and enqueue it for processing."""
+
+        job = self.create_job(prompt, mode, params or {})
+        self.enqueue_job(job.id, background_tasks=background_tasks, **enqueue_kwargs)
+        return job
+
+    def enqueue_job(
+        self,
+        job_id: str,
+        *,
+        background_tasks: Optional[BackgroundTasks] = None,
+        **enqueue_kwargs: Any,
+    ) -> None:
+        """Enqueue an existing job using the configured queue backends."""
+
+        last_error: Optional[Exception] = None
+        if self._queue_backend is not None:
+            try:
+                self._queue_backend.enqueue_delivery(
+                    job_id,
+                    background_tasks=background_tasks,
+                    **enqueue_kwargs,
+                )
+                return
+            except Exception as exc:  # pragma: no cover - defensive branch
+                last_error = exc
+
+        if self._fallback_queue_backend is not None:
+            self._fallback_queue_backend.enqueue_delivery(
+                job_id,
+                background_tasks=background_tasks,
+                **enqueue_kwargs,
+            )
+            return
+
+        if last_error is not None:
+            raise last_error
+        raise RuntimeError("No queue backend configured for delivery jobs")
+
+    def create_job(
+        self,
+        prompt: str,
+        mode: str,
+        params: Optional[Dict[str, Any]] = None,
+    ) -> DeliveryJob:
+        """Create and persist a DeliveryJob record."""
+
         dj = DeliveryJob(
-            prompt=prompt, 
-            mode=mode, 
+            prompt=prompt,
+            mode=mode,
             params=json.dumps(params or {}),
         )
         self.db_session.add(dj)
@@ -43,33 +108,22 @@ class DeliveryService:
         return dj
 
     def get_job(self, job_id: str) -> Optional[DeliveryJob]:
-        """Get a delivery job by ID.
-        
-        Args:
-            job_id: Job ID
-            
-        Returns:
-            DeliveryJob instance or None if not found
+        """Get a delivery job by ID."""
 
-        """
         return self.db_session.get(DeliveryJob, job_id)
 
-    def list_jobs(self, status: Optional[str] = None, limit: int = 100, offset: int = 0) -> List[DeliveryJob]:
-        """List delivery jobs with optional filtering and pagination.
-        
-        Args:
-            status: Optional status filter (pending, running, succeeded, failed)
-            limit: Maximum number of jobs to return
-            offset: Number of jobs to skip
-            
-        Returns:
-            List of DeliveryJob instances
+    def list_jobs(
+        self,
+        status: Optional[str] = None,
+        limit: int = 100,
+        offset: int = 0,
+    ) -> List[DeliveryJob]:
+        """List delivery jobs with optional filtering and pagination."""
 
-        """
         q = select(DeliveryJob)
         if status:
             q = q.where(DeliveryJob.status == status)
-        
+
         q = q.offset(offset).limit(limit).order_by(DeliveryJob.created_at.desc())
         return list(self.db_session.exec(q).all())
 
@@ -77,27 +131,17 @@ class DeliveryService:
         self,
         job_id: str,
         status: str,
-        result: Optional[Dict] = None,
+        result: Optional[Dict[str, Any]] = None,
         error: Optional[str] = None,
     ) -> Optional[DeliveryJob]:
-        """Update a delivery job's status and result.
-        
-        Args:
-            job_id: Job ID
-            status: New status (pending, running, succeeded, failed)
-            result: Optional result data
-            error: Optional error message
-            
-        Returns:
-            Updated DeliveryJob instance or None if not found
+        """Update a delivery job's status and result."""
 
-        """
         job = self.get_job(job_id)
         if job is None:
             return None
-        
+
         job.status = status
-        stored_result: Optional[Dict] = None
+        stored_result: Optional[Dict[str, Any]] = None
         if result is not None:
             stored_result = dict(result)
 
@@ -113,45 +157,154 @@ class DeliveryService:
         # Set timestamps based on status
         if status == "running" and job.started_at is None:
             from datetime import datetime, timezone
+
             job.started_at = datetime.now(timezone.utc)
         elif status in ("succeeded", "failed", "cancelled") and job.finished_at is None:
             from datetime import datetime, timezone
+
             job.finished_at = datetime.now(timezone.utc)
-        
+
         self.db_session.add(job)
         self.db_session.commit()
         self.db_session.refresh(job)
         return job
 
-    def get_job_params(self, job: DeliveryJob) -> Dict:
-        """Parse and return job parameters as dict.
-        
-        Args:
-            job: DeliveryJob instance
-            
-        Returns:
-            Parsed parameters dict
+    def get_job_params(self, job: DeliveryJob) -> Dict[str, Any]:
+        """Parse and return job parameters as dict."""
 
-        """
         try:
             return json.loads(job.params) if job.params else {}
         except json.JSONDecodeError:
             return {}
 
-    def get_job_result(self, job: DeliveryJob) -> Optional[Dict]:
-        """Parse and return job result as dict.
-        
-        Args:
-            job: DeliveryJob instance
-            
-        Returns:
-            Parsed result dict or None
+    def get_job_result(self, job: DeliveryJob) -> Optional[Dict[str, Any]]:
+        """Parse and return job result as dict."""
 
-        """
         if not job.result:
             return None
-        
+
         try:
             return json.loads(job.result)
         except json.JSONDecodeError:
             return None
+
+
+def process_delivery_job(
+    job_id: str,
+    retries_left: Optional[int] = None,
+    *,
+    raise_on_error: bool = False,
+) -> None:
+    """Process a delivery job synchronously."""
+
+    async def runner() -> None:
+        await _process_delivery_job_async(
+            job_id,
+            retries_left=retries_left,
+            raise_on_error=raise_on_error,
+        )
+
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        asyncio.run(runner())
+    else:  # pragma: no cover - defensive branch
+        task = loop.create_task(runner())
+        if raise_on_error:
+            raise RuntimeError(
+                "Cannot raise errors when scheduling delivery processing on an"
+                " active event loop",
+            )
+        return task
+
+
+async def _process_delivery_job_async(
+    job_id: str,
+    *,
+    retries_left: Optional[int] = None,
+    raise_on_error: bool = False,
+) -> None:
+    """Internal coroutine to process a delivery job."""
+
+    from backend.core.database import get_session_context
+
+    prompt: str
+    mode: str
+    params: Dict[str, Any]
+    error: Optional[Exception] = None
+    result_payload: Dict[str, Any] = {}
+    status: str = "failed"
+
+    with get_session_context() as session:
+        service = DeliveryService(session)
+        job = service.get_job(job_id)
+        if job is None:
+            return
+
+        service.update_job_status(job_id, "running")
+        prompt = job.prompt
+        mode = job.mode
+        params = service.get_job_params(job)
+
+    try:
+        result_payload = await _execute_delivery_backend(prompt, mode, params)
+        status = "succeeded" if _is_successful_result(result_payload) else "failed"
+    except Exception as exc:  # pragma: no cover - defensive branch
+        error = exc
+        result_payload = {"error": str(exc)}
+        if retries_left is not None and retries_left > 0:
+            result_payload["retries_left"] = retries_left
+            status = "retrying"
+        else:
+            status = "failed"
+
+    with get_session_context() as session:
+        service = DeliveryService(session)
+        service.update_job_status(job_id, status, result_payload)
+
+    if error is not None and raise_on_error:
+        raise error
+
+
+async def _execute_delivery_backend(
+    prompt: str,
+    mode: str,
+    params: Dict[str, Any],
+) -> Dict[str, Any]:
+    """Execute the delivery backend for a job and return the result."""
+
+    if mode == "http":
+        from backend.delivery import get_delivery_backend
+
+        backend = get_delivery_backend("http")
+        return await backend.deliver(prompt, params)
+    if mode == "cli":
+        from backend.delivery import get_delivery_backend
+
+        backend = get_delivery_backend("cli")
+        return await backend.deliver(prompt, params)
+    if mode == "sdnext":
+        from backend.delivery import get_generation_backend
+        from backend.schemas import SDNextGenerationParams
+
+        backend = get_generation_backend("sdnext")
+
+        gen_params_dict = params.get("generation_params", {}).copy()
+        gen_params_dict["prompt"] = prompt
+
+        gen_params = SDNextGenerationParams(**gen_params_dict)
+        full_params = {
+            "generation_params": gen_params.model_dump(),
+            "mode": params.get("mode", "immediate"),
+            "save_images": params.get("save_images", True),
+            "return_format": params.get("return_format", "base64"),
+        }
+        result_obj = await backend.generate_image(prompt, full_params)
+        return result_obj.model_dump()
+
+    return {"status": "error", "detail": f"unknown mode: {mode}"}
+
+
+def _is_successful_result(result: Dict[str, Any]) -> bool:
+    status = result.get("status")
+    return status in _SUCCESS_STATUSES

--- a/backend/services/queue.py
+++ b/backend/services/queue.py
@@ -1,0 +1,86 @@
+"""Queue backend abstractions for delivery job scheduling."""
+
+from __future__ import annotations
+
+import asyncio
+from abc import ABC, abstractmethod
+from typing import Any, Callable, Optional
+
+from fastapi import BackgroundTasks
+
+
+class QueueBackend(ABC):
+    """Abstract interface for enqueuing delivery jobs."""
+
+    @abstractmethod
+    def enqueue_delivery(
+        self,
+        job_id: str,
+        *,
+        background_tasks: Optional[BackgroundTasks] = None,
+        **enqueue_kwargs: Any,
+    ) -> Any:
+        """Enqueue a delivery job for processing."""
+
+
+class RedisQueueBackend(QueueBackend):
+    """Redis-backed queue implementation using RQ."""
+
+    def __init__(
+        self,
+        redis_url: str,
+        queue_name: str = "default",
+        task_name: str = "backend.workers.tasks.process_delivery",
+    ) -> None:
+        self.redis_url = redis_url
+        self.queue_name = queue_name
+        self.task_name = task_name
+        self._queue = None
+
+    def _get_queue(self):
+        if self._queue is None:
+            from redis import Redis
+            from rq import Queue
+
+            redis_conn = Redis.from_url(self.redis_url)
+            self._queue = Queue(self.queue_name, connection=redis_conn)
+        return self._queue
+
+    @property
+    def queue(self):
+        """Expose the underlying RQ queue instance."""
+        return self._get_queue()
+
+    def enqueue_delivery(
+        self,
+        job_id: str,
+        *,
+        background_tasks: Optional[BackgroundTasks] = None,
+        **enqueue_kwargs: Any,
+    ) -> Any:
+        queue = self._get_queue()
+        return queue.enqueue(self.task_name, job_id, **enqueue_kwargs)
+
+
+class BackgroundTaskQueueBackend(QueueBackend):
+    """Queue implementation that executes jobs in-process via BackgroundTasks."""
+
+    def __init__(self, runner: Callable[[str], Any]) -> None:
+        self._runner = runner
+
+    def _execute(self, job_id: str) -> None:
+        result = self._runner(job_id)
+        if asyncio.iscoroutine(result):
+            asyncio.run(result)
+
+    def enqueue_delivery(
+        self,
+        job_id: str,
+        *,
+        background_tasks: Optional[BackgroundTasks] = None,
+        **enqueue_kwargs: Any,
+    ) -> None:
+        if background_tasks is not None:
+            background_tasks.add_task(self._execute, job_id)
+        else:
+            self._execute(job_id)

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -10,6 +10,7 @@ from rq import Queue, SimpleWorker  # noqa: E402
 
 from backend.core.database import get_session_context, init_db  # noqa: E402
 from backend.models.deliveries import DeliveryJob  # noqa: E402
+from backend.workers import tasks as worker_tasks  # noqa: E402
 from backend.workers.tasks import enqueue_delivery  # noqa: E402
 
 
@@ -21,7 +22,8 @@ def test_worker_process_cycle(tmp_path, monkeypatch):
 
     # patch the queue in tasks to use a fake connection
     fake_q = Queue("default", connection=fake_redis)
-    monkeypatch.setattr("backend.workers.tasks.q", fake_q)
+    monkeypatch.setattr(worker_tasks, "q", fake_q)
+    monkeypatch.setattr(worker_tasks.queue_backend, "_queue", fake_q, raising=False)
 
     # Ensure DB initialized in a temp directory to avoid collisions. The DB
     # is created in the module path, so ensure init_db runs (it will create


### PR DESCRIPTION
## Summary
- Introduced queue abstraction for delivery jobs with Redis and background implementations and wired ServiceContainer/DeliveryService to use them.
- Simplified the delivery API to schedule jobs via the service and updated the worker to share the new processing helper.
- Added coverage for queue selection paths and aligned test fixtures with the configurable session engine.

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d036e923a08329b2f4b0fee0a43fff