### PR TITLE
Track global adapter totals separately from filtered counts

### DIFF
--- a/backend/services/adapters.py
+++ b/backend/services/adapters.py
@@ -294,6 +294,8 @@ class AdapterService:
             AdapterSearchResult describing the filtered items and pagination.
         """
 
+        total_count = self.count_total()
+
         base_query = select(Adapter)
         filters = []
 
@@ -329,7 +331,8 @@ class AdapterService:
         if filters:
             count_query = count_query.where(*filters)
 
-        filtered_count = self.db_session.exec(count_query).one()
+        filtered_count_result = self.db_session.exec(count_query).one()
+        filtered_count = int(filtered_count_result or 0)
 
         per_page_value = max(per_page, 1)
         page_value = max(page, 1)
@@ -363,7 +366,7 @@ class AdapterService:
 
         return AdapterSearchResult(
             items=items,
-            total=filtered_count,
+            total=total_count,
             filtered=filtered_count,
             page=page_value,
             pages=total_pages,

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -105,7 +105,7 @@ class TestAdapterService:
             per_page=1,
         )
 
-        assert first_page.total == 2
+        assert first_page.total == 3
         assert first_page.filtered == 2
         assert first_page.page == 1
         assert first_page.per_page == 1
@@ -121,12 +121,16 @@ class TestAdapterService:
             per_page=1,
         )
 
+        assert second_page.total == 3
+        assert second_page.filtered == 2
         assert second_page.page == 2
         assert second_page.per_page == 1
         assert second_page.items[0].name == "Alpha"
 
         # Sorting by updated_at should return most recently updated first
         updated_order = adapter_service.search_adapters(sort="updated_at", per_page=5)
+        assert updated_order.total == 3
+        assert updated_order.filtered == 3
         assert [adapter.name for adapter in updated_order.items[:3]] == [
             "Gamma",
             "Beta",
@@ -175,7 +179,8 @@ class TestAdapterService:
 
         names = [adapter.name for adapter in result.items]
         assert names == ["Beta", "Alpha"]
-        assert result.total == 2
+        assert result.total == 3
+        assert result.filtered == 2
         assert len(set(names)) == len(names)
 
     def test_get_all_tags(self, adapter_service, db_session):


### PR DESCRIPTION
## Summary
- compute the overall adapter total before applying search filters so filtered queries retain global context
- populate AdapterSearchResult with distinct total and filtered counts
- update AdapterService tests to assert the new semantics for total versus filtered counts

## Testing
- pytest tests/test_services.py

------
https://chatgpt.com/codex/tasks/task_e_68d06a850fec8329be1a61394c588669