### PR TITLE
Refactor composition helper usage across endpoints

### DIFF
--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -7,6 +7,7 @@ import pytest
 
 from backend.models.adapters import Adapter
 from backend.schemas.adapters import AdapterCreate
+from backend.services.composition import CompositionResult
 from backend.services.deliveries import DeliveryService, process_delivery_job
 from backend.services.queue import QueueBackend
 
@@ -433,3 +434,59 @@ class TestComposeService:
         """Test the formatting of a lora token."""
         token = compose_service.format_token("test-lora", 0.75)
         assert token == "<lora:test-lora:0.750>"
+
+    def test_compose_from_adapter_service_builds_prompt(self, compose_service):
+        """Helper should compose prompt, tokens, and warnings in one place."""
+
+        adapters = [
+            Adapter(name="alpha", file_path="/tmp/a", weight=0.5, active=True),
+            Adapter(name="beta", file_path="/tmp/b", weight=0.75, active=True),
+        ]
+
+        class DummyAdapterService:
+            def __init__(self, items):
+                self.items = items
+                self.calls = 0
+
+            def list_active_ordered(self):
+                self.calls += 1
+                return self.items
+
+        dummy_service = DummyAdapterService(adapters)
+
+        result = compose_service.compose_from_adapter_service(
+            dummy_service,
+            prefix="start",
+            suffix="end",
+        )
+
+        assert isinstance(result, CompositionResult)
+        assert dummy_service.calls == 1
+        assert result.tokens == [
+            "<lora:alpha:0.500>",
+            "<lora:beta:0.750>",
+        ]
+        assert result.prompt == "start <lora:alpha:0.500> <lora:beta:0.750> end"
+        assert result.warnings == []
+
+    def test_compose_from_adapter_service_captures_warnings(self, compose_service):
+        """Warnings from validation should propagate through the helper."""
+
+        adapters = [
+            Adapter(name="gamma", file_path="/tmp/a", weight=0.0, active=True),
+            Adapter(name="gamma", file_path="/tmp/b", weight=0.0, active=True),
+        ]
+
+        class DummyAdapterService:
+            def list_active_ordered(self):
+                return adapters
+
+        result = compose_service.compose_from_adapter_service(
+            DummyAdapterService(),
+            prefix="start",
+            suffix="end",
+        )
+
+        assert "Duplicate adapter names" in " ".join(result.warnings)
+        assert "Adapters with zero weight" in " ".join(result.warnings)
+        assert result.prompt == "start <lora:gamma:0.000> <lora:gamma:0.000> end"


### PR DESCRIPTION
## Summary
- add a CompositionResult helper on ComposeService to centralize prompt assembly and warning collection
- refactor the /compose and /compose-and-generate endpoints to reuse the shared helper
- expand service and API tests to cover the shared helper and updated SDNext delivery flow

## Testing
- pytest tests/test_services.py tests/test_main.py

------
https://chatgpt.com/codex/tasks/task_e_68d096e38dbc8329b1e1bb52f015223c