### PR TITLE
Centralize frontend backend URL resolution

### DIFF
--- a/app/frontend/src/components/GenerationHistory.vue
+++ b/app/frontend/src/components/GenerationHistory.vue
@@ -414,12 +414,10 @@
 
 <script setup lang="ts">
 import { computed, onMounted, onUnmounted, reactive, ref, watch, type Ref } from 'vue';
-import { storeToRefs } from 'pinia';
 
 import { debounce } from '@/utils/async';
 import { downloadFile } from '@/utils/browser';
 import { formatFileSize as formatBytes } from '@/utils/format';
-import { useSettingsStore } from '@/stores/settings';
 import {
   deleteResult as deleteHistoryResult,
   deleteResults as deleteHistoryResults,
@@ -430,6 +428,7 @@ import {
   listResults as listHistoryResults,
   rateResult as rateHistoryResult,
 } from '@/services/historyService';
+import { useBackendBase } from '@/utils/backend';
 import type { ListResultsOutput } from '@/services/historyService';
 import type {
   GenerationHistoryResult,
@@ -478,9 +477,7 @@ const stats = reactive<GenerationHistoryStats>({
 });
 
 // Runtime configuration
-const settingsStore = useSettingsStore();
-const { backendUrl: configuredBackendUrl } = storeToRefs(settingsStore);
-const apiBaseUrl = computed(() => configuredBackendUrl.value || '/api/v1');
+const apiBaseUrl = useBackendBase();
 
 // Methods - mirrors Alpine.js implementation
 const loadResults = async (): Promise<void> => {

--- a/app/frontend/src/components/LoraCard.vue
+++ b/app/frontend/src/components/LoraCard.vue
@@ -251,9 +251,7 @@
 
 <script setup lang="ts">
 import { computed, onMounted, onUnmounted, ref, watch } from 'vue';
-import { storeToRefs } from 'pinia';
-
-import { useSettingsStore } from '@/stores/settings';
+import { useBackendBase } from '@/utils/backend';
 import {
   buildRecommendationsUrl,
   deleteLora as deleteLoraRequest,
@@ -297,9 +295,7 @@ const emit = defineEmits<{
 
 const windowExtras = window as WindowWithExtras;
 
-const settingsStore = useSettingsStore();
-const { backendUrl: configuredBackendUrl } = storeToRefs(settingsStore);
-const apiBaseUrl = computed(() => configuredBackendUrl.value || '/api/v1');
+const apiBaseUrl = useBackendBase();
 
 // Local state
 const showActions = ref(false);

--- a/app/frontend/src/components/LoraGallery.vue
+++ b/app/frontend/src/components/LoraGallery.vue
@@ -207,15 +207,14 @@
 
 <script setup lang="ts">
 import { computed, onMounted, ref } from 'vue';
-import { storeToRefs } from 'pinia';
 
 import LoraCard from './LoraCard.vue';
-import { useSettingsStore } from '@/stores/settings';
 import {
   fetchAdapterTags,
   fetchAdapters,
   performBulkLoraAction,
 } from '@/services/loraService';
+import { useBackendBase } from '@/utils/backend';
 import type {
   LoraBulkAction,
   LoraGalleryFilters,
@@ -253,9 +252,7 @@ const filters = ref<LoraGalleryFilters>({
 });
 const sortBy = ref<LoraGallerySortOption>('name_asc');
 
-const settingsStore = useSettingsStore();
-const { backendUrl: configuredBackendUrl } = storeToRefs(settingsStore);
-const apiBaseUrl = computed(() => configuredBackendUrl.value || '/api/v1');
+const apiBaseUrl = useBackendBase();
 const windowExtras = window as WindowWithExtras;
 
 // Computed

--- a/app/frontend/src/components/SystemAdminStatusCard.vue
+++ b/app/frontend/src/components/SystemAdminStatusCard.vue
@@ -174,15 +174,14 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onBeforeUnmount, onMounted, reactive, ref } from 'vue';
-import { storeToRefs } from 'pinia';
+import { onBeforeUnmount, onMounted, reactive, ref } from 'vue';
 
-import { useSettingsStore } from '@/stores/settings';
 import {
   deriveMetricsFromDashboard,
   emptyMetricsSnapshot,
   fetchDashboardStats,
 } from '@/services/systemService';
+import { useBackendBase } from '@/utils/backend';
 import type {
   DashboardStatsSummary,
   SystemMetricsSnapshot,
@@ -191,9 +190,7 @@ import type {
   SystemStatusOverview,
 } from '@/types';
 
-const settingsStore = useSettingsStore();
-const { backendUrl: configuredBackendUrl } = storeToRefs(settingsStore);
-const apiBaseUrl = computed(() => configuredBackendUrl.value || '/api/v1');
+const apiBaseUrl = useBackendBase();
 
 const systemStatus = reactive<SystemStatusOverview>({
   overall: 'unknown',

--- a/app/frontend/src/components/SystemStatusPanel.vue
+++ b/app/frontend/src/components/SystemStatusPanel.vue
@@ -141,19 +141,15 @@
 
 <script setup lang="ts">
 import { computed, onMounted, onUnmounted, ref } from 'vue';
-import { storeToRefs } from 'pinia';
-
-import { useSettingsStore } from '@/stores/settings';
 import {
   deriveMetricsFromDashboard,
   emptyMetricsSnapshot,
   fetchDashboardStats,
 } from '@/services/systemService';
+import { useBackendBase } from '@/utils/backend';
 import type { DashboardStatsSummary, SystemMetricsSnapshot } from '@/types';
 
-const settingsStore = useSettingsStore();
-const { backendUrl: configuredBackendUrl } = storeToRefs(settingsStore);
-const apiBaseUrl = computed(() => configuredBackendUrl.value || '/api/v1');
+const apiBaseUrl = useBackendBase();
 
 const metricsData = ref<SystemMetricsSnapshot>(emptyMetricsSnapshot());
 const dashboardSummary = ref<DashboardStatsSummary | null>(null);

--- a/app/frontend/src/composables/apiClients.ts
+++ b/app/frontend/src/composables/apiClients.ts
@@ -12,7 +12,7 @@ import type {
   RecommendationResponse,
   SystemStatusPayload,
 } from '@/types';
-import { resolveBackendUrl } from '@/services/generationService';
+import { resolveBackendUrl } from '@/utils/backend';
 
 export type DashboardStatsResponse = DashboardStatsSummary;
 

--- a/app/frontend/src/composables/usePerformanceAnalytics.ts
+++ b/app/frontend/src/composables/usePerformanceAnalytics.ts
@@ -4,12 +4,11 @@
  * Manages data fetching and state for performance analytics dashboards.
  */
 
-import { computed, ref } from 'vue';
-import { storeToRefs } from 'pinia';
+import { ref } from 'vue';
 
 import { fetchTopAdapters } from '@/services/loraService';
 import { fetchDashboardStats } from '@/services/systemService';
-import { useSettingsStore } from '@/stores/settings';
+import { useBackendBase } from '@/utils/backend';
 import { formatDuration as formatDurationLabel } from '@/utils/format';
 
 import type {
@@ -148,10 +147,7 @@ const generateMockChartData = (
 };
 
 export function usePerformanceAnalytics() {
-  const settingsStore = useSettingsStore();
-  const { backendUrl } = storeToRefs(settingsStore);
-
-  const backendBase = computed<string>(() => backendUrl.value || '/api/v1');
+  const backendBase = useBackendBase();
 
   const timeRange = ref<PerformanceTimeRange>('24h');
   const autoRefresh = ref<boolean>(false);

--- a/app/frontend/src/composables/useSystemStatus.ts
+++ b/app/frontend/src/composables/useSystemStatus.ts
@@ -4,9 +4,9 @@ import { storeToRefs } from 'pinia';
 import { ApiError } from '@/composables/useApi';
 import { fetchSystemStatus } from '@/services/systemService';
 import { useAppStore } from '@/stores/app';
+import { useBackendBase } from '@/utils/backend';
 
 import type { SystemStatusState } from '@/types';
-import { useSettingsStore } from '@/stores/settings';
 
 const DEFAULT_STATUS: SystemStatusState = {
   gpu_status: 'Loading…',
@@ -95,11 +95,8 @@ export const useSystemStatus = (options: UseSystemStatusOptions = {}) => {
   const pollInterval = options.pollInterval ?? DEFAULT_POLL_INTERVAL;
 
   const appStore = useAppStore();
-  const settingsStore = useSettingsStore();
   const { systemStatus } = storeToRefs(appStore);
-  const { backendUrl: configuredBackendUrl } = storeToRefs(settingsStore);
-
-  const backendBase = computed<string>(() => configuredBackendUrl.value || '/api/v1');
+  const backendBase = useBackendBase();
 
   const apiAvailable = ref<boolean>(true);
   const isReady = ref<boolean>(false);

--- a/app/frontend/src/services/systemService.ts
+++ b/app/frontend/src/services/systemService.ts
@@ -1,7 +1,7 @@
-import { unref } from 'vue';
 import type { MaybeRefOrGetter } from 'vue';
 
 import { useApi } from '@/composables/useApi';
+import { createBackendUrlGetter } from '@/utils/backend';
 
 import type {
   DashboardStatsSummary,
@@ -10,29 +10,19 @@ import type {
   SystemStatusPayload,
 } from '@/types';
 
-const DEFAULT_BASE = '/api/v1';
-
-const sanitizeBaseUrl = (value?: string): string => {
-  if (!value) {
-    return DEFAULT_BASE;
-  }
-  return value.replace(/\/+$/, '') || DEFAULT_BASE;
-};
-
-const resolveBase = (baseUrl: MaybeRefOrGetter<string>) => {
-  const raw = typeof baseUrl === 'function' ? (baseUrl as () => string)() : unref(baseUrl);
-  return sanitizeBaseUrl(raw);
-};
-
-export const useSystemStatusApi = (baseUrl: MaybeRefOrGetter<string> = DEFAULT_BASE) =>
+export const useSystemStatusApi = (
+  baseUrl?: MaybeRefOrGetter<string | null>,
+) =>
   useApi<SystemStatusPayload>(
-    () => `${resolveBase(baseUrl)}/system/status`,
+    createBackendUrlGetter('/system/status', baseUrl),
     { credentials: 'same-origin' },
   );
 
-export const useDashboardStatsApi = (baseUrl: MaybeRefOrGetter<string> = DEFAULT_BASE) =>
+export const useDashboardStatsApi = (
+  baseUrl?: MaybeRefOrGetter<string | null>,
+) =>
   useApi<DashboardStatsSummary>(
-    () => `${resolveBase(baseUrl)}/dashboard/stats`,
+    createBackendUrlGetter('/dashboard/stats', baseUrl),
     { credentials: 'same-origin' },
   );
 
@@ -48,18 +38,16 @@ export const loadFrontendSettings = async (): Promise<FrontendRuntimeSettings | 
 };
 
 export const fetchDashboardStats = async (
-  baseUrl: string,
+  baseUrl?: string | null,
 ): Promise<DashboardStatsSummary | null> => {
-  const base = sanitizeBaseUrl(baseUrl);
-  const api = useDashboardStatsApi(base);
+  const api = useDashboardStatsApi(baseUrl);
   return api.fetchData();
 };
 
 export const fetchSystemStatus = async (
-  baseUrl: string,
+  baseUrl?: string | null,
 ): Promise<SystemStatusPayload | null> => {
-  const base = sanitizeBaseUrl(baseUrl);
-  const api = useSystemStatusApi(base);
+  const api = useSystemStatusApi(baseUrl);
   return api.fetchData();
 };
 

--- a/app/frontend/src/utils/backend.ts
+++ b/app/frontend/src/utils/backend.ts
@@ -1,0 +1,165 @@
+import { computed, unref, type ComputedRef, type MaybeRefOrGetter } from 'vue';
+import { storeToRefs } from 'pinia';
+
+import { useSettingsStore } from '@/stores/settings';
+
+export const DEFAULT_BACKEND_BASE = '/api/v1';
+
+export const trimTrailingSlash = (value: string): string => value.replace(/\/+$/, '');
+
+export const trimLeadingSlash = (value: string): string => value.replace(/^\/+/, '');
+
+const splitPathSuffix = (input: string): { pathname: string; suffix: string } => {
+  const match = input.match(/^([^?#]*)(.*)$/);
+  if (!match) {
+    return { pathname: input, suffix: '' };
+  }
+  return { pathname: match[1] ?? '', suffix: match[2] ?? '' };
+};
+
+const pickBackendBase = (override?: string | null, configured?: string | null): string => {
+  const trimmedOverride = typeof override === 'string' ? override.trim() : '';
+  if (trimmedOverride.length > 0) {
+    return trimmedOverride;
+  }
+
+  const trimmedConfigured = typeof configured === 'string' ? configured.trim() : '';
+  if (trimmedConfigured.length > 0) {
+    return trimmedConfigured;
+  }
+
+  return DEFAULT_BACKEND_BASE;
+};
+
+const normaliseBackendBase = (base: string): string => {
+  if (/^https?:\/\//i.test(base)) {
+    return trimTrailingSlash(base);
+  }
+
+  const withoutTrailing = trimTrailingSlash(base);
+  if (!withoutTrailing) {
+    return DEFAULT_BACKEND_BASE;
+  }
+
+  return withoutTrailing.startsWith('/') ? withoutTrailing : `/${withoutTrailing}`;
+};
+
+const joinBackendPath = (base: string, path: string): string => {
+  const { pathname, suffix } = splitPathSuffix(path);
+  const normalisedBase = trimTrailingSlash(base);
+  const normalisedPathname = trimLeadingSlash(pathname);
+
+  if (!normalisedPathname) {
+    return normalisedBase || DEFAULT_BACKEND_BASE;
+  }
+
+  if (!normalisedBase) {
+    return `/${normalisedPathname}${suffix}`;
+  }
+
+  const combined = /^https?:\/\//i.test(normalisedBase)
+    ? `${normalisedBase}/${normalisedPathname}`
+    : `${normalisedBase}/${normalisedPathname}`.replace(/^\/+/, '/');
+
+  return `${combined}${suffix}`;
+};
+
+const resolveMaybeRef = (
+  value?: MaybeRefOrGetter<string | null>,
+): string | null | undefined => {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  try {
+    const resolved = typeof value === 'function'
+      ? (value as () => string | null | undefined)()
+      : unref(value);
+
+    if (typeof resolved === 'string') {
+      return resolved;
+    }
+
+    return resolved ?? undefined;
+  } catch (error) {
+    if (import.meta.env?.DEV) {
+      console.warn('Failed to resolve backend override', error);
+    }
+    return undefined;
+  }
+};
+
+export const resolveBackendBaseUrl = (baseOverride?: string | null): string => {
+  const settingsStore = useSettingsStore();
+  const base = pickBackendBase(baseOverride, settingsStore.backendUrl);
+  return normaliseBackendBase(base);
+};
+
+export const resolveBackendUrl = (path = '', baseOverride?: string | null): string => {
+  const base = resolveBackendBaseUrl(baseOverride);
+  if (!path) {
+    return base;
+  }
+  return joinBackendPath(base, path);
+};
+
+export const useBackendBase = (
+  baseOverride?: MaybeRefOrGetter<string | null>,
+): ComputedRef<string> => {
+  const settingsStore = useSettingsStore();
+  const { backendUrl } = storeToRefs(settingsStore);
+
+  return computed(() => {
+    const override = resolveMaybeRef(baseOverride);
+    const base = pickBackendBase(override, backendUrl.value);
+    return normaliseBackendBase(base);
+  });
+};
+
+const resolvePathInput = (path: MaybeRefOrGetter<string>): string => {
+  try {
+    const resolved = typeof path === 'function' ? (path as () => string)() : unref(path);
+    return typeof resolved === 'string' ? resolved : '';
+  } catch (error) {
+    if (import.meta.env?.DEV) {
+      console.warn('Failed to resolve backend path', error);
+    }
+    return '';
+  }
+};
+
+export const useBackendUrl = (
+  path: MaybeRefOrGetter<string>,
+  baseOverride?: MaybeRefOrGetter<string | null>,
+): ComputedRef<string> => {
+  const backendBase = useBackendBase(baseOverride);
+
+  return computed(() => {
+    const targetPath = resolvePathInput(path);
+    if (!targetPath) {
+      return backendBase.value;
+    }
+    return joinBackendPath(backendBase.value, targetPath);
+  });
+};
+
+export const createBackendUrlGetter = (
+  path: MaybeRefOrGetter<string>,
+  baseOverride?: MaybeRefOrGetter<string | null>,
+): (() => string) => {
+  const resolved = useBackendUrl(path, baseOverride);
+  return () => resolved.value;
+};
+
+export const backendUtils = {
+  DEFAULT_BACKEND_BASE,
+  trimLeadingSlash,
+  trimTrailingSlash,
+  resolveBackendBaseUrl,
+  resolveBackendUrl,
+  useBackendBase,
+  useBackendUrl,
+  createBackendUrlGetter,
+};
+
+export default backendUtils;

--- a/tests/vue/apiClients.spec.ts
+++ b/tests/vue/apiClients.spec.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
+  useActiveJobsApi,
   useAdapterListApi,
   useDashboardStatsApi,
   useSystemStatusApi,
@@ -72,6 +73,22 @@ describe('apiClients composables', () => {
 
     expect(fetchMock).toHaveBeenCalledWith(
       'https://status.example/api/system/status',
+      expect.objectContaining({ credentials: 'same-origin' }),
+    );
+  });
+
+  it('resolves active job polling against a remote backend host', async () => {
+    const settingsStore = useSettingsStore();
+    settingsStore.setSettings({ backendUrl: 'https://remote.example/internal/api/' });
+
+    const fetchMock = vi.fn().mockResolvedValue(createJsonResponse([]));
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const { fetchData } = useActiveJobsApi();
+    await fetchData();
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://remote.example/internal/api/generation/jobs/active',
       expect.objectContaining({ credentials: 'same-origin' }),
     );
   });

--- a/tests/vue/generationService.spec.ts
+++ b/tests/vue/generationService.spec.ts
@@ -152,6 +152,16 @@ describe('resolveBackendUrl', () => {
 
     expect(resolveGenerationBaseUrl()).toBe('/prefixed/api')
   })
+
+  it('resolves an absolute backend base when the frontend origin differs', () => {
+    const store = useSettingsStore()
+    store.setSettings({ backendUrl: 'https://remote.example/api/v3/' })
+
+    expect(resolveGenerationBaseUrl()).toBe('https://remote.example/api/v3')
+    expect(resolveBackendUrl('/generation/jobs/active')).toBe(
+      'https://remote.example/api/v3/generation/jobs/active',
+    )
+  })
 })
 
 describe('generationService URL resolution', () => {


### PR DESCRIPTION
## Summary
- add a shared `backend` utility that normalizes configured backend bases and exposes helpers/computed accessors
- refactor generation/system services and SPA dashboard components to consume the helper instead of hard-coding `/api/v1`
- extend vitest suites to verify service hooks respect remote backend hosts

## Testing
- npm run test:unit:vue

------
https://chatgpt.com/codex/tasks/task_e_68d07663a0b483299d767d60f632a7c0