### PR TITLE
Refactor dashboard endpoints to use service metrics

### DIFF
--- a/backend/api/v1/dashboard.py
+++ b/backend/api/v1/dashboard.py
@@ -1,61 +1,34 @@
 """Dashboard API endpoints for frontend statistics and system health."""
 
 from fastapi import APIRouter, Depends
-from sqlmodel import Session, func, select
 
-from backend.core.database import get_session
-from backend.models.adapters import Adapter
+from backend.core.dependencies import get_service_container
+from backend.services import ServiceContainer
 
 router = APIRouter(prefix="/dashboard", tags=["dashboard"])
 
+
 @router.get("/stats")
-async def get_dashboard_stats(session: Session = Depends(get_session)):
+async def get_dashboard_stats(services: ServiceContainer = Depends(get_service_container)):
     """Get dashboard statistics and system health information."""
-    # LoRA Statistics
-    total_loras_result = session.exec(select(func.count(Adapter.id))).first()
-    total_loras = total_loras_result or 0
-    
-    active_loras_result = session.exec(
-        select(func.count(Adapter.id)).where(Adapter.active),
-    ).first()
-    active_loras = active_loras_result or 0
-    
-    # Embeddings coverage (mock for now - would calculate from actual embeddings)
-    embeddings_coverage = min(100, (total_loras * 85) // max(1, total_loras)) if total_loras > 0 else 0
-    
-    # Recent imports (last 24 hours - simplified)
-    recent_imports = 0  # Would implement with actual timestamp tracking
-    
-    # System health (mock data - would implement actual monitoring)
-    system_health = {
-        "status": "healthy",
-        "gpu_status": "GPU Available",
-        "gpu_memory": "8.2 GB / 24 GB",
-        "queue_status": "active",
-        "storage_usage": "45.2 GB / 500 GB",
-    }
-    
+
+    stats = services.adapters.get_dashboard_statistics()
+    stats["active_jobs"] = services.deliveries.count_active_jobs()
+
+    system_health = services.system.get_health_summary().as_dict()
+
     return {
-        "stats": {
-            "total_loras": total_loras,
-            "active_loras": active_loras,
-            "embeddings_coverage": embeddings_coverage,
-            "recent_imports": recent_imports,
-        },
+        "stats": stats,
         "system_health": system_health,
     }
 
+
 @router.get("/featured-loras")
-async def get_featured_loras(session: Session = Depends(get_session)):
+async def get_featured_loras(services: ServiceContainer = Depends(get_service_container)):
     """Get featured LoRAs for the dashboard."""
-    # Get top 5 most recently active LoRAs
-    featured_loras = session.exec(
-        select(Adapter)
-        .where(Adapter.active)
-        .order_by(Adapter.id.desc())
-        .limit(5),
-    ).all()
-    
+
+    featured_loras = services.adapters.get_featured_adapters(limit=5)
+
     return [
         {
             "id": lora.id,
@@ -63,45 +36,15 @@ async def get_featured_loras(session: Session = Depends(get_session)):
             "version": lora.version,
             "tags": lora.tags or [],
             "active": lora.active,
-            "civitai_url": None,  # Field doesn't exist in model, use None or implement later
+            "civitai_url": None,
             "description": lora.description,
         }
         for lora in featured_loras
     ]
 
+
 @router.get("/activity-feed")
-async def get_activity_feed():
+async def get_activity_feed(services: ServiceContainer = Depends(get_service_container)):
     """Get recent activity feed for the dashboard."""
-    # Mock activity data - would implement with actual activity tracking
-    activities = [
-        {
-            "id": 1,
-            "type": "import",
-            "message": "Imported 3 new LoRAs",
-            "timestamp": "2 hours ago",
-            "icon": "📥",
-        },
-        {
-            "id": 2,
-            "type": "generation",
-            "message": "Generated 5 images with AnimeMix LoRA",
-            "timestamp": "4 hours ago",
-            "icon": "🎨",
-        },
-        {
-            "id": 3,
-            "type": "recommendation",
-            "message": "AI recommended 4 similar LoRAs",
-            "timestamp": "6 hours ago",
-            "icon": "🎯",
-        },
-        {
-            "id": 4,
-            "type": "activation",
-            "message": "Activated RealisticVision LoRA",
-            "timestamp": "1 day ago",
-            "icon": "✅",
-        },
-    ]
-    
-    return activities
+
+    return services.deliveries.get_recent_activity(limit=10)

--- a/backend/services/__init__.py
+++ b/backend/services/__init__.py
@@ -14,6 +14,7 @@ from .deliveries import DeliveryService, process_delivery_job
 from .generation import GenerationService
 from .queue import BackgroundTaskQueueBackend, QueueBackend, RedisQueueBackend
 from .storage import StorageService, get_storage_service
+from .system import SystemService
 from .websocket import WebSocketService, websocket_service
 
 
@@ -49,6 +50,7 @@ class ServiceContainer:
         self._compose_service: Optional[ComposeService] = None
         self._generation_service: Optional[GenerationService] = None
         self._websocket_service: Optional[WebSocketService] = None
+        self._system_service: Optional[SystemService] = None
         self._queue_backend = queue_backend
         self._fallback_queue_backend = fallback_queue_backend
     
@@ -111,6 +113,14 @@ class ServiceContainer:
         if self._websocket_service is None:
             self._websocket_service = websocket_service
         return self._websocket_service
+
+    @property
+    def system(self) -> SystemService:
+        """Get system monitoring service instance."""
+
+        if self._system_service is None:
+            self._system_service = SystemService(self.deliveries)
+        return self._system_service
 
 
 # Factory function for creating service containers

--- a/backend/services/system.py
+++ b/backend/services/system.py
@@ -1,0 +1,103 @@
+"""System-level service helpers for dashboard and monitoring endpoints."""
+
+from __future__ import annotations
+
+import os
+import shutil
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Dict, Optional
+
+from backend.core.config import settings
+from backend.core.gpu import detect_gpu, get_gpu_memory_info
+
+if TYPE_CHECKING:  # pragma: no cover
+    from .deliveries import DeliveryService
+
+
+def _bytes_to_gigabytes(value: Optional[int]) -> float:
+    if not value or value <= 0:
+        return 0.0
+    return round(value / (1024 ** 3), 1)
+
+
+@dataclass
+class SystemHealthSummary:
+    """Structured summary of system health for the dashboard."""
+
+    status: str
+    gpu_status: str
+    gpu_memory: str
+    queue_status: str
+    storage_usage: str
+
+    def as_dict(self) -> Dict[str, str]:
+        return {
+            "status": self.status,
+            "gpu_status": self.gpu_status,
+            "gpu_memory": self.gpu_memory,
+            "queue_status": self.queue_status,
+            "storage_usage": self.storage_usage,
+        }
+
+
+class SystemService:
+    """Service that aggregates system health metrics."""
+
+    def __init__(self, delivery_service: "DeliveryService") -> None:
+        self._delivery_service = delivery_service
+
+    def get_health_summary(self) -> SystemHealthSummary:
+        """Compute a lightweight system health summary for dashboard views."""
+
+        queue_stats = self._delivery_service.get_queue_statistics()
+        gpu_info = detect_gpu()
+        gpu_available = bool(gpu_info.get("available"))
+        gpu_details = gpu_info.get("details", {})
+
+        memory_info = get_gpu_memory_info() or {}
+        used_bytes = memory_info.get("allocated") or gpu_details.get("memory_used")
+        total_bytes = memory_info.get("total") or gpu_details.get("memory_total")
+
+        used_gb = _bytes_to_gigabytes(used_bytes)
+        total_gb = _bytes_to_gigabytes(total_bytes)
+        if total_gb and used_gb > total_gb:
+            total_gb = used_gb
+
+        if total_gb:
+            gpu_memory = f"{used_gb:.1f} GB / {total_gb:.1f} GB"
+        elif used_gb:
+            gpu_memory = f"{used_gb:.1f} GB"
+        else:
+            gpu_memory = "0.0 GB"
+
+        queue_status = "active" if queue_stats["active"] else "idle"
+
+        gpu_status_label = (
+            gpu_details.get("device_name")
+            or gpu_details.get("name")
+            or ("GPU Available" if gpu_available else "GPU Unavailable")
+        )
+
+        health_status = "healthy"
+        if not gpu_available or queue_stats["failed"]:
+            health_status = "warning"
+
+        storage_path = settings.IMPORT_PATH or os.getcwd()
+        try:
+            usage = shutil.disk_usage(storage_path)
+            used = _bytes_to_gigabytes(usage.used)
+            total = _bytes_to_gigabytes(usage.total)
+            storage_usage = f"{used:.1f} GB / {total:.1f} GB"
+        except (FileNotFoundError, PermissionError, OSError):
+            storage_usage = "unknown"
+
+        return SystemHealthSummary(
+            status=health_status,
+            gpu_status=gpu_status_label,
+            gpu_memory=gpu_memory,
+            queue_status=queue_status,
+            storage_usage=storage_usage,
+        )
+
+
+__all__ = ["SystemService", "SystemHealthSummary"]

--- a/tests/integration/test_dashboard_routes.py
+++ b/tests/integration/test_dashboard_routes.py
@@ -1,0 +1,150 @@
+"""Integration tests for dashboard API endpoints."""
+
+from datetime import datetime, timedelta, timezone
+from typing import Optional
+
+from backend.models.adapters import Adapter
+from backend.models.deliveries import DeliveryJob
+
+
+def _make_adapter(
+    name: str,
+    *,
+    active: bool = True,
+    created_at: datetime,
+    updated_at: datetime,
+    last_ingested_at: Optional[datetime] = None,
+) -> Adapter:
+    return Adapter(
+        name=name,
+        version="1.0",
+        file_path=f"/tmp/{name}.safetensors",
+        active=active,
+        created_at=created_at,
+        updated_at=updated_at,
+        last_ingested_at=last_ingested_at,
+    )
+
+
+def test_dashboard_stats_reflects_live_data(client, db_session):
+    """Dashboard stats should mirror values from the database."""
+
+    now = datetime.now(timezone.utc)
+    earlier = now - timedelta(days=2)
+
+    fresh_adapter = _make_adapter(
+        "fresh",
+        created_at=now,
+        updated_at=now,
+        last_ingested_at=now,
+    )
+    old_adapter = _make_adapter(
+        "stale",
+        active=False,
+        created_at=earlier,
+        updated_at=earlier,
+        last_ingested_at=earlier,
+    )
+
+    pending_job = DeliveryJob(
+        prompt="pending job",
+        mode="api",
+        status="pending",
+        created_at=now,
+    )
+    failed_job = DeliveryJob(
+        prompt="failed job",
+        mode="api",
+        status="failed",
+        created_at=now - timedelta(hours=1),
+    )
+
+    db_session.add_all([fresh_adapter, old_adapter, pending_job, failed_job])
+    db_session.commit()
+
+    response = client.get("/api/v1/dashboard/stats")
+    assert response.status_code == 200
+
+    payload = response.json()
+    stats = payload["stats"]
+    system_health = payload["system_health"]
+
+    assert stats["total_loras"] == 2
+    assert stats["active_loras"] == 1
+    assert stats["recent_imports"] == 1
+    assert stats["active_jobs"] == 1
+
+    assert system_health["queue_status"] == "active"
+    assert system_health["status"] in {"healthy", "warning"}
+    assert isinstance(system_health["gpu_status"], str) and system_health["gpu_status"]
+    assert isinstance(system_health["gpu_memory"], str)
+    assert isinstance(system_health["storage_usage"], str) and system_health["storage_usage"]
+
+
+def test_dashboard_endpoints_handle_empty_dataset(client):
+    """Endpoints should gracefully handle empty databases."""
+
+    stats_response = client.get("/api/v1/dashboard/stats")
+    assert stats_response.status_code == 200
+    stats_payload = stats_response.json()
+    assert stats_payload["stats"] == {
+        "total_loras": 0,
+        "active_loras": 0,
+        "embeddings_coverage": 0,
+        "recent_imports": 0,
+        "active_jobs": 0,
+    }
+    assert stats_payload["system_health"]["queue_status"] == "idle"
+
+    featured_response = client.get("/api/v1/dashboard/featured-loras")
+    assert featured_response.status_code == 200
+    assert featured_response.json() == []
+
+    activity_response = client.get("/api/v1/dashboard/activity-feed")
+    assert activity_response.status_code == 200
+    assert activity_response.json() == []
+
+
+def test_featured_loras_returns_recent_active_adapters(client, db_session):
+    """Featured endpoint should return active adapters ordered by recency."""
+
+    now = datetime.now(timezone.utc)
+    adapters = [
+        _make_adapter("alpha", created_at=now - timedelta(hours=4), updated_at=now - timedelta(hours=2)),
+        _make_adapter("beta", created_at=now - timedelta(hours=3), updated_at=now - timedelta(minutes=30)),
+        _make_adapter("gamma", created_at=now - timedelta(hours=5), updated_at=now - timedelta(hours=1)),
+        _make_adapter("delta", active=False, created_at=now, updated_at=now),
+    ]
+    db_session.add_all(adapters)
+    db_session.commit()
+
+    response = client.get("/api/v1/dashboard/featured-loras")
+    assert response.status_code == 200
+    payload = response.json()
+
+    assert len(payload) == 3
+    returned_names = [item["name"] for item in payload]
+    assert returned_names == ["beta", "gamma", "alpha"]
+
+
+def test_activity_feed_reflects_recent_jobs(client, db_session):
+    """Activity feed should include delivery jobs sorted by recency."""
+
+    now = datetime.now(timezone.utc)
+    jobs = [
+        DeliveryJob(prompt="first", mode="api", status="succeeded", created_at=now - timedelta(hours=2)),
+        DeliveryJob(prompt="second", mode="api", status="running", created_at=now - timedelta(hours=1)),
+        DeliveryJob(prompt="third", mode="cli", status="pending", created_at=now),
+    ]
+    db_session.add_all(jobs)
+    db_session.commit()
+
+    response = client.get("/api/v1/dashboard/activity-feed")
+    assert response.status_code == 200
+    payload = response.json()
+
+    assert [item["prompt"] for item in payload[:3]] == ["third", "second", "first"]
+    for entry in payload[:3]:
+        assert entry["icon"]
+        assert entry["timestamp"].endswith("Z") or "T" in entry["timestamp"]
+        assert entry["message"].startswith("Delivery job")


### PR DESCRIPTION
## Summary
- add adapter, delivery, and system service helpers to compute dashboard metrics
- refactor dashboard endpoints to consume ServiceContainer dependencies
- add integration tests covering dashboard stats, featured LoRAs, and activity feed

## Testing
- pytest tests/integration/test_dashboard_routes.py

------
https://chatgpt.com/codex/tasks/task_e_68d04cf3884883298fee36d9aa34e896