### PR TITLE
Expose composition warnings in compose response

### DIFF
--- a/app/frontend/src/types/deliveries.ts
+++ b/app/frontend/src/types/deliveries.ts
@@ -29,6 +29,7 @@ export interface ComposeDeliveryInfo {
 export interface ComposeResponse {
   prompt: string;
   tokens: string[];
+  warnings: string[];
   delivery?: ComposeDeliveryInfo | null;
 }
 

--- a/backend/api/v1/compose.py
+++ b/backend/api/v1/compose.py
@@ -48,5 +48,6 @@ async def compose(
     return ComposeResponse(
         prompt=composition.prompt,
         tokens=composition.tokens,
+        warnings=composition.warnings,
         delivery=delivery_info,
     )

--- a/backend/schemas/deliveries.py
+++ b/backend/schemas/deliveries.py
@@ -3,7 +3,7 @@
 from datetime import datetime
 from typing import Any, Dict, List, Optional
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from .generation import ComposeDeliverySDNext
 
@@ -43,6 +43,7 @@ class ComposeResponse(BaseModel):
 
     prompt: str
     tokens: List[str]
+    warnings: List[str] = Field(default_factory=list)
     delivery: Optional[ComposeDeliveryInfo] = None
 
 


### PR DESCRIPTION
## Summary
- add a warnings list to the compose response schema and mirror it in the frontend type definitions
- return composition warnings from the compose endpoint so callers can surface validation feedback
- extend compose API tests to assert the warnings contract, including a case with no active adapters

## Testing
- pytest tests/test_main.py

------
https://chatgpt.com/codex/tasks/task_e_68d0faec798c83299cf85a958d44a286