### PR TITLE
Update docs to reflect Vue SPA hybrid state

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ ENVIRONMENT=production uvicorn app.main:app --host 0.0.0.0 --port 8000
 - ✅ **GPU Acceleration** - AMD ROCm and NVIDIA CUDA support
 - ✅ **Comprehensive API** - 28+ endpoints with full CRUD operations
 - ✅ **Background Processing** - Redis/RQ for async operations
-- ✅ **Modern Frontend** - Vite + Alpine.js + Tailwind CSS with component architecture
+- ✅ **Modern Frontend** - Vue 3 single-page application built with Vite, complemented by a legacy Alpine.js layer for unchanged modules
 - ✅ **Progressive Web App** - Offline capabilities and mobile-optimized interface
 
 ## 🏗️ Architecture
@@ -76,8 +76,12 @@ The project uses a modular architecture with a clear separation between the back
 ### Project Root
 ```
 .
-├── app/              # Main application: FastAPI wrapper and frontend
-│   ├── frontend/     # Frontend assets (templates, static files)
+├── app/              # Main application: FastAPI wrapper and frontend assets
+│   ├── frontend/
+│   │   ├── src/      # Vue 3 SPA source (components, composables, router)
+│   │   ├── static/   # Legacy Alpine.js modules and supporting assets
+│   │   ├── public/   # Static assets copied verbatim by Vite
+│   │   └── index.html  # SPA entrypoint served by FastAPI
 │   └── main.py       # Main FastAPI app entry point
 ├── backend/          # Backend API (self-contained FastAPI app)
 │   ├── api/          # API endpoint routers
@@ -107,29 +111,28 @@ backend/
 
 ### Frontend Application (`app/frontend/`)
 
-The frontend is built with Vite, Alpine.js, and Tailwind CSS. FastAPI serves the HTML templates, and the frontend assets are managed by Vite.
+The frontend now centers on a Vue 3 single-page application compiled by Vite. FastAPI serves the SPA shell (`index.html`) while the Vue source lives in `src/`. Legacy Alpine.js modules in `static/js/` continue to power screens that have not yet been migrated. The previously documented `templates/` directory no longer exists.
 
 ```
 app/frontend/
+├── src/               # Vue SPA source (components, composables, router, stores)
 ├── static/
-│   ├── js/
-│   │   ├── components/    # Modular Alpine.js components (e.g., lora-gallery, generation-studio)
-│   │   ├── services/      # API communication layer (api-service.js)
-│   │   └── utils/         # Shared utility functions
-│   ├── css/           # Compiled CSS
-│   └── images/        # Static images
-└── templates/
-    ├── pages/         # Main HTML pages for each route
-    └── partials/      # Reusable HTML fragments (e.g., for HTMX)
+│   └── js/
+│       ├── components/ # Alpine.js components still in production use
+│       ├── services/   # Legacy API helpers referenced by Alpine modules
+│       └── utils/      # Shared utilities for legacy code
+├── public/            # Static assets copied verbatim during build
+├── index.html         # SPA entrypoint served by FastAPI
+└── utils/             # Shared utilities (including legacy compatibility helpers)
 ```
 
 ### Frontend Technology Stack
 
+- **Vue 3 + Pinia** - Primary SPA framework and state management
 - **Vite** - Modern build tool with hot module replacement
-- **Alpine.js** - Lightweight reactive framework for component behavior
-- **Tailwind CSS** - Utility-first CSS framework
-- **HTMX** - Dynamic HTML exchanges for seamless updates
-- **Jinja2** - Server-side templating
+- **Tailwind CSS** - Utility-first CSS framework shared by both stacks
+- **Alpine.js (Legacy)** - Still used by modules in `app/frontend/static/js/`
+- **Compatibility Layer** - `app/frontend/src/utils/legacy.ts` exposes Vue utilities to Alpine code while migration continues
 - **PWA** - Progressive Web App with offline support and mobile optimization
 
 ## 🧪 Testing
@@ -146,12 +149,14 @@ pytest tests/test_main.py -v            # API endpoints
 ```
 
 ### Frontend Tests (JavaScript)
+Legacy Alpine modules rely on Jest helpers in `tests/utils/test-helpers.js`, while Vue components use Vitest.
 ```bash
 # Run all frontend tests
 npm test
 
 # Run specific test types
-npm run test:unit          # Jest unit tests for components
+npm run test:unit          # Jest unit tests for Alpine-driven views
+npm run test:unit:vue      # Vitest suite for Vue single-file components
 npm run test:integration   # API integration tests
 npm run test:e2e          # Playwright end-to-end tests
 npm run test:performance  # Lighthouse performance audits

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -5,8 +5,8 @@
 This project follows a modern, decoupled architecture with a distinct backend API and a separate frontend application.
 
 -   **Backend**: A self-contained FastAPI application located in the `backend/` directory. It handles all business logic, database interactions, and serves the API.
--   **Frontend**: A Vite-powered single-page application located in `app/frontend/`. It's built with Alpine.js and Tailwind CSS.
--   **Main Entrypoint**: The `app/main.py` file acts as a wrapper that serves the frontend and mounts the backend API under the versioned `/v1` path.
+-   **Frontend**: A Vite-powered Vue 3 single-page application in `app/frontend/src/` with a compatibility layer that continues to expose utilities to the remaining Alpine.js modules under `app/frontend/static/js/`. The previously referenced `templates/` directory has been removed in favor of the SPA shell served from `index.html`.
+-   **Main Entrypoint**: The `app/main.py` file acts as a wrapper that serves the SPA shell and mounts the backend API under the versioned `/v1` path.
 
 ---
 
@@ -15,14 +15,12 @@ This project follows a modern, decoupled architecture with a distinct backend AP
 ```
 .
 ├── app/              # Main application wrapper and frontend
-│   ├── frontend/     # All frontend assets (served by Vite/FastAPI)
-│   │   ├── static/
-│   │   │   ├── js/
-│   │   │   │   ├── components/ # Modular Alpine.js components
-│   │   │   │   ├── services/   # API communication
-│   │   │   │   └── utils/      # Shared utilities
-│   │   │   └── css/
-│   │   └── templates/      # Jinja2 HTML templates
+│   ├── frontend/
+│   │   ├── src/      # Vue SPA source (components, composables, router, stores)
+│   │   ├── static/   # Legacy Alpine.js modules and supporting assets
+│   │   ├── public/   # Static assets copied verbatim by Vite
+│   │   ├── index.html  # SPA entrypoint served by FastAPI
+│   │   └── utils/    # Shared helpers, including the legacy bridge
 │   └── main.py       # Main FastAPI entrypoint to serve frontend & mount backend
 │
 ├── backend/          # Self-contained backend FastAPI application
@@ -57,11 +55,13 @@ This project follows a modern, decoupled architecture with a distinct backend AP
 ### Frontend (`app/frontend/`)
 
 -   **Build Tool**: Vite for fast development and optimized builds.
--   **Framework**: Vue 3 SPA with Pinia for global state management.
--   **Styling**: Tailwind CSS for utility-first styling.
+-   **Frameworks**: Vue 3 SPA with Pinia for global state management, plus legacy Alpine.js controllers that remain in production under `static/js/`.
+-   **Styling**: Tailwind CSS for utility-first styling shared across both frameworks.
 -   **Entrypoint (`src/main.ts`)**: Boots Vue Router, Pinia, and global styles for the application.
+-   **Compatibility Layer (`src/utils/legacy.ts`)**: Exposes Vue-era utilities to Alpine modules until the migration completes.
 -   **Components (`src/components/`)**: Vue single-file components covering dashboard widgets, tools, and layout.
 -   **Composables (`src/composables/`)**: Shared logic for API access, notifications, and system status polling.
+-   **Legacy Modules (`static/js/`)**: Alpine components, services, and utilities that still power system administration, prompt composition, and generation studio views.
 
 ---
 
@@ -113,13 +113,14 @@ The project has a comprehensive testing suite.
     ```
 -   Tests are located in `tests/integration` and `tests/unit`. They use an in-memory SQLite database and mock external services.
 
-### Frontend Testing (Jest & Playwright)
+### Frontend Testing (Jest, Vitest & Playwright)
 
 -   **Run all frontend tests:**
     ```bash
     npm test
     ```
--   **Unit Tests (`tests/unit/js/`)**: Use Jest to test individual Alpine.js components.
+-   **Alpine Unit Tests (`tests/unit/js/`)**: Use Jest with the helpers in `tests/utils/test-helpers.js` to mock Alpine.js, HTMX, and other browser APIs.
+-   **Vue Unit Tests (`npm run test:unit:vue`)**: Use Vitest for Vue single-file components.
 -   **End-to-End Tests (`tests/e2e/`)**: Use Playwright to simulate user interactions in a real browser.
 
 ---

--- a/docs/IMPLEMENTATION_COMPLETE.md
+++ b/docs/IMPLEMENTATION_COMPLETE.md
@@ -1,9 +1,4 @@
-# 🎉 Imple### 2. Docker Containerization
-- **Multi-variant Setup**: GPU (NVIDIA), ROCm (AMD), CPU, and auto-detect configurations
-- **SDNext Service Integration**: Full containerized SDNext deployment with GPU/CPU support
-- **ROCm Support**: Complete AMD GPU acceleration with architecture detection
-- **Automated Setup**: `setup_sdnext_docker.sh` script for one-command deployment
-- **Health Monitoring**: `check_health.sh` for comprehensive service validationtion Complete: SDNext Integration & Docker Setup
+# 🎉 Implementation Complete: SDNext Integration & Docker Setup
 
 ## ✅ What Was Implemented
 
@@ -14,7 +9,7 @@
 - **Async Processing**: Background job queue with RQ integration
 
 ### 2. Docker Containerization
-- **Multi-variant Setup**: GPU, CPU, and auto-detect configurations
+- **Multi-variant Setup**: GPU, CPU, and auto-detect configurations (including NVIDIA and AMD ROCm)
 - **SDNext Service Integration**: Full containerized SDNext deployment
 - **Automated Setup**: `setup_sdnext_docker.sh` script for one-command deployment
 - **Health Monitoring**: `check_health.sh` for comprehensive service validation
@@ -29,7 +24,7 @@
 - **HTML Test Client**: Interactive browser-based testing interface
 - **Python Test Client**: Command-line async testing tool
 - **Comprehensive Documentation**: Updated README with quick start guides
-- **All Tests Passing**: 15/15 test suite validation
+- **All Tests Passing**: 15/15 test suite validation at implementation time
 
 ## 🚀 Quick Start Commands
 
@@ -72,7 +67,7 @@ python websocket_client_example.py                  # Python client
 
 ### Docker Infrastructure
 - `docker-compose.yml` - Main containerization setup
-- `docker-compose.gpu.yml` - NVIDIA GPU-optimized configuration  
+- `docker-compose.gpu.yml` - NVIDIA GPU-optimized configuration
 - `docker-compose.rocm.yml` - AMD ROCm-optimized configuration
 - `docker-compose.cpu.yml` - CPU-only deployment
 - `setup_sdnext_docker.sh` - Automated setup script with hardware detection
@@ -106,7 +101,7 @@ python websocket_client_example.py                  # Python client
 
 1. **ControlNet Advanced Features**: Extend ControlNet integration with preprocessing
 2. **Batch Processing**: Queue management for multiple concurrent generations
-3. **Frontend Development**: React/Vue UI consuming the WebSocket API
+3. **Frontend Modernization**: Continue migrating remaining Alpine.js surfaces into the Vue SPA and retire the legacy compatibility layer once complete
 4. **Production Hardening**: SSL/TLS, rate limiting, authentication improvements
 5. **Monitoring**: Prometheus metrics, logging aggregation
 


### PR DESCRIPTION
## Summary
- refresh the README architecture and feature descriptions to highlight the Vue SPA, legacy Alpine modules, and related test helpers
- align the development guide with the hybrid frontend structure and removal of the old templates directory
- repair the implementation status header and future-work notes to match the current frontend modernization roadmap

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68d071767528832997a9544300565714