### PR TITLE
Refactor adapter API helpers to share service module

### DIFF
--- a/app/frontend/src/components/PromptComposer.vue
+++ b/app/frontend/src/components/PromptComposer.vue
@@ -129,15 +129,15 @@
 <script setup lang="ts">
 import { computed, onMounted, ref, watch, type ComputedRef, type Ref } from 'vue';
 
-import { useAdapterListApi } from '@/composables/apiClients';
+import { useAdapterListApi } from '@/services/loraService';
 import { createGenerationParams, requestGeneration } from '@/services/generationService';
 import { copyToClipboard } from '@/utils/browser';
 
 import type {
-  AdapterRead,
   AdapterSummary,
   CompositionEntry,
   SavedComposition,
+  LoraListItem,
 } from '@/types';
 
 const STORAGE_KEY = 'prompt-composer-composition';
@@ -425,8 +425,8 @@ onMounted(async () => {
 });
 
 watch(
-  () => adapters.value as AdapterRead[] | undefined,
-  (next: AdapterRead[] | undefined) => {
+  adapters,
+  (next: LoraListItem[] | undefined) => {
     const items = Array.isArray(next) ? next : [];
 
     loras.value = items.map((item) => ({

--- a/app/frontend/src/components/RecommendationsPanel.vue
+++ b/app/frontend/src/components/RecommendationsPanel.vue
@@ -114,8 +114,9 @@
 
 <script setup lang="ts">
 import { computed, onMounted, ref, watch } from 'vue';
-import { useAdapterListApi, useRecommendationApi } from '@/composables/apiClients';
-import type { AdapterRead, RecommendationItem, RecommendationResponse } from '@/types';
+import { useRecommendationApi } from '@/composables/apiClients';
+import { useAdapterListApi } from '@/services/loraService';
+import type { LoraListItem, RecommendationItem, RecommendationResponse } from '@/types';
 
 const WEIGHT_KEYS = ['semantic', 'artistic', 'technical'] as const;
 type WeightKey = (typeof WEIGHT_KEYS)[number];
@@ -144,11 +145,11 @@ const {
   adapters: adapterResults,
 } = useAdapterListApi({ page: 1, perPage: 100 });
 
-const loras = computed<AdapterRead[]>(() => adapterResults.value);
+const loras = computed<LoraListItem[]>(() => adapterResults.value);
 const lorasError = ref<string>('');
 
-const selectedLoraId = ref<AdapterRead['id'] | ''>('');
-const selectedLora = computed<AdapterRead | null>(() => {
+const selectedLoraId = ref<LoraListItem['id'] | ''>('');
+const selectedLora = computed<LoraListItem | null>(() => {
   if (!selectedLoraId.value) {
     return null;
   }

--- a/app/frontend/src/composables/apiClients.ts
+++ b/app/frontend/src/composables/apiClients.ts
@@ -1,17 +1,14 @@
-import { computed, reactive } from 'vue';
 import type { MaybeRefOrGetter } from 'vue';
 
 import { useApi } from './useApi';
 import type {
-  AdapterListQuery,
-  AdapterListResponse,
-  AdapterRead,
   DashboardStatsSummary,
   GenerationJob,
   GenerationResult,
   RecommendationResponse,
   SystemStatusPayload,
 } from '@/types';
+import { buildAdapterListQuery, useAdapterListApi } from '@/services/loraService';
 import { resolveBackendUrl } from '@/utils/backend';
 
 export type DashboardStatsResponse = DashboardStatsSummary;
@@ -20,75 +17,6 @@ const withCredentials = (init: RequestInit = {}): RequestInit => ({
   credentials: 'same-origin',
   ...init,
 });
-
-function buildQueryString(query: AdapterListQuery): string {
-  const params = new URLSearchParams();
-
-  if (typeof query.page === 'number') {
-    params.set('page', String(query.page));
-  }
-
-  if (typeof query.perPage === 'number') {
-    params.set('per_page', String(query.perPage));
-  }
-
-  if (query.search) {
-    params.set('search', query.search);
-  }
-
-  if (typeof query.active === 'boolean') {
-    params.set('active', query.active ? 'true' : 'false');
-  }
-
-  if (query.tags?.length) {
-    params.set('tags', query.tags.join(','));
-  }
-
-  if (query.sort) {
-    params.set('sort', query.sort);
-  }
-
-  const search = params.toString();
-  return search ? `?${search}` : '';
-}
-
-export function useAdapterListApi(initialQuery: AdapterListQuery = { page: 1, perPage: 100 }) {
-  const query = reactive<AdapterListQuery>({ ...initialQuery });
-
-  const { data, error, isLoading, fetchData, lastResponse } = useApi<AdapterListResponse>(
-    () => resolveBackendUrl(`/adapters${buildQueryString(query)}`),
-    { credentials: 'same-origin' },
-  );
-
-  const adapters = computed<AdapterRead[]>(() => {
-    const payload = data.value as AdapterListResponse | AdapterRead[] | null;
-    if (!payload) {
-      return [];
-    }
-
-    if (Array.isArray(payload)) {
-      return payload;
-    }
-
-    return Array.isArray(payload.items) ? payload.items : [];
-  });
-
-  const load = async (overrides: AdapterListQuery = {}) => {
-    Object.assign(query, overrides);
-    await fetchData();
-    return data.value;
-  };
-
-  return {
-    data,
-    error,
-    isLoading,
-    fetchData: load,
-    lastResponse,
-    query,
-    adapters,
-  };
-}
 
 export const useRecommendationApi = (
   url: MaybeRefOrGetter<string>,
@@ -108,3 +36,5 @@ export const useRecentResultsApi = (
   url: MaybeRefOrGetter<string>,
   init: RequestInit = {},
 ) => useApi<GenerationResult[]>(url, withCredentials(init));
+
+export { buildAdapterListQuery, useAdapterListApi };


### PR DESCRIPTION
## Summary
- promote `services/loraService` as the single adapter API surface and add default backend resolution while preserving existing query behaviour
- have `composables/apiClients` re-export the shared adapter helpers instead of re-implementing them
- update PromptComposer and RecommendationsPanel to consume the unified adapter module and align their types

## Testing
- npm run test:unit

------
https://chatgpt.com/codex/tasks/task_e_68d096e667ac832986407a9793702103