### PR TITLE
Implement recommendation feedback persistence and index rebuild

### DIFF
--- a/backend/schemas/__init__.py
+++ b/backend/schemas/__init__.py
@@ -38,14 +38,17 @@ from .recommendations import (
     BatchEmbeddingRequest,
     BatchEmbeddingResponse,
     EmbeddingStatus,
+    IndexRebuildResponse,
     PromptRecommendationRequest,
     RecommendationItem,
     RecommendationRequest,
     RecommendationResponse,
     RecommendationStats,
     SimilarityRequest,
+    RecommendationFeedbackRead,
     UserFeedbackRequest,
     UserPreferenceRequest,
+    UserPreferenceRead,
 )
 
 __all__ = [
@@ -84,10 +87,13 @@ __all__ = [
     "SimilarityRequest",
     "UserFeedbackRequest",
     "UserPreferenceRequest",
+    "RecommendationFeedbackRead",
+    "UserPreferenceRead",
     "RecommendationStats",
     "EmbeddingStatus",
     "BatchEmbeddingRequest",
     "BatchEmbeddingResponse",
+    "IndexRebuildResponse",
     # Common
     "WebSocketMessage",
     "WebSocketSubscription",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,6 +18,13 @@ from backend.services.composition import ComposeService
 from backend.services.deliveries import DeliveryService
 
 
+@pytest.fixture
+def anyio_backend():
+    """Force AnyIO tests to execute using the asyncio backend."""
+
+    return "asyncio"
+
+
 @pytest.fixture(name="mock_storage")
 def mock_storage_fixture(monkeypatch) -> MagicMock:
     """Mock storage adapter fixture that patches storage functions.


### PR DESCRIPTION
## Summary
- add Pydantic read models for recommendation feedback, user preferences, and index rebuild responses
- extend `RecommendationService` with feedback recording, preference updates, index rebuild persistence, and refreshed stats
- wire the new service behaviors into the feedback, preferences, and index rebuild API routes and add fixtures/tests for persistence, validation, and index caching

## Testing
- `pytest tests/test_recommendations.py`


------
https://chatgpt.com/codex/tasks/task_e_68d063bc508c8329b6985ba795c9d63d