### PR TITLE
Optimize duplicate detection in composition service

### DIFF
--- a/backend/services/composition.py
+++ b/backend/services/composition.py
@@ -116,7 +116,18 @@ class ComposeService:
         
         # Check for duplicate names
         names = [adapter.name for adapter in adapters]
-        duplicates = set([name for name in names if names.count(name) > 1])
+        seen = set()
+        duplicate_set = set()
+        duplicates: List[str] = []
+
+        for name in names:
+            if name in seen:
+                if name not in duplicate_set:
+                    duplicate_set.add(name)
+                    duplicates.append(name)
+            else:
+                seen.add(name)
+
         if duplicates:
             warnings.append(f"Duplicate adapter names found: {', '.join(duplicates)}")
         

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -490,3 +490,18 @@ class TestComposeService:
         assert "Duplicate adapter names" in " ".join(result.warnings)
         assert "Adapters with zero weight" in " ".join(result.warnings)
         assert result.prompt == "start <lora:gamma:0.000> <lora:gamma:0.000> end"
+
+    def test_validate_adapters_reports_each_duplicate_once(self, compose_service):
+        """Duplicate adapter warnings should enumerate each repeated name once."""
+
+        adapters = [
+            Adapter(name="alpha", file_path="/tmp/a", weight=0.5, active=True),
+            Adapter(name="beta", file_path="/tmp/b", weight=0.6, active=True),
+            Adapter(name="alpha", file_path="/tmp/c", weight=0.7, active=True),
+            Adapter(name="beta", file_path="/tmp/d", weight=0.8, active=True),
+            Adapter(name="gamma", file_path="/tmp/e", weight=0.9, active=True),
+        ]
+
+        warnings = compose_service.validate_adapters(adapters)
+
+        assert "Duplicate adapter names found: alpha, beta" in warnings


### PR DESCRIPTION
## Summary
- replace the quadratic duplicate-name scan in `ComposeService.validate_adapters` with a linear-time pass that preserves warning order
- extend `TestComposeService` coverage to ensure duplicate warnings list each repeated adapter only once

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d0f52db8c883298b578177cf6f7eae