### PR TITLE
Route logging uses structlog

### DIFF
--- a/backend/api/v1/compose.py
+++ b/backend/api/v1/compose.py
@@ -4,11 +4,15 @@ This module exposes a single POST /compose endpoint that builds a prompt
 from active adapters and optionally schedules a delivery.
 """
 
+import structlog
+
 from fastapi import APIRouter, BackgroundTasks, Depends
 
 from backend.core.dependencies import get_service_container
 from backend.schemas import ComposeRequest, ComposeResponse
 from backend.services import ServiceContainer
+
+logger = structlog.get_logger(__name__)
 
 router = APIRouter()
 
@@ -29,7 +33,7 @@ async def compose(
 
     if composition.warnings:
         # Log warnings but continue
-        print(f"Composition warnings: {composition.warnings}")
+        logger.warning("composition warnings", warnings=composition.warnings)
 
     delivery_info = None
     if req.delivery:


### PR DESCRIPTION
## Summary
- add structlog loggers to the compose and generation routers
- replace ad-hoc print statements with structured warnings for composition and generation validation

## Testing
- pytest tests/test_generation_jobs.py

------
https://chatgpt.com/codex/tasks/task_e_68d0a21d353c832986e8f3b522604d36