### PR TITLE
Refactor delivery runner into dedicated module

### DIFF
--- a/backend/services/deliveries.py
+++ b/backend/services/deliveries.py
@@ -1,8 +1,7 @@
-"""Delivery service for managing delivery jobs and execution."""
+"""Delivery service for managing delivery jobs and queue hand-off."""
 
 from __future__ import annotations
 
-import asyncio
 import json
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
@@ -16,7 +15,6 @@ from backend.models import DeliveryJob
 if TYPE_CHECKING:  # pragma: no cover - used for type checking only
     from .queue import QueueBackend
 
-_SUCCESS_STATUSES = {"ok", "completed", 200}
 _ACTIVE_STATUSES = {"pending", "running", "retrying"}
 
 
@@ -263,124 +261,3 @@ class DeliveryService:
             return json.loads(job.result)
         except json.JSONDecodeError:
             return None
-
-
-def process_delivery_job(
-    job_id: str,
-    retries_left: Optional[int] = None,
-    *,
-    raise_on_error: bool = False,
-) -> None:
-    """Process a delivery job synchronously."""
-
-    async def runner() -> None:
-        await _process_delivery_job_async(
-            job_id,
-            retries_left=retries_left,
-            raise_on_error=raise_on_error,
-        )
-
-    try:
-        loop = asyncio.get_running_loop()
-    except RuntimeError:
-        asyncio.run(runner())
-    else:  # pragma: no cover - defensive branch
-        task = loop.create_task(runner())
-        if raise_on_error:
-            raise RuntimeError(
-                "Cannot raise errors when scheduling delivery processing on an"
-                " active event loop",
-            )
-        return task
-
-
-async def _process_delivery_job_async(
-    job_id: str,
-    *,
-    retries_left: Optional[int] = None,
-    raise_on_error: bool = False,
-) -> None:
-    """Internal coroutine to process a delivery job."""
-
-    from backend.core.database import get_session_context
-
-    prompt: str
-    mode: str
-    params: Dict[str, Any]
-    error: Optional[Exception] = None
-    result_payload: Dict[str, Any] = {}
-    status: str = "failed"
-
-    with get_session_context() as session:
-        service = DeliveryService(session)
-        job = service.get_job(job_id)
-        if job is None:
-            return
-
-        service.update_job_status(job_id, "running")
-        prompt = job.prompt
-        mode = job.mode
-        params = service.get_job_params(job)
-
-    try:
-        result_payload = await _execute_delivery_backend(prompt, mode, params)
-        status = "succeeded" if _is_successful_result(result_payload) else "failed"
-    except Exception as exc:  # pragma: no cover - defensive branch
-        error = exc
-        result_payload = {"error": str(exc)}
-        if retries_left is not None and retries_left > 0:
-            result_payload["retries_left"] = retries_left
-            status = "retrying"
-        else:
-            status = "failed"
-
-    with get_session_context() as session:
-        service = DeliveryService(session)
-        service.update_job_status(job_id, status, result_payload)
-
-    if error is not None and raise_on_error:
-        raise error
-
-
-async def _execute_delivery_backend(
-    prompt: str,
-    mode: str,
-    params: Dict[str, Any],
-) -> Dict[str, Any]:
-    """Execute the delivery backend for a job and return the result."""
-
-    if mode == "http":
-        from backend.delivery import get_delivery_backend
-
-        backend = get_delivery_backend("http")
-        return await backend.deliver(prompt, params)
-    if mode == "cli":
-        from backend.delivery import get_delivery_backend
-
-        backend = get_delivery_backend("cli")
-        return await backend.deliver(prompt, params)
-    if mode == "sdnext":
-        from backend.delivery import get_generation_backend
-        from backend.schemas import SDNextGenerationParams
-
-        backend = get_generation_backend("sdnext")
-
-        gen_params_dict = params.get("generation_params", {}).copy()
-        gen_params_dict["prompt"] = prompt
-
-        gen_params = SDNextGenerationParams(**gen_params_dict)
-        full_params = {
-            "generation_params": gen_params.model_dump(),
-            "mode": params.get("mode", "immediate"),
-            "save_images": params.get("save_images", True),
-            "return_format": params.get("return_format", "base64"),
-        }
-        result_obj = await backend.generate_image(prompt, full_params)
-        return result_obj.model_dump()
-
-    return {"status": "error", "detail": f"unknown mode: {mode}"}
-
-
-def _is_successful_result(result: Dict[str, Any]) -> bool:
-    status = result.get("status")
-    return status in _SUCCESS_STATUSES

--- a/backend/workers/delivery_runner.py
+++ b/backend/workers/delivery_runner.py
@@ -1,0 +1,133 @@
+"""Delivery job runner that orchestrates backend execution."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Dict, Optional
+
+from backend.core.database import get_session_context
+from backend.delivery.base import DeliveryRegistry
+from backend.schemas import SDNextGenerationParams
+from backend.services.deliveries import DeliveryService
+
+_SUCCESS_STATUSES = {"ok", "completed", 200}
+
+
+class DeliveryRunner:
+    """Coordinate delivery job execution using registered backends."""
+
+    def __init__(self, delivery_registry: DeliveryRegistry) -> None:
+        self._delivery_registry = delivery_registry
+
+    def process_delivery_job(
+        self,
+        job_id: str,
+        retries_left: Optional[int] = None,
+        *,
+        raise_on_error: bool = False,
+    ) -> None:
+        """Process a delivery job, mirroring the previous synchronous helper."""
+
+        async def runner() -> None:
+            await self._process_delivery_job_async(
+                job_id,
+                retries_left=retries_left,
+                raise_on_error=raise_on_error,
+            )
+
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            asyncio.run(runner())
+        else:  # pragma: no cover - defensive branch
+            task = loop.create_task(runner())
+            if raise_on_error:
+                raise RuntimeError(
+                    "Cannot raise errors when scheduling delivery processing on an"
+                    " active event loop",
+                )
+            return task
+
+    async def _process_delivery_job_async(
+        self,
+        job_id: str,
+        *,
+        retries_left: Optional[int] = None,
+        raise_on_error: bool = False,
+    ) -> None:
+        """Internal coroutine that loads state and executes the backend."""
+
+        prompt: str
+        mode: str
+        params: Dict[str, Any]
+        error: Optional[Exception] = None
+        result_payload: Dict[str, Any] = {}
+        status: str = "failed"
+
+        with get_session_context() as session:
+            service = DeliveryService(session)
+            job = service.get_job(job_id)
+            if job is None:
+                return
+
+            service.update_job_status(job_id, "running")
+            prompt = job.prompt
+            mode = job.mode
+            params = service.get_job_params(job)
+
+        try:
+            result_payload = await self._execute_delivery_backend(prompt, mode, params)
+            status = "succeeded" if self._is_successful_result(result_payload) else "failed"
+        except Exception as exc:  # pragma: no cover - defensive branch
+            error = exc
+            result_payload = {"error": str(exc)}
+            if retries_left is not None and retries_left > 0:
+                result_payload["retries_left"] = retries_left
+                status = "retrying"
+            else:
+                status = "failed"
+
+        with get_session_context() as session:
+            service = DeliveryService(session)
+            service.update_job_status(job_id, status, result_payload)
+
+        if error is not None and raise_on_error:
+            raise error
+
+    async def _execute_delivery_backend(
+        self,
+        prompt: str,
+        mode: str,
+        params: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        """Execute the delivery backend associated with the job mode."""
+
+        if mode == "sdnext":
+            backend = self._delivery_registry.get_generation_backend("sdnext")
+            if backend is None:
+                return {"status": "error", "detail": "generation backend 'sdnext' not found"}
+
+            gen_params_dict = params.get("generation_params", {}).copy()
+            gen_params_dict["prompt"] = prompt
+
+            gen_params = SDNextGenerationParams(**gen_params_dict)
+            full_params = {
+                "generation_params": gen_params.model_dump(),
+                "mode": params.get("mode", "immediate"),
+                "save_images": params.get("save_images", True),
+                "return_format": params.get("return_format", "base64"),
+            }
+            result_obj = await backend.generate_image(prompt, full_params)
+            return result_obj.model_dump()
+
+        backend = self._delivery_registry.get_delivery_backend(mode)
+        if backend is None:
+            return {"status": "error", "detail": f"unknown mode: {mode}"}
+
+        return await backend.deliver(prompt, params)
+
+    @staticmethod
+    def _is_successful_result(result: Dict[str, Any]) -> bool:
+        status = result.get("status")
+        return status in _SUCCESS_STATUSES
+

--- a/backend/workers/tasks.py
+++ b/backend/workers/tasks.py
@@ -27,9 +27,10 @@ except Exception:
 
 
 from backend.core.database import get_session_context
+from backend.delivery.base import delivery_registry
 from backend.services import create_service_container
-from backend.services.deliveries import process_delivery_job
 from backend.services.queue import QueueBackend, RedisQueueBackend, get_queue_backends
+from backend.workers.delivery_runner import DeliveryRunner
 
 # Basic structured-ish logger for worker events
 logger = logging.getLogger("lora.tasks")
@@ -44,6 +45,7 @@ primary_queue_backend: Optional[RedisQueueBackend]
 fallback_queue_backend: QueueBackend
 queue_backend: QueueBackend
 q: Optional[Queue]
+delivery_runner = DeliveryRunner(delivery_registry)
 
 
 def initialize_queue_backends() -> None:
@@ -123,7 +125,7 @@ def process_delivery(delivery_id: str):
         except Exception:  # pragma: no cover - defensive branch
             retries_left = None
 
-        process_delivery_job(
+        delivery_runner.process_delivery_job(
             delivery_id,
             retries_left=retries_left,
             raise_on_error=True,

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -340,14 +340,14 @@ def test_compose_sdnext_delivery(
 
     captured: dict[str, object] = {}
 
-    async def fake_execute(prompt: str, mode: str, params: dict) -> dict:
+    async def fake_execute(self, prompt: str, mode: str, params: dict) -> dict:
         captured["prompt"] = prompt
         captured["params"] = params
         captured["mode"] = mode
         return {"status": "succeeded"}
 
     monkeypatch.setattr(
-        "backend.services.deliveries._execute_delivery_backend",
+        "backend.workers.delivery_runner.DeliveryRunner._execute_delivery_backend",
         fake_execute,
     )
 


### PR DESCRIPTION
## Summary
- add `DeliveryRunner` to encapsulate job execution against the delivery registry
- simplify `DeliveryService` to persistence and queue coordination and wire queue/workers to the new runner
- update delivery-related tests to patch the runner and cover the refactored flow

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68d1466e70608329968dac97cf02b737