### PR TITLE
Refactor compose endpoint to use delivery service scheduling

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -135,10 +135,14 @@ def client_fixture(db_session: Session, monkeypatch):
     def session_context_override():
         yield db_session
 
-    monkeypatch.setattr(
-        "backend.api.v1.compose.get_session_context",
-        lambda: session_context_override(),
-    )
+    from backend.api.v1 import compose as compose_module
+
+    if hasattr(compose_module, "get_session_context"):
+        monkeypatch.setattr(
+            compose_module,
+            "get_session_context",
+            lambda: session_context_override(),
+        )
 
     yield TestClient(fastapi_app)
 


### PR DESCRIPTION
## Summary
- update the compose API to schedule delivery jobs via `DeliveryService.schedule_job`
- remove the in-module delivery helpers and let the configured queue backends dispatch work
- add tests covering primary and fallback queue scheduling and adjust fixtures for the new flow

## Testing
- pytest tests


------
https://chatgpt.com/codex/tasks/task_e_68d07179d6d48329a8c1aec6ddb87f5d