### PR TITLE
Use resolveBackendUrl in API composables

### DIFF
--- a/app/frontend/src/composables/apiClients.ts
+++ b/app/frontend/src/composables/apiClients.ts
@@ -56,7 +56,7 @@ export function useAdapterListApi(initialQuery: AdapterListQuery = { page: 1, pe
   const query = reactive<AdapterListQuery>({ ...initialQuery });
 
   const { data, error, isLoading, fetchData, lastResponse } = useApi<AdapterListResponse>(
-    () => `/api/v1/adapters${buildQueryString(query)}`,
+    () => resolveBackendUrl(`/adapters${buildQueryString(query)}`),
     { credentials: 'same-origin' },
   );
 
@@ -95,9 +95,11 @@ export const useRecommendationApi = (
   init: RequestInit = {},
 ) => useApi<RecommendationResponse>(url, withCredentials(init));
 
-export const useDashboardStatsApi = () => useApi<DashboardStatsResponse>('/api/v1/dashboard/stats');
+export const useDashboardStatsApi = () =>
+  useApi<DashboardStatsResponse>(() => resolveBackendUrl('/dashboard/stats'));
 
-export const useSystemStatusApi = () => useApi<SystemStatusPayload>('/api/v1/system/status');
+export const useSystemStatusApi = () =>
+  useApi<SystemStatusPayload>(() => resolveBackendUrl('/system/status'));
 
 export const useActiveJobsApi = () =>
   useApi<Partial<GenerationJob>[]>(() => resolveBackendUrl('/generation/jobs/active'));

--- a/tests/vue/apiClients.spec.ts
+++ b/tests/vue/apiClients.spec.ts
@@ -1,0 +1,78 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  useAdapterListApi,
+  useDashboardStatsApi,
+  useSystemStatusApi,
+} from '../../app/frontend/src/composables/apiClients';
+import { useSettingsStore } from '../../app/frontend/src/stores/settings';
+
+const createJsonResponse = (payload: unknown): Response => ({
+  ok: true,
+  status: 200,
+  statusText: 'OK',
+  headers: new Headers({ 'content-type': 'application/json' }),
+  json: vi.fn().mockResolvedValue(payload),
+  text: vi.fn().mockResolvedValue(JSON.stringify(payload)),
+}) as unknown as Response;
+
+describe('apiClients composables', () => {
+  beforeEach(() => {
+    const settingsStore = useSettingsStore();
+    settingsStore.reset();
+    settingsStore.setSettings({ backendUrl: 'https://example.test/api/v1' });
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('resolves adapter list requests against the configured backend URL', async () => {
+    const settingsStore = useSettingsStore();
+    settingsStore.setSettings({ backendUrl: 'https://backend.example/api/v2/' });
+
+    const fetchMock = vi.fn().mockResolvedValue(createJsonResponse({ items: [] }));
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const api = useAdapterListApi({ page: 2, perPage: 25, search: 'demo' });
+    await api.fetchData();
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://backend.example/api/v2/adapters?page=2&per_page=25&search=demo',
+      expect.objectContaining({ credentials: 'same-origin' }),
+    );
+  });
+
+  it('resolves dashboard stats requests against the configured backend URL', async () => {
+    const settingsStore = useSettingsStore();
+    settingsStore.setSettings({ backendUrl: 'https://stats.example/backend' });
+
+    const fetchMock = vi.fn().mockResolvedValue(createJsonResponse({}));
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const { fetchData } = useDashboardStatsApi();
+    await fetchData();
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://stats.example/backend/dashboard/stats',
+      expect.objectContaining({ credentials: 'same-origin' }),
+    );
+  });
+
+  it('resolves system status requests against the configured backend URL', async () => {
+    const settingsStore = useSettingsStore();
+    settingsStore.setSettings({ backendUrl: 'https://status.example/api' });
+
+    const fetchMock = vi.fn().mockResolvedValue(createJsonResponse({}));
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const { fetchData } = useSystemStatusApi();
+    await fetchData();
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://status.example/api/system/status',
+      expect.objectContaining({ credentials: 'same-origin' }),
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- update adapter, dashboard stats, and system status composables to resolve backend URLs via the settings-aware helper
- add unit tests covering the new dynamic URL behaviour for the shared API composables

## Testing
- npm run test:unit:vue

------
https://chatgpt.com/codex/tasks/task_e_68d040ec67908329912178bbcafbbe0e