### PR TITLE
Remove unused S3 storage backend references

### DIFF
--- a/backend/services/storage.py
+++ b/backend/services/storage.py
@@ -1,4 +1,4 @@
-"""Storage service with enhanced backend abstraction."""
+"""Storage service for local filesystem interactions."""
 
 import os
 from pathlib import Path
@@ -96,63 +96,6 @@ class LocalFileSystemStorage:
         except Exception:
             return []
 
-
-class S3StorageBackend:
-    """S3/MinIO storage backend (placeholder implementation)."""
-    
-    def __init__(self, bucket_name: str, endpoint_url: Optional[str] = None):
-        """Initialize S3 storage backend.
-        
-        Args:
-            bucket_name: S3 bucket name
-            endpoint_url: Custom S3 endpoint (for MinIO)
-
-        """
-        self.bucket_name = bucket_name
-        self.endpoint_url = endpoint_url
-        # TODO: Initialize boto3 client
-    
-    def file_exists(self, path: str) -> bool:
-        """Check if object exists in S3 bucket.
-        
-        Args:
-            path: Object key/path
-            
-        Returns:
-            True if object exists
-
-        """
-        # TODO: Implement S3 object existence check
-        raise NotImplementedError("S3 backend not yet implemented")
-    
-    def get_file_size(self, path: str) -> Optional[int]:
-        """Get object size in S3.
-        
-        Args:
-            path: Object key/path
-            
-        Returns:
-            Object size in bytes or None if not found
-
-        """
-        # TODO: Implement S3 object size check
-        raise NotImplementedError("S3 backend not yet implemented")
-    
-    def list_files(self, directory: str, pattern: str = "*") -> List[str]:
-        """List objects in S3 bucket with prefix.
-        
-        Args:
-            directory: Key prefix
-            pattern: Pattern filter (basic support)
-            
-        Returns:
-            List of object keys
-
-        """
-        # TODO: Implement S3 object listing
-        raise NotImplementedError("S3 backend not yet implemented")
-
-
 class StorageService:
     """Service for managing storage operations."""
     
@@ -220,14 +163,15 @@ class StorageService:
 
 
 def get_storage_backend() -> StorageBackend:
-    """Get the configured storage backend.
-    
+    """Return the supported storage backend implementation.
+
+    The application currently supports only the local filesystem for storage,
+    so this helper always returns :class:`LocalFileSystemStorage`.
+
     Returns:
-        Configured storage backend instance
+        LocalFileSystemStorage: The local filesystem storage backend instance.
 
     """
-    # For now, always return local filesystem
-    # TODO: Add configuration-based backend selection
     return LocalFileSystemStorage()
 
 

--- a/docs/contract.md
+++ b/docs/contract.md
@@ -25,7 +25,7 @@ up clients or planning future work.
 | Dashboard & system status | Implemented | Dashboard endpoints aggregate adapter statistics and delivery activity; `/system/status` exposes queue and hardware telemetry.【F:backend/api/v1/dashboard.py†L1-L40】【F:backend/api/v1/system.py†L1-L16】 |
 | Import/export utilities | Partially implemented | Archive endpoints stream ZIP files and ingest uploads, but backup history uses mock data and long-running flows rely on future work in `ArchiveService`.【F:backend/api/v1/import_export.py†L1-L170】 |
 | WebSocket progress | Implemented | `/ws/progress` hands connections to the `WebSocketService` which relays delivery/generation updates.【F:backend/api/v1/websocket.py†L1-L43】 |
-| Storage abstraction | Local filesystem only | The storage service validates paths on disk; the alternative cloud-storage backend placeholder still raises `NotImplementedError`.【F:backend/services/storage.py†L46-L153】 |
+| Storage abstraction | Local filesystem only | The storage service validates paths on disk; cloud-storage integrations are not supported and the local backend is the only option. |
 
 ## Known limitations and TODOs
 


### PR DESCRIPTION
## Summary
- remove the unimplemented S3 storage backend placeholder so the storage service only exposes the local filesystem backend
- clarify get_storage_backend documentation and project docs to reflect the local-only storage model

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d10467004083299db34e3e6bc54754