### PR TITLE
Fix analytics export path and test streaming archive

### DIFF
--- a/app/frontend/src/services/analyticsService.ts
+++ b/app/frontend/src/services/analyticsService.ts
@@ -23,12 +23,15 @@ export const exportAnalyticsReport = async (
     ...options,
   };
 
-  const { blob, response } = await requestBlob(resolveBackendUrl('/export', baseUrl ?? undefined), {
-    method: 'POST',
-    credentials: 'same-origin',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(payload),
-  });
+  const { blob, response } = await requestBlob(
+    resolveBackendUrl('/import-export/export', baseUrl ?? undefined),
+    {
+      method: 'POST',
+      credentials: 'same-origin',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    },
+  );
 
   const filename =
     getFilenameFromContentDisposition(response.headers.get('content-disposition'))

--- a/backend/api/v1/import_export.py
+++ b/backend/api/v1/import_export.py
@@ -221,3 +221,17 @@ async def create_backup(backup_type: str = "full"):
         "type": backup_type,
         "status": "initiated",
     }
+
+
+# ---------------------------------------------------------------------------
+# Prefixed route aliases for `/import-export/*`
+# ---------------------------------------------------------------------------
+# Maintain backwards compatibility by exposing import/export endpoints with
+# the expected `/import-export` prefix used by the frontend SPA. Legacy routes
+# without the prefix remain available because the primary decorators above use
+# the original paths.
+router.add_api_route("/import-export/export", export_data, methods=["POST"])
+router.add_api_route("/import-export/export/estimate", estimate_export, methods=["POST"])
+router.add_api_route("/import-export/import", import_data, methods=["POST"])
+router.add_api_route("/import-export/backups/history", get_backup_history, methods=["GET"])
+router.add_api_route("/import-export/backup/create", create_backup, methods=["POST"])

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,4 +1,5 @@
 """Tests for the HTTP API, using FastAPI's TestClient and pytest fixtures."""
+from pathlib import Path
 from unittest.mock import MagicMock
 
 from fastapi.testclient import TestClient
@@ -8,6 +9,7 @@ from backend.main import app as backend_app
 from backend.schemas import SDNextGenerationResult
 from backend.services import ServiceContainer
 from backend.services.queue import QueueBackend
+from backend.services.storage import get_storage_service
 
 
 class RecordingQueueBackend(QueueBackend):
@@ -81,6 +83,49 @@ def test_frontend_settings_endpoint(client: TestClient):
     payload = response.json()
     assert "backendUrl" in payload
     assert payload["backendUrl"].endswith("/v1")
+
+
+def test_import_export_export_streams_archive(
+    client: TestClient,
+    mock_storage: MagicMock,
+    tmp_path,
+):
+    """The import/export export endpoint should stream a ZIP archive."""
+
+    adapter_file = tmp_path / "adapter.safetensors"
+    adapter_file.write_bytes(b"fake-weights")
+
+    def _path_exists(path: str) -> bool:
+        return Path(path).exists()
+
+    mock_storage.exists.side_effect = _path_exists
+
+    storage_service = get_storage_service()
+    storage_service.backend.get_file_size = (
+        lambda path: Path(path).stat().st_size if Path(path).exists() else 0
+    )
+
+    create_payload = {
+        "name": "export-test",
+        "version": "v1",
+        "file_path": str(adapter_file),
+        "weight": 1.0,
+    }
+
+    create_response = client.post("/api/v1/adapters", json=create_payload)
+    assert create_response.status_code == 201
+
+    export_response = client.post(
+        "/api/v1/import-export/export",
+        json={"loras": True, "format": "zip"},
+    )
+
+    assert export_response.status_code == 200
+    assert export_response.headers.get("content-type") == "application/zip"
+    disposition = export_response.headers.get("content-disposition", "")
+    assert "attachment; filename=" in disposition
+    assert export_response.content.startswith(b"PK\x03\x04")
+    assert len(export_response.content) > 0
 
 
 def test_adapter_lifecycle(client: TestClient, mock_storage: MagicMock):


### PR DESCRIPTION
## Summary
- point analytics export client at the /import-export/export backend route
- expose /import-export prefixed aliases for import/export endpoints while keeping legacy paths
- add a regression test that exercises the prefixed export endpoint and validates the streamed ZIP

## Testing
- pytest tests/test_main.py -k import_export_export_streams_archive


------
https://chatgpt.com/codex/tasks/task_e_68d0eb08342083299a28e24650497be5