### PR TITLE
Handle legacy job queue fallback more gracefully

### DIFF
--- a/tests/vue/useJobQueue.spec.ts
+++ b/tests/vue/useJobQueue.spec.ts
@@ -1,0 +1,95 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { computed, effectScope } from 'vue';
+
+import { useJobQueue } from '@/composables/useJobQueue';
+import { ApiError } from '@/types';
+
+const serviceMocks = vi.hoisted(() => ({
+  fetchActiveGenerationJobs: vi.fn(),
+  fetchLegacyJobStatuses: vi.fn(),
+  cancelGenerationJob: vi.fn(),
+  cancelLegacyJob: vi.fn(),
+}));
+
+vi.mock('@/services/generationService', () => serviceMocks);
+
+const notificationMocks = vi.hoisted(() => ({
+  notifications: { value: [] as unknown[] },
+  showSuccess: vi.fn(),
+  showError: vi.fn(),
+  showInfo: vi.fn(),
+  showWarning: vi.fn(),
+  addNotification: vi.fn(),
+  removeNotification: vi.fn(),
+  clearAll: vi.fn(),
+}));
+
+vi.mock('@/composables/useNotifications', () => ({
+  useNotifications: () => notificationMocks,
+}));
+
+vi.mock('@/utils/backend', () => ({
+  useBackendBase: () => computed(() => '/api/v1'),
+}));
+
+const withQueue = async (run: (queue: ReturnType<typeof useJobQueue>) => Promise<void>) => {
+  const scope = effectScope();
+  let queueInstance: ReturnType<typeof useJobQueue>;
+
+  scope.run(() => {
+    queueInstance = useJobQueue();
+  });
+
+  try {
+    await run(queueInstance!);
+  } finally {
+    scope.stop();
+  }
+};
+
+describe('useJobQueue', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    notificationMocks.notifications.value = [];
+  });
+
+  it('retries the primary endpoint when fallback returns 404 and continues polling', async () => {
+    const fallbackNotFound = new ApiError({
+      message: 'Not Found',
+      status: 404,
+      statusText: 'Not Found',
+      payload: null,
+      meta: { ok: false, status: 404, statusText: 'Not Found' },
+    });
+
+    serviceMocks.fetchActiveGenerationJobs
+      .mockRejectedValueOnce(new Error('Primary endpoint failed'))
+      .mockResolvedValueOnce([
+        {
+          id: 'job-1',
+          status: 'running',
+          progress: 25,
+          message: 'Working',
+        },
+      ]);
+
+    serviceMocks.fetchLegacyJobStatuses.mockRejectedValueOnce(fallbackNotFound);
+
+    await withQueue(async (queue) => {
+      await queue.refresh();
+
+      expect(queue.apiAvailable.value).toBe(true);
+      expect(serviceMocks.fetchActiveGenerationJobs).toHaveBeenCalledTimes(1);
+      expect(serviceMocks.fetchLegacyJobStatuses).toHaveBeenCalledTimes(1);
+
+      await queue.refresh();
+
+      expect(serviceMocks.fetchActiveGenerationJobs).toHaveBeenCalledTimes(2);
+      expect(serviceMocks.fetchLegacyJobStatuses).toHaveBeenCalledTimes(1);
+      expect(queue.jobs.value).toHaveLength(1);
+      expect(queue.jobs.value[0]).toMatchObject({ id: 'job-1', status: 'running', progress: 25 });
+    });
+  });
+});
+
+


### PR DESCRIPTION
## Summary
- treat legacy job fallback 404 responses as a missing endpoint without disabling polling
- add a cooldown before re-logging primary endpoint failures so retries keep hitting the modern API
- cover the fallback-missing scenario with a dedicated Vitest specification

## Testing
- npm run test:unit *(fails: existing GenerationStudio specs currently failing in main)*
- npx vitest run tests/vue/useJobQueue.spec.ts


------
https://chatgpt.com/codex/tasks/task_e_68d101efbd1883298b509e92b687e0a3