### PR TITLE
Refactor queue backend configuration and add regression tests

### DIFF
--- a/tests/test_queue_configuration.py
+++ b/tests/test_queue_configuration.py
@@ -1,0 +1,71 @@
+"""Regression tests for shared queue backend configuration."""
+
+from __future__ import annotations
+
+from backend.core.config import settings
+from backend.services import ServiceContainer
+from backend.services.queue import (
+    BackgroundTaskQueueBackend,
+    RedisQueueBackend,
+    get_queue_backends,
+    reset_queue_backends,
+)
+from backend.workers import tasks as worker_tasks
+
+
+def _restore_queue_state(original_url: str | None) -> None:
+    """Restore settings and queue backends to their original state."""
+
+    settings.REDIS_URL = original_url
+    reset_queue_backends()
+    worker_tasks.initialize_queue_backends()
+
+
+def test_queue_factory_shared_backend_with_redis(db_session) -> None:
+    """API services and worker tasks should share the Redis queue backend."""
+
+    original_url = settings.REDIS_URL
+    reset_queue_backends()
+    try:
+        settings.REDIS_URL = "redis://localhost:6379/0"
+        worker_tasks.initialize_queue_backends()
+
+        primary, fallback = get_queue_backends()
+        assert isinstance(primary, RedisQueueBackend)
+        assert isinstance(fallback, BackgroundTaskQueueBackend)
+
+        container = ServiceContainer(db_session)
+        deliveries_service = container.deliveries
+
+        assert deliveries_service._queue_backend is primary
+        assert deliveries_service._fallback_queue_backend is fallback
+        assert worker_tasks.queue_backend is primary
+        assert worker_tasks.fallback_queue_backend is fallback
+    finally:
+        _restore_queue_state(original_url)
+
+
+def test_queue_factory_shared_backend_without_redis(db_session) -> None:
+    """Fallback queue should be shared when Redis is not configured."""
+
+    original_url = settings.REDIS_URL
+    reset_queue_backends()
+    try:
+        settings.REDIS_URL = None
+        worker_tasks.initialize_queue_backends()
+
+        primary, fallback = get_queue_backends()
+        assert primary is None
+        assert isinstance(fallback, BackgroundTaskQueueBackend)
+
+        container = ServiceContainer(db_session)
+        deliveries_service = container.deliveries
+
+        assert deliveries_service._queue_backend is None
+        assert deliveries_service._fallback_queue_backend is fallback
+        assert worker_tasks.primary_queue_backend is None
+        assert worker_tasks.queue_backend is fallback
+        assert worker_tasks.fallback_queue_backend is fallback
+        assert worker_tasks.q is None
+    finally:
+        _restore_queue_state(original_url)

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -8,8 +8,10 @@ import pytest
 fakeredis = pytest.importorskip("fakeredis")
 from rq import Queue, SimpleWorker  # noqa: E402
 
+from backend.core.config import settings  # noqa: E402
 from backend.core.database import get_session_context, init_db  # noqa: E402
 from backend.models.deliveries import DeliveryJob  # noqa: E402
+from backend.services.queue import reset_queue_backends  # noqa: E402
 from backend.workers import tasks as worker_tasks  # noqa: E402
 from backend.workers.tasks import enqueue_delivery  # noqa: E402
 
@@ -18,33 +20,41 @@ def test_worker_process_cycle(tmp_path, monkeypatch):
     """Run a full enqueue -> worker cycle using a FakeRedis connection."""
     # Use FakeRedis for the queue connection
     fake_redis = fakeredis.FakeStrictRedis()
-    monkeypatch.setenv("REDIS_URL", "redis://localhost:6379/0")
+    original_url = settings.REDIS_URL
+    reset_queue_backends()
+    try:
+        settings.REDIS_URL = "redis://localhost:6379/0"
+        worker_tasks.initialize_queue_backends()
 
-    # patch the queue in tasks to use a fake connection
-    fake_q = Queue("default", connection=fake_redis)
-    monkeypatch.setattr(worker_tasks, "q", fake_q)
-    monkeypatch.setattr(worker_tasks.queue_backend, "_queue", fake_q, raising=False)
+        # patch the queue in tasks to use a fake connection
+        fake_q = Queue("default", connection=fake_redis)
+        monkeypatch.setattr(worker_tasks, "q", fake_q)
+        monkeypatch.setattr(worker_tasks.queue_backend, "_queue", fake_q, raising=False)
 
-    # Ensure DB initialized in a temp directory to avoid collisions. The DB
-    # is created in the module path, so ensure init_db runs (it will create
-    # db.sqlite next to files).
-    init_db()
+        # Ensure DB initialized in a temp directory to avoid collisions. The DB
+        # is created in the module path, so ensure init_db runs (it will create
+        # db.sqlite next to files).
+        init_db()
 
-    # enqueue a simple CLI delivery
-    did = enqueue_delivery("hello", "cli", {"template": "t"}, max_retries=1)
-    assert did is not None
+        # enqueue a simple CLI delivery
+        did = enqueue_delivery("hello", "cli", {"template": "t"}, max_retries=1)
+        assert did is not None
 
-    # Run a SimpleWorker to process queued jobs synchronously
-    worker = SimpleWorker([fake_q], connection=fake_redis)
-    worker.work(burst=True)
+        # Run a SimpleWorker to process queued jobs synchronously
+        worker = SimpleWorker([fake_q], connection=fake_redis)
+        worker.work(burst=True)
 
-    # check DB state
-    with get_session_context() as sess:
-        dj = sess.get(DeliveryJob, did)
-        assert dj is not None
-        # Either succeeded or failed depending on execution; we expect at
-        # least a status set
-        assert dj.status in ("succeeded", "failed", "retrying")
+        # check DB state
+        with get_session_context() as sess:
+            dj = sess.get(DeliveryJob, did)
+            assert dj is not None
+            # Either succeeded or failed depending on execution; we expect at
+            # least a status set
+            assert dj.status in ("succeeded", "failed", "retrying")
+    finally:
+        settings.REDIS_URL = original_url
+        reset_queue_backends()
+        worker_tasks.initialize_queue_backends()
 
 
 # duplicate test removed; the single test above exercises the worker cycle


### PR DESCRIPTION
## Summary
- add a shared queue backend factory that lazily caches the Redis and background implementations
- update the service container and worker task bootstrap to source queue backends from the factory
- add regression coverage for Redis and background modes and align the worker test with the shared setup

## Testing
- pytest tests/test_queue_configuration.py tests/test_worker.py

------
https://chatgpt.com/codex/tasks/task_e_68d096e1fed88329828331c561c50ae8