### PR TITLE
feat: share generation progress normalization helper

### DIFF
--- a/app/frontend/src/composables/useGenerationStudio.ts
+++ b/app/frontend/src/composables/useGenerationStudio.ts
@@ -11,6 +11,7 @@ import {
 } from '@/services/generationService'
 import { useAppStore } from '@/stores/app'
 import { useSettingsStore } from '@/stores/settings'
+import { normalizeGenerationProgress } from '@/utils/progress'
 import type {
   GenerationFormState,
   GenerationJob,
@@ -18,13 +19,6 @@ import type {
   NotificationType,
   SystemStatusState,
 } from '@/types'
-
-const normalizeProgress = (value?: number | null): number => {
-  if (typeof value !== 'number' || Number.isNaN(value)) {
-    return 0
-  }
-  return value <= 1 ? Math.round(value * 100) : Math.round(value)
-}
 
 export const useGenerationStudio = () => {
   const appStore = useAppStore()
@@ -103,7 +97,7 @@ export const useGenerationStudio = () => {
           id: response.job_id,
           prompt: payload.prompt,
           status: response.status as GenerationJob['status'],
-          progress: normalizeProgress(response.progress),
+          progress: normalizeGenerationProgress(response.progress),
           startTime: createdAt,
           created_at: createdAt,
           width: payload.width,

--- a/app/frontend/src/composables/useGenerationUpdates.ts
+++ b/app/frontend/src/composables/useGenerationUpdates.ts
@@ -4,6 +4,7 @@ import { storeToRefs } from 'pinia'
 import { useActiveJobsApi, useRecentResultsApi, useSystemStatusApi } from '@/composables/apiClients'
 import { resolveBackendUrl, resolveGenerationBaseUrl } from '@/services/generationService'
 import { useAppStore } from '@/stores/app'
+import { normalizeGenerationProgress } from '@/utils/progress'
 import type {
   GenerationCompleteMessage,
   GenerationErrorMessage,
@@ -44,13 +45,6 @@ const parseTimestamp = (value?: string): number => {
   }
   const timestamp = Date.parse(value)
   return Number.isNaN(timestamp) ? 0 : timestamp
-}
-
-const normalizeProgress = (value?: number | null): number => {
-  if (typeof value !== 'number' || Number.isNaN(value)) {
-    return 0
-  }
-  return value <= 1 ? Math.round(value * 100) : Math.round(value)
 }
 
 const appendWebSocketPath = (path: string): string => {
@@ -188,7 +182,7 @@ export const useGenerationUpdates = ({
       return
     }
 
-    job.progress = normalizeProgress(update.progress)
+    job.progress = normalizeGenerationProgress(update.progress)
     job.status = update.status as GenerationJob['status']
 
     if (typeof update.current_step === 'number') {

--- a/app/frontend/src/utils/progress.ts
+++ b/app/frontend/src/utils/progress.ts
@@ -1,0 +1,7 @@
+export const normalizeGenerationProgress = (value?: number | null): number => {
+  if (typeof value !== 'number' || Number.isNaN(value)) {
+    return 0
+  }
+
+  return value <= 1 ? Math.round(value * 100) : Math.round(value)
+}

--- a/tests/vue/progressUtils.spec.ts
+++ b/tests/vue/progressUtils.spec.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest'
+
+import { normalizeGenerationProgress } from '../../app/frontend/src/utils/progress.ts'
+
+describe('normalizeGenerationProgress', () => {
+  it('returns 0 for undefined and null values', () => {
+    expect(normalizeGenerationProgress()).toBe(0)
+    expect(normalizeGenerationProgress(null)).toBe(0)
+  })
+
+  it('returns 0 for non-numeric values', () => {
+    expect(normalizeGenerationProgress(Number.NaN)).toBe(0)
+  })
+
+  it('normalizes fractional progress to percentages', () => {
+    expect(normalizeGenerationProgress(0.25)).toBe(25)
+    expect(normalizeGenerationProgress(0.5)).toBe(50)
+    expect(normalizeGenerationProgress(0.999)).toBe(100)
+  })
+
+  it('rounds numeric percentages above 1', () => {
+    expect(normalizeGenerationProgress(45.2)).toBe(45)
+    expect(normalizeGenerationProgress(99.6)).toBe(100)
+  })
+})


### PR DESCRIPTION
## Summary
- add a shared `normalizeGenerationProgress` helper under `app/frontend/src/utils`
- update the generation composables to reuse the shared progress normaliser
- cover the helper with focused unit tests so rounding behaviour only needs tweaking once

## Testing
- npm run test:unit *(fails: pre-existing GenerationStudio component expectations that could not be resolved within this change)*

------
https://chatgpt.com/codex/tasks/task_e_68d0bda348408329956bc26b36d1d746