### PR TITLE
Refactor prompt composer into composable components

### DIFF
--- a/app/frontend/src/components/PromptComposer.vue
+++ b/app/frontend/src/components/PromptComposer.vue
@@ -1,6 +1,5 @@
 <template>
   <div class="space-y-6">
-    <!-- Header -->
     <div class="page-header">
       <div class="flex items-center justify-between">
         <div>
@@ -8,479 +7,103 @@
           <p class="page-subtitle">Build and compose prompts with LoRAs</p>
         </div>
         <div class="header-actions flex gap-2">
-          <button class="btn btn-secondary btn-sm" @click="loadComposition">Load Composition</button>
-          <button class="btn btn-secondary btn-sm" @click="clearComposition" :disabled="activeLoras.length === 0">Clear All</button>
+          <button class="btn btn-secondary btn-sm" type="button" @click="loadComposition">Load Composition</button>
+          <button class="btn btn-secondary btn-sm" type="button" :disabled="!canSave" @click="clearComposition">
+            Clear All
+          </button>
         </div>
       </div>
     </div>
 
-    <div class="grid grid-cols-1 lg:grid-cols-3 gap-6">
-      <!-- Left: Available LoRAs -->
+    <div class="grid grid-cols-1 gap-6 lg:grid-cols-3">
       <div class="lg:col-span-1">
-        <div class="card">
-          <div class="card-header">
-            <h3 class="card-title">Available LoRAs</h3>
-          </div>
-          <div class="card-body space-y-4">
-            <!-- Search/Filter -->
-            <div>
-              <input class="form-input w-full" placeholder="Search LoRAs..." v-model="searchTerm" />
-              <label class="inline-flex items-center gap-2 mt-2 text-sm">
-                <input type="checkbox" v-model="activeOnly" />
-                <span>Active Only</span>
-              </label>
-            </div>
-
-            <!-- Lora list -->
-            <div class="space-y-2 max-h-96 overflow-y-auto" data-testid="lora-list">
-              <div
-                v-for="l in filteredLoras"
-                :key="l.id"
-                class="flex items-center justify-between p-3 bg-gray-50 hover:bg-gray-100 rounded cursor-pointer"
-                :class="{ 'opacity-50': isInComposition(l.id) }"
-                @click="addToComposition(l)"
-              >
-                <div class="min-w-0">
-                  <div class="font-medium text-sm truncate">{{ l.name }}</div>
-                  <div class="text-xs text-gray-500 truncate">{{ l.description || 'No description' }}</div>
-                </div>
-                <div class="text-xs text-gray-500" v-if="l.active">Active</div>
-              </div>
-              <div v-if="!isLoading && filteredLoras.length === 0" class="text-sm text-gray-500">No LoRAs found</div>
-              <div v-if="error" class="text-sm text-red-600">Failed to load LoRAs</div>
-              <div v-if="isLoading" class="text-sm text-gray-500">Loading…</div>
-            </div>
-          </div>
-        </div>
+        <PromptComposerAvailableList
+          :loras="filteredLoras"
+          :search-term="searchTerm"
+          :active-only="activeOnly"
+          :is-loading="isLoading"
+          :error="error"
+          :is-in-composition="isInComposition"
+          @update:searchTerm="setSearchTerm"
+          @update:activeOnly="setActiveOnly"
+          @select="addToComposition"
+        />
       </div>
 
-      <!-- Middle: Composition -->
       <div class="lg:col-span-1">
-        <div class="card">
-          <div class="card-header">
-            <h3 class="card-title">Composition</h3>
-          </div>
-          <div class="card-body space-y-3" data-testid="composition">
-            <div
-              v-for="(l, idx) in activeLoras"
-              :key="l.id"
-              class="border rounded p-3 bg-white"
-            >
-              <div class="flex items-center gap-2">
-                <div class="font-medium flex-1 truncate">{{ l.name }}</div>
-                <button class="btn btn-secondary btn-xs" @click="moveUp(idx)" :disabled="idx === 0">↑</button>
-                <button class="btn btn-secondary btn-xs" @click="moveDown(idx)" :disabled="idx === activeLoras.length - 1">↓</button>
-                <button class="btn btn-secondary btn-xs" @click="removeFromComposition(idx)">✕</button>
-              </div>
-              <div class="mt-2">
-                <label class="text-xs">Weight: {{ l.weight.toFixed(2) }}</label>
-                <input type="range" min="0" max="2" step="0.05" v-model.number="l.weight" @input="updateFinal" class="w-full" />
-              </div>
-            </div>
-            <div v-if="activeLoras.length === 0" class="text-sm text-gray-500">No LoRAs in composition</div>
-          </div>
-        </div>
-
-        <div class="card mt-4">
-          <div class="card-header">
-            <h3 class="card-title">Quick Actions</h3>
-          </div>
-          <div class="card-body space-y-2">
-            <button class="btn btn-secondary btn-sm w-full" @click="balanceWeights" :disabled="activeLoras.length === 0">Balance All Weights</button>
-            <button class="btn btn-secondary btn-sm w-full" @click="duplicateComposition" :disabled="activeLoras.length === 0">Duplicate Composition</button>
-          </div>
-        </div>
+        <PromptComposerComposition
+          :items="activeLoras"
+          @remove="removeFromComposition"
+          @move-up="moveUp"
+          @move-down="moveDown"
+          @update-weight="onUpdateWeight"
+          @balance="balanceWeights"
+          @duplicate="duplicateComposition"
+        />
       </div>
 
-      <!-- Right: Prompt and actions -->
       <div class="lg:col-span-1">
-        <div class="card">
-          <div class="card-header"><h3 class="card-title">Generated Prompt</h3></div>
-          <div class="card-body space-y-3">
-            <div>
-              <label class="form-label">Base Prompt</label>
-              <textarea class="form-input h-20" v-model.trim="basePrompt" @input="updateFinal" placeholder="Enter your base prompt"></textarea>
-              <p v-if="basePromptError" class="text-xs text-red-600" data-testid="base-error">{{ basePromptError }}</p>
-            </div>
-            <div>
-              <label class="form-label">Negative Prompt</label>
-              <textarea class="form-input h-16" v-model.trim="negativePrompt" placeholder="Enter negative prompt"></textarea>
-            </div>
-            <div>
-              <label class="form-label">Complete Prompt</label>
-              <textarea class="form-input h-28 font-mono text-xs" readonly :value="finalPrompt"></textarea>
-            </div>
-            <div class="space-y-2">
-              <button class="btn btn-secondary w-full" @click="copyPrompt">Copy Prompt</button>
-              <button class="btn btn-secondary w-full" :disabled="activeLoras.length === 0" @click="saveComposition">Save Composition</button>
-              <button class="btn btn-primary w-full" :disabled="isGenerating" @click="generateImage">
-                <span v-if="!isGenerating">Generate Image</span>
-                <span v-else>Generating…</span>
-              </button>
-            </div>
-          </div>
-        </div>
+        <PromptComposerActions
+          :base-prompt="basePrompt"
+          :negative-prompt="negativePrompt"
+          :final-prompt="finalPrompt"
+          :base-prompt-error="basePromptError"
+          :is-generating="isGenerating"
+          :can-save="canSave"
+          :can-generate="canGenerate"
+          @update:basePrompt="setBasePrompt"
+          @update:negativePrompt="setNegativePrompt"
+          @copy="copyPrompt"
+          @save="saveComposition"
+          @generate="generateImage"
+        />
       </div>
     </div>
   </div>
-  
 </template>
 
 <script setup lang="ts">
-import { computed, onBeforeUnmount, onMounted, ref, watch, type ComputedRef, type Ref } from 'vue';
+import PromptComposerActions from './PromptComposerActions.vue';
+import PromptComposerAvailableList from './PromptComposerAvailableList.vue';
+import PromptComposerComposition from './PromptComposerComposition.vue';
 
-import { useAdapterListApi } from '@/services/loraService';
-import { createGenerationParams, requestGeneration } from '@/services/generationService';
-import { copyToClipboard } from '@/utils/browser';
+import { usePromptComposition } from '@/composables/usePromptComposition';
 
-import type {
-  AdapterSummary,
-  CompositionEntry,
-  SavedComposition,
-  LoraListItem,
-} from '@/types';
+const {
+  searchTerm,
+  activeOnly,
+  filteredLoras,
+  isLoading,
+  error,
+  activeLoras,
+  basePrompt,
+  negativePrompt,
+  finalPrompt,
+  basePromptError,
+  isGenerating,
+  canGenerate,
+  canSave,
+  setSearchTerm,
+  setActiveOnly,
+  addToComposition,
+  removeFromComposition,
+  moveUp,
+  moveDown,
+  updateWeight,
+  balanceWeights,
+  duplicateComposition,
+  clearComposition,
+  setBasePrompt,
+  setNegativePrompt,
+  copyPrompt,
+  saveComposition,
+  loadComposition,
+  generateImage,
+  isInComposition,
+} = usePromptComposition();
 
-const STORAGE_KEY = 'prompt-composer-composition';
-const DEFAULT_WEIGHT = 1;
-
-const lastSaved: Ref<SavedComposition | null> = ref(null);
-
-const loras: Ref<AdapterSummary[]> = ref([]);
-const searchTerm = ref<string>('');
-const activeOnly = ref<boolean>(false);
-const { adapters, error, isLoading, fetchData: loadLoras } = useAdapterListApi({ page: 1, perPage: 200 });
-
-const activeLoras: Ref<CompositionEntry[]> = ref([]);
-const basePrompt = ref<string>('');
-const negativePrompt = ref<string>('');
-const finalPrompt = ref<string>('');
-const basePromptError = ref<string>('');
-const isGenerating = ref<boolean>(false);
-
-const filteredLoras: ComputedRef<AdapterSummary[]> = computed(() => {
-  const term = searchTerm.value.trim().toLowerCase();
-  let items = loras.value;
-
-  if (activeOnly.value) {
-    items = items.filter((item) => item.active);
-  }
-
-  if (term) {
-    items = items.filter((item) => item.name.toLowerCase().includes(term));
-  }
-
-  return items;
-});
-
-const isInComposition = (id: AdapterSummary['id']): boolean => {
-  return activeLoras.value.some((entry) => String(entry.id) === String(id));
+const onUpdateWeight = (payload: { index: number; weight: number }) => {
+  updateWeight(payload.index, payload.weight);
 };
-
-const addToComposition = (lora: AdapterSummary): void => {
-  if (isInComposition(lora.id)) {
-    return;
-  }
-
-  activeLoras.value.push({ id: lora.id, name: lora.name, weight: DEFAULT_WEIGHT });
-  updateFinal();
-};
-
-const removeFromComposition = (index: number): void => {
-  if (index < 0 || index >= activeLoras.value.length) {
-    return;
-  }
-
-  activeLoras.value.splice(index, 1);
-  updateFinal();
-};
-
-const moveUp = (index: number): void => {
-  if (index <= 0 || index >= activeLoras.value.length) {
-    return;
-  }
-
-  const [item] = activeLoras.value.splice(index, 1);
-
-  if (!item) {
-    return;
-  }
-
-  activeLoras.value.splice(index - 1, 0, item);
-  updateFinal();
-};
-
-const moveDown = (index: number): void => {
-  if (index < 0 || index >= activeLoras.value.length - 1) {
-    return;
-  }
-
-  const [item] = activeLoras.value.splice(index, 1);
-
-  if (!item) {
-    return;
-  }
-
-  activeLoras.value.splice(index + 1, 0, item);
-  updateFinal();
-};
-
-const balanceWeights = (): void => {
-  if (activeLoras.value.length === 0) {
-    return;
-  }
-
-  activeLoras.value.forEach((entry) => {
-    entry.weight = DEFAULT_WEIGHT;
-  });
-  updateFinal();
-};
-
-const duplicateComposition = (): void => {
-  activeLoras.value = activeLoras.value.map((entry) => ({ ...entry }));
-  updateFinal();
-};
-
-const formatWeightToken = (value: number | string | null | undefined): string => {
-  const parsed = typeof value === 'number' ? value : Number(value);
-  const numeric = Number.isFinite(parsed) ? parsed : DEFAULT_WEIGHT;
-  const fixed = numeric.toFixed(2);
-  const trimmed = fixed
-    .replace(/(\.\d*?[1-9])0+$/u, '$1')
-    .replace(/\.0+$/u, '');
-  return trimmed.includes('.') ? trimmed : `${trimmed}.0`;
-};
-
-const buildFinalPrompt = (): string => {
-  const base = basePrompt.value.trim();
-
-  if (!base) {
-    return '';
-  }
-
-  const parts: string[] = [base];
-
-  activeLoras.value.forEach((entry) => {
-    const weightToken = formatWeightToken(entry.weight);
-    parts.push(`<lora:${entry.name}:${weightToken}>`);
-  });
-
-  return parts.join(' ');
-};
-
-const validate = (): boolean => {
-  basePromptError.value = '';
-
-  if (!basePrompt.value.trim()) {
-    basePromptError.value = 'Base prompt is required';
-    return false;
-  }
-
-  if (basePrompt.value.length > 1000) {
-    basePromptError.value = 'Base prompt is too long';
-    return false;
-  }
-
-  return true;
-};
-
-const updateFinal = (): void => {
-  finalPrompt.value = buildFinalPrompt();
-};
-
-const copyPrompt = async (): Promise<void> => {
-  try {
-    updateFinal();
-    const success = await copyToClipboard(finalPrompt.value || '');
-
-    if (!success && import.meta.env.DEV) {
-      console.warn('Failed to copy prompt to clipboard');
-    }
-  } catch (error) {
-    if (import.meta.env.DEV) {
-      console.warn('Copy prompt failed', error);
-    }
-  }
-};
-
-const toSavedComposition = (value: unknown): SavedComposition | null => {
-  if (!value || typeof value !== 'object') {
-    return null;
-  }
-
-  const record = value as Partial<SavedComposition> & { items?: unknown };
-
-  const items = Array.isArray(record.items)
-    ? record.items
-        .map((item) => {
-          if (!item || typeof item !== 'object') {
-            return null;
-          }
-
-          const entry = item as Partial<CompositionEntry>;
-
-          if (typeof entry.id !== 'string' || typeof entry.name !== 'string') {
-            return null;
-          }
-
-          const weight =
-            typeof entry.weight === 'number' ? entry.weight : Number(entry.weight);
-          const normalisedWeight = Number.isFinite(weight) ? weight : DEFAULT_WEIGHT;
-
-          return {
-            id: entry.id,
-            name: entry.name,
-            weight: normalisedWeight,
-          } satisfies CompositionEntry;
-        })
-        .filter((entry): entry is CompositionEntry => entry !== null)
-    : [];
-
-  const base = typeof record.base === 'string' ? record.base : '';
-  const neg = typeof record.neg === 'string' ? record.neg : '';
-
-  return { items, base, neg };
-};
-
-const PERSIST_DEBOUNCE_MS = 250;
-
-let persistTimeout: ReturnType<typeof setTimeout> | null = null;
-
-const cancelScheduledPersist = (): void => {
-  if (persistTimeout !== null) {
-    clearTimeout(persistTimeout);
-    persistTimeout = null;
-  }
-};
-
-const persistComposition = (payload: SavedComposition): void => {
-  try {
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(payload));
-  } catch (error) {
-    if (import.meta.env.DEV) {
-      console.warn('Failed to persist composition', error);
-    }
-  }
-};
-
-const schedulePersist = (payload: SavedComposition): void => {
-  cancelScheduledPersist();
-  persistTimeout = setTimeout(() => {
-    persistTimeout = null;
-    persistComposition(payload);
-  }, PERSIST_DEBOUNCE_MS);
-};
-
-const saveComposition = (): void => {
-  const payload: SavedComposition = {
-    items: activeLoras.value.map((entry) => ({ ...entry })),
-    base: basePrompt.value,
-    neg: negativePrompt.value,
-  };
-
-  lastSaved.value = payload;
-
-  cancelScheduledPersist();
-  persistComposition(payload);
-};
-
-const loadComposition = (): void => {
-  try {
-    const raw = localStorage.getItem(STORAGE_KEY);
-    let payload: SavedComposition | null = null;
-
-    if (raw) {
-      payload = toSavedComposition(JSON.parse(raw) as unknown);
-    } else if (lastSaved.value) {
-      payload = lastSaved.value;
-    }
-
-    if (!payload) {
-      return;
-    }
-
-    activeLoras.value = payload.items.map((entry) => ({ ...entry }));
-    basePrompt.value = payload.base;
-    negativePrompt.value = payload.neg;
-    lastSaved.value = payload;
-    updateFinal();
-  } catch (error) {
-    if (import.meta.env.DEV) {
-      console.warn('Failed to load composition', error);
-    }
-  }
-};
-
-const clearComposition = (): void => {
-  activeLoras.value = [];
-  updateFinal();
-};
-
-const generateImage = async (): Promise<void> => {
-  if (!validate()) {
-    updateFinal();
-    return;
-  }
-
-  isGenerating.value = true;
-
-  try {
-    updateFinal();
-    const trimmedNegative = negativePrompt.value.trim();
-    const params = createGenerationParams({
-      prompt: finalPrompt.value,
-      negative_prompt: trimmedNegative ? trimmedNegative : null,
-    });
-
-    await requestGeneration({
-      ...params,
-      loras: activeLoras.value.map((entry) => ({ ...entry })),
-    });
-  } catch (error) {
-    if (import.meta.env.DEV) {
-      console.warn('Failed to trigger generation', error);
-    }
-  } finally {
-    isGenerating.value = false;
-  }
-};
-
-onMounted(async () => {
-  await loadLoras();
-});
-
-watch(
-  adapters,
-  (next: LoraListItem[] | undefined) => {
-    const items = Array.isArray(next) ? next : [];
-
-    loras.value = items.map((item) => ({
-      id: item.id,
-      name: item.name,
-      description: item.description,
-      active: item.active ?? true,
-    }));
-  },
-  { immediate: true },
-);
-
-watch<[CompositionEntry[], string, string]>(
-  () => [activeLoras.value, basePrompt.value, negativePrompt.value],
-  ([items, base, neg]: [CompositionEntry[], string, string]) => {
-    const payload: SavedComposition = {
-      items: items.map((entry) => ({ ...entry })),
-      base,
-      neg,
-    };
-
-    lastSaved.value = payload;
-
-    schedulePersist(payload);
-  },
-  { deep: true },
-);
-
-onBeforeUnmount(() => {
-  cancelScheduledPersist();
-});
-
 </script>
+

--- a/app/frontend/src/components/PromptComposerActions.vue
+++ b/app/frontend/src/components/PromptComposerActions.vue
@@ -1,0 +1,101 @@
+<template>
+  <div class="card">
+    <div class="card-header">
+      <h3 class="card-title">Generated Prompt</h3>
+    </div>
+    <div class="card-body space-y-3">
+      <div>
+        <label class="form-label" for="prompt-composer-base">Base Prompt</label>
+        <textarea
+          id="prompt-composer-base"
+          class="form-input h-20"
+          data-testid="base-prompt"
+          :value="basePrompt"
+          @input="onUpdateBase"
+          placeholder="Enter your base prompt"
+        ></textarea>
+        <p v-if="basePromptError" class="text-xs text-red-600" data-testid="base-error">{{ basePromptError }}</p>
+      </div>
+      <div>
+        <label class="form-label" for="prompt-composer-negative">Negative Prompt</label>
+        <textarea
+          id="prompt-composer-negative"
+          class="form-input h-16"
+          data-testid="negative-prompt"
+          :value="negativePrompt"
+          @input="onUpdateNegative"
+          placeholder="Enter negative prompt"
+        ></textarea>
+      </div>
+      <div>
+        <label class="form-label" for="prompt-composer-final">Complete Prompt</label>
+        <textarea
+          id="prompt-composer-final"
+          class="form-input h-28 font-mono text-xs"
+          data-testid="final-prompt"
+          :value="finalPrompt"
+          readonly
+        ></textarea>
+      </div>
+      <div class="space-y-2">
+        <button class="btn btn-secondary w-full" type="button" data-testid="copy-prompt" @click="emit('copy')">
+          Copy Prompt
+        </button>
+        <button
+          class="btn btn-secondary w-full"
+          type="button"
+          data-testid="save-composition"
+          :disabled="!canSave"
+          @click="emit('save')"
+        >
+          Save Composition
+        </button>
+        <button
+          class="btn btn-primary w-full"
+          type="button"
+          data-testid="generate-image"
+          :disabled="!canGenerate"
+          @click="emit('generate')"
+        >
+          <span v-if="!isGenerating">Generate Image</span>
+          <span v-else>Generating…</span>
+        </button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { toRefs } from 'vue';
+
+const props = defineProps<{
+  basePrompt: string;
+  negativePrompt: string;
+  finalPrompt: string;
+  basePromptError: string;
+  isGenerating: boolean;
+  canSave: boolean;
+  canGenerate: boolean;
+}>();
+
+const emit = defineEmits<{
+  (e: 'update:basePrompt', value: string): void;
+  (e: 'update:negativePrompt', value: string): void;
+  (e: 'copy'): void;
+  (e: 'save'): void;
+  (e: 'generate'): void;
+}>();
+
+const { basePrompt, negativePrompt, finalPrompt, basePromptError, isGenerating, canSave, canGenerate } = toRefs(props);
+
+const onUpdateBase = (event: Event) => {
+  const target = event.target as HTMLTextAreaElement | null;
+  emit('update:basePrompt', target?.value ?? '');
+};
+
+const onUpdateNegative = (event: Event) => {
+  const target = event.target as HTMLTextAreaElement | null;
+  emit('update:negativePrompt', target?.value ?? '');
+};
+</script>
+

--- a/app/frontend/src/components/PromptComposerAvailableList.vue
+++ b/app/frontend/src/components/PromptComposerAvailableList.vue
@@ -1,0 +1,76 @@
+<template>
+  <div class="card">
+    <div class="card-header">
+      <h3 class="card-title">Available LoRAs</h3>
+    </div>
+    <div class="card-body space-y-4">
+      <div>
+        <input
+          class="form-input w-full"
+          placeholder="Search LoRAs..."
+          :value="searchTerm"
+          @input="onSearch"
+        />
+        <label class="inline-flex items-center gap-2 mt-2 text-sm">
+          <input type="checkbox" :checked="activeOnly" @change="onToggleActive" />
+          <span>Active Only</span>
+        </label>
+      </div>
+
+      <div class="space-y-2 max-h-96 overflow-y-auto" data-testid="lora-list">
+        <button
+          v-for="lora in loras"
+          :key="lora.id"
+          type="button"
+          class="flex w-full items-center justify-between rounded bg-gray-50 p-3 text-left hover:bg-gray-100"
+          :class="{ 'opacity-50': isInComposition(lora.id) }"
+          @click="emit('select', lora)"
+        >
+          <div class="min-w-0">
+            <div class="truncate text-sm font-medium">{{ lora.name }}</div>
+            <div class="truncate text-xs text-gray-500">{{ lora.description || 'No description' }}</div>
+          </div>
+          <div v-if="lora.active" class="text-xs text-gray-500">Active</div>
+        </button>
+        <div v-if="!isLoading && !loras.length" class="text-sm text-gray-500">No LoRAs found</div>
+        <div v-if="error" class="text-sm text-red-600">Failed to load LoRAs</div>
+        <div v-if="isLoading" class="text-sm text-gray-500">Loading…</div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { toRefs } from 'vue';
+
+import type { AdapterSummary } from '@/types';
+
+const props = defineProps<{
+  loras: AdapterSummary[];
+  searchTerm: string;
+  activeOnly: boolean;
+  isLoading: boolean;
+  error: unknown;
+  isInComposition: (id: AdapterSummary['id']) => boolean;
+}>();
+
+const emit = defineEmits<{
+  (e: 'update:searchTerm', value: string): void;
+  (e: 'update:activeOnly', value: boolean): void;
+  (e: 'select', value: AdapterSummary): void;
+}>();
+
+const { loras, searchTerm, activeOnly, isLoading, error } = toRefs(props);
+const isInComposition = props.isInComposition;
+
+const onSearch = (event: Event) => {
+  const target = event.target as HTMLInputElement | null;
+  emit('update:searchTerm', target?.value ?? '');
+};
+
+const onToggleActive = (event: Event) => {
+  const target = event.target as HTMLInputElement | null;
+  emit('update:activeOnly', Boolean(target?.checked));
+};
+</script>
+

--- a/app/frontend/src/components/PromptComposerComposition.vue
+++ b/app/frontend/src/components/PromptComposerComposition.vue
@@ -1,0 +1,102 @@
+<template>
+  <div class="space-y-4">
+    <div class="card">
+      <div class="card-header">
+        <h3 class="card-title">Composition</h3>
+      </div>
+      <div class="card-body space-y-3" data-testid="composition">
+        <div
+          v-for="(entry, index) in items"
+          :key="entry.id"
+          class="rounded border bg-white p-3"
+        >
+          <div class="flex items-center gap-2">
+            <div class="flex-1 truncate font-medium">{{ entry.name }}</div>
+            <button
+              class="btn btn-secondary btn-xs"
+              type="button"
+              data-testid="move-up"
+              :disabled="index === 0"
+              @click="emit('move-up', index)"
+            >
+              ↑
+            </button>
+            <button
+              class="btn btn-secondary btn-xs"
+              type="button"
+              data-testid="move-down"
+              :disabled="index === items.length - 1"
+              @click="emit('move-down', index)"
+            >
+              ↓
+            </button>
+            <button
+              class="btn btn-secondary btn-xs"
+              type="button"
+              data-testid="remove-entry"
+              @click="emit('remove', index)"
+            >
+              ✕
+            </button>
+          </div>
+          <div class="mt-2">
+            <label class="text-xs">Weight: {{ entry.weight.toFixed(2) }}</label>
+            <input
+              type="range"
+              min="0"
+              max="2"
+              step="0.05"
+              :value="entry.weight"
+              data-testid="weight-slider"
+              @input="onWeightInput(index, $event)"
+              class="w-full"
+            />
+          </div>
+        </div>
+        <div v-if="!items.length" class="text-sm text-gray-500">No LoRAs in composition</div>
+      </div>
+    </div>
+
+    <div class="card">
+      <div class="card-header">
+        <h3 class="card-title">Quick Actions</h3>
+      </div>
+      <div class="card-body space-y-2">
+        <button class="btn btn-secondary btn-sm w-full" type="button" :disabled="!items.length" @click="emit('balance')">
+          Balance All Weights
+        </button>
+        <button class="btn btn-secondary btn-sm w-full" type="button" :disabled="!items.length" @click="emit('duplicate')">
+          Duplicate Composition
+        </button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { toRefs } from 'vue';
+
+import type { CompositionEntry } from '@/types';
+
+const props = defineProps<{
+  items: CompositionEntry[];
+}>();
+
+const emit = defineEmits<{
+  (e: 'remove', index: number): void;
+  (e: 'move-up', index: number): void;
+  (e: 'move-down', index: number): void;
+  (e: 'update-weight', payload: { index: number; weight: number }): void;
+  (e: 'balance'): void;
+  (e: 'duplicate'): void;
+}>();
+
+const { items } = toRefs(props);
+
+const onWeightInput = (index: number, event: Event) => {
+  const target = event.target as HTMLInputElement | null;
+  const value = target ? Number(target.value) : 0;
+  emit('update-weight', { index, weight: value });
+};
+</script>
+

--- a/app/frontend/src/composables/usePromptComposition.ts
+++ b/app/frontend/src/composables/usePromptComposition.ts
@@ -1,0 +1,450 @@
+import { computed, onBeforeUnmount, onMounted, ref, watch, type ComputedRef, type Ref } from 'vue';
+
+import { useAdapterListApi } from '@/services/loraService';
+import { createGenerationParams, requestGeneration } from '@/services/generationService';
+import { copyToClipboard } from '@/utils/browser';
+
+import type {
+  AdapterSummary,
+  CompositionEntry,
+  SavedComposition,
+  LoraListItem,
+} from '@/types';
+
+type PersistTimeout = ReturnType<typeof setTimeout> | null;
+
+const STORAGE_KEY = 'prompt-composer-composition';
+const DEFAULT_WEIGHT = 1;
+const PERSIST_DEBOUNCE_MS = 250;
+
+const formatWeightToken = (value: number | string | null | undefined): string => {
+  const parsed = typeof value === 'number' ? value : Number(value);
+  const numeric = Number.isFinite(parsed) ? parsed : DEFAULT_WEIGHT;
+  const fixed = numeric.toFixed(2);
+  const trimmed = fixed
+    .replace(/(\.\d*?[1-9])0+$/u, '$1')
+    .replace(/\.0+$/u, '');
+  return trimmed.includes('.') ? trimmed : `${trimmed}.0`;
+};
+
+const buildFinalPrompt = (base: string, items: CompositionEntry[]): string => {
+  const trimmedBase = base.trim();
+
+  if (!trimmedBase) {
+    return '';
+  }
+
+  const tokens = items.map((entry) => `<lora:${entry.name}:${formatWeightToken(entry.weight)}>`);
+  return [trimmedBase, ...tokens].join(' ');
+};
+
+const toSavedComposition = (value: unknown): SavedComposition | null => {
+  if (!value || typeof value !== 'object') {
+    return null;
+  }
+
+  const record = value as Partial<SavedComposition> & { items?: unknown };
+  const items = Array.isArray(record.items)
+    ? record.items
+        .map((item) => {
+          if (!item || typeof item !== 'object') {
+            return null;
+          }
+
+          const entry = item as Partial<CompositionEntry>;
+
+          if (typeof entry.id !== 'string' || typeof entry.name !== 'string') {
+            return null;
+          }
+
+          const weight = typeof entry.weight === 'number' ? entry.weight : Number(entry.weight);
+          const normalisedWeight = Number.isFinite(weight) ? weight : DEFAULT_WEIGHT;
+
+          return {
+            id: entry.id,
+            name: entry.name,
+            weight: normalisedWeight,
+          } satisfies CompositionEntry;
+        })
+        .filter((entry): entry is CompositionEntry => entry !== null)
+    : [];
+
+  const base = typeof record.base === 'string' ? record.base : '';
+  const neg = typeof record.neg === 'string' ? record.neg : '';
+
+  return { items, base, neg };
+};
+
+const normaliseWeight = (value: number): number => {
+  if (!Number.isFinite(value)) {
+    return DEFAULT_WEIGHT;
+  }
+
+  if (value < 0) {
+    return 0;
+  }
+
+  if (value > 2) {
+    return 2;
+  }
+
+  return value;
+};
+
+export interface PromptCompositionState {
+  searchTerm: Ref<string>;
+  activeOnly: Ref<boolean>;
+  filteredLoras: ComputedRef<AdapterSummary[]>;
+  isLoading: Ref<boolean>;
+  error: Ref<unknown>;
+  activeLoras: Ref<CompositionEntry[]>;
+  basePrompt: Ref<string>;
+  negativePrompt: Ref<string>;
+  finalPrompt: ComputedRef<string>;
+  basePromptError: Ref<string>;
+  isGenerating: Ref<boolean>;
+  canGenerate: ComputedRef<boolean>;
+  canSave: ComputedRef<boolean>;
+}
+
+export interface PromptCompositionActions {
+  setSearchTerm: (value: string) => void;
+  setActiveOnly: (value: boolean) => void;
+  addToComposition: (lora: AdapterSummary) => void;
+  removeFromComposition: (index: number) => void;
+  moveUp: (index: number) => void;
+  moveDown: (index: number) => void;
+  updateWeight: (index: number, weight: number) => void;
+  balanceWeights: () => void;
+  duplicateComposition: () => void;
+  clearComposition: () => void;
+  setBasePrompt: (value: string) => void;
+  setNegativePrompt: (value: string) => void;
+  copyPrompt: () => Promise<boolean>;
+  saveComposition: () => void;
+  loadComposition: () => void;
+  generateImage: () => Promise<boolean>;
+  isInComposition: (id: AdapterSummary['id']) => boolean;
+}
+
+export const usePromptComposition = (): PromptCompositionState & PromptCompositionActions => {
+  const lastSaved = ref<SavedComposition | null>(null);
+  const loras = ref<AdapterSummary[]>([]);
+  const searchTerm = ref<string>('');
+  const activeOnly = ref<boolean>(false);
+  const { adapters, error, isLoading, fetchData: loadLoras } = useAdapterListApi({ page: 1, perPage: 200 });
+  const activeLoras = ref<CompositionEntry[]>([]);
+  const basePrompt = ref<string>('');
+  const negativePrompt = ref<string>('');
+  const basePromptError = ref<string>('');
+  const isGenerating = ref<boolean>(false);
+  let persistTimeout: PersistTimeout = null;
+
+  const filteredLoras = computed<AdapterSummary[]>(() => {
+    const term = searchTerm.value.trim().toLowerCase();
+    let items = loras.value;
+
+    if (activeOnly.value) {
+      items = items.filter((item) => item.active);
+    }
+
+    if (term) {
+      items = items.filter((item) => item.name.toLowerCase().includes(term));
+    }
+
+    return items;
+  });
+
+  const finalPrompt = computed<string>(() => buildFinalPrompt(basePrompt.value, activeLoras.value));
+  const canGenerate = computed<boolean>(() => !isGenerating.value);
+  const canSave = computed<boolean>(() => activeLoras.value.length > 0);
+
+  const cancelScheduledPersist = () => {
+    if (persistTimeout !== null) {
+      clearTimeout(persistTimeout);
+      persistTimeout = null;
+    }
+  };
+
+  const persistComposition = (payload: SavedComposition): void => {
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(payload));
+    } catch (err) {
+      if (import.meta.env.DEV) {
+        console.warn('Failed to persist composition', err);
+      }
+    }
+  };
+
+  const schedulePersist = (payload: SavedComposition): void => {
+    cancelScheduledPersist();
+    persistTimeout = setTimeout(() => {
+      persistTimeout = null;
+      persistComposition(payload);
+    }, PERSIST_DEBOUNCE_MS);
+  };
+
+  const setSearchTerm = (value: string) => {
+    searchTerm.value = value;
+  };
+
+  const setActiveOnly = (value: boolean) => {
+    activeOnly.value = value;
+  };
+
+  const setBasePrompt = (value: string) => {
+    basePrompt.value = value;
+  };
+
+  const setNegativePrompt = (value: string) => {
+    negativePrompt.value = value;
+  };
+
+  const isInComposition = (id: AdapterSummary['id']): boolean => {
+    return activeLoras.value.some((entry) => String(entry.id) === String(id));
+  };
+
+  const addToComposition = (lora: AdapterSummary): void => {
+    if (isInComposition(lora.id)) {
+      return;
+    }
+
+    activeLoras.value.push({ id: lora.id, name: lora.name, weight: DEFAULT_WEIGHT });
+  };
+
+  const removeFromComposition = (index: number): void => {
+    if (index < 0 || index >= activeLoras.value.length) {
+      return;
+    }
+
+    activeLoras.value.splice(index, 1);
+  };
+
+  const moveUp = (index: number): void => {
+    if (index <= 0 || index >= activeLoras.value.length) {
+      return;
+    }
+
+    const [item] = activeLoras.value.splice(index, 1);
+
+    if (!item) {
+      return;
+    }
+
+    activeLoras.value.splice(index - 1, 0, item);
+  };
+
+  const moveDown = (index: number): void => {
+    if (index < 0 || index >= activeLoras.value.length - 1) {
+      return;
+    }
+
+    const [item] = activeLoras.value.splice(index, 1);
+
+    if (!item) {
+      return;
+    }
+
+    activeLoras.value.splice(index + 1, 0, item);
+  };
+
+  const updateWeight = (index: number, weight: number): void => {
+    if (index < 0 || index >= activeLoras.value.length) {
+      return;
+    }
+
+    activeLoras.value[index].weight = normaliseWeight(weight);
+  };
+
+  const balanceWeights = (): void => {
+    if (activeLoras.value.length === 0) {
+      return;
+    }
+
+    activeLoras.value.forEach((entry) => {
+      entry.weight = DEFAULT_WEIGHT;
+    });
+  };
+
+  const duplicateComposition = (): void => {
+    activeLoras.value = activeLoras.value.map((entry) => ({ ...entry }));
+  };
+
+  const clearComposition = (): void => {
+    activeLoras.value = [];
+  };
+
+  const validate = (): boolean => {
+    basePromptError.value = '';
+
+    if (!basePrompt.value.trim()) {
+      basePromptError.value = 'Base prompt is required';
+      return false;
+    }
+
+    if (basePrompt.value.length > 1000) {
+      basePromptError.value = 'Base prompt is too long';
+      return false;
+    }
+
+    return true;
+  };
+
+  const copyPrompt = async (): Promise<boolean> => {
+    try {
+      const success = await copyToClipboard(finalPrompt.value || '');
+
+      if (!success && import.meta.env.DEV) {
+        console.warn('Failed to copy prompt to clipboard');
+      }
+
+      return success;
+    } catch (err) {
+      if (import.meta.env.DEV) {
+        console.warn('Copy prompt failed', err);
+      }
+      return false;
+    }
+  };
+
+  const saveComposition = (): void => {
+    const payload: SavedComposition = {
+      items: activeLoras.value.map((entry) => ({ ...entry })),
+      base: basePrompt.value,
+      neg: negativePrompt.value,
+    };
+
+    lastSaved.value = payload;
+
+    cancelScheduledPersist();
+    persistComposition(payload);
+  };
+
+  const loadComposition = (): void => {
+    try {
+      const raw = localStorage.getItem(STORAGE_KEY);
+      let payload: SavedComposition | null = null;
+
+      if (raw) {
+        payload = toSavedComposition(JSON.parse(raw) as unknown);
+      } else if (lastSaved.value) {
+        payload = lastSaved.value;
+      }
+
+      if (!payload) {
+        return;
+      }
+
+      activeLoras.value = payload.items.map((entry) => ({ ...entry }));
+      basePrompt.value = payload.base;
+      negativePrompt.value = payload.neg;
+      basePromptError.value = '';
+      lastSaved.value = payload;
+    } catch (err) {
+      if (import.meta.env.DEV) {
+        console.warn('Failed to load composition', err);
+      }
+    }
+  };
+
+  const generateImage = async (): Promise<boolean> => {
+    if (!validate()) {
+      return false;
+    }
+
+    isGenerating.value = true;
+
+    try {
+      const trimmedNegative = negativePrompt.value.trim();
+      const params = createGenerationParams({
+        prompt: finalPrompt.value,
+        negative_prompt: trimmedNegative ? trimmedNegative : null,
+      });
+
+      await requestGeneration({
+        ...params,
+        loras: activeLoras.value.map((entry) => ({ ...entry })),
+      });
+      return true;
+    } catch (err) {
+      if (import.meta.env.DEV) {
+        console.warn('Failed to trigger generation', err);
+      }
+      return false;
+    } finally {
+      isGenerating.value = false;
+    }
+  };
+
+  onMounted(async () => {
+    await loadLoras();
+  });
+
+  watch(
+    adapters,
+    (next: LoraListItem[] | undefined) => {
+      const items = Array.isArray(next) ? next : [];
+
+      loras.value = items.map((item) => ({
+        id: item.id,
+        name: item.name,
+        description: item.description,
+        active: item.active ?? true,
+      }));
+    },
+    { immediate: true },
+  );
+
+  watch(
+    [activeLoras, basePrompt, negativePrompt],
+    ([items, base, neg]: [CompositionEntry[], string, string]) => {
+      const payload: SavedComposition = {
+        items: items.map((entry) => ({ ...entry })),
+        base,
+        neg,
+      };
+
+      lastSaved.value = payload;
+      schedulePersist(payload);
+    },
+    { deep: true },
+  );
+
+  onBeforeUnmount(() => {
+    cancelScheduledPersist();
+  });
+
+  return {
+    searchTerm,
+    activeOnly,
+    filteredLoras,
+    isLoading,
+    error,
+    activeLoras,
+    basePrompt,
+    negativePrompt,
+    finalPrompt,
+    basePromptError,
+    isGenerating,
+    canGenerate,
+    canSave,
+    setSearchTerm,
+    setActiveOnly,
+    addToComposition,
+    removeFromComposition,
+    moveUp,
+    moveDown,
+    updateWeight,
+    balanceWeights,
+    duplicateComposition,
+    clearComposition,
+    setBasePrompt,
+    setNegativePrompt,
+    copyPrompt,
+    saveComposition,
+    loadComposition,
+    generateImage,
+    isInComposition,
+  };
+};
+

--- a/tests/vue/PromptComposer.spec.js
+++ b/tests/vue/PromptComposer.spec.js
@@ -58,7 +58,7 @@ describe('PromptComposer.vue', () => {
     const wrapper = mount(PromptComposer);
     await flush();
     // Click Generate without a base prompt
-    const generateBtn = wrapper.find('button.btn.btn-primary.w-full');
+    const generateBtn = wrapper.find('[data-testid="generate-image"]');
     await generateBtn.trigger('click');
     await flush();
     expect(wrapper.find('[data-testid="base-error"]').text()).toContain('Base prompt is required');
@@ -69,21 +69,21 @@ describe('PromptComposer.vue', () => {
     await flush();
 
     // Click first available lora
-    const firstItem = wrapper.find('[data-testid="lora-list"] > div');
+    const firstItem = wrapper.find('[data-testid="lora-list"] button');
     await firstItem.trigger('click');
     await nextTick();
 
     // Set base prompt
-    const base = wrapper.find('textarea');
+    const base = wrapper.find('[data-testid="base-prompt"]');
     await base.setValue('A scenic view');
     await nextTick();
 
     // Change weight slider
-    const slider = wrapper.find('input[type="range"]');
+    const slider = wrapper.find('[data-testid="weight-slider"]');
     await slider.setValue('1.5');
     await nextTick();
 
-    const finalPrompt = wrapper.findAll('textarea').at(2).element.value;
+    const finalPrompt = wrapper.find('[data-testid="final-prompt"]').element.value;
     expect(finalPrompt).toContain('A scenic view');
     expect(finalPrompt).toContain('<lora:LoraOne:1.5>');
   });
@@ -92,21 +92,21 @@ describe('PromptComposer.vue', () => {
     const wrapper = mount(PromptComposer);
     await flush();
 
-    await wrapper.find('[data-testid="lora-list"] > div').trigger('click');
+    await wrapper.find('[data-testid="lora-list"] button').trigger('click');
     await nextTick();
 
-    const base = wrapper.find('textarea');
+    const base = wrapper.find('[data-testid="base-prompt"]');
     await base.setValue('A base prompt');
     await nextTick();
 
-    let finalPrompt = wrapper.findAll('textarea').at(2).element.value;
+    let finalPrompt = wrapper.find('[data-testid="final-prompt"]').element.value;
     expect(finalPrompt).toContain('<lora:LoraOne:1.0>');
 
-    const slider = wrapper.find('input[type="range"]');
+    const slider = wrapper.find('[data-testid="weight-slider"]');
     await slider.setValue('0');
     await nextTick();
 
-    finalPrompt = wrapper.findAll('textarea').at(2).element.value;
+    finalPrompt = wrapper.find('[data-testid="final-prompt"]').element.value;
     expect(finalPrompt).toContain('<lora:LoraOne:0.0>');
   });
 
@@ -114,15 +114,15 @@ describe('PromptComposer.vue', () => {
     const wrapper = mount(PromptComposer);
     await flush();
 
-    const base = wrapper.find('textarea');
+    const base = wrapper.find('[data-testid="base-prompt"]');
     await base.setValue('Base prompt');
     await nextTick();
 
-    const negative = wrapper.findAll('textarea').at(1);
+    const negative = wrapper.find('[data-testid="negative-prompt"]');
     await negative.setValue('blurry, low quality');
     await nextTick();
 
-    const finalPrompt = wrapper.findAll('textarea').at(2).element.value;
+    const finalPrompt = wrapper.find('[data-testid="final-prompt"]').element.value;
     expect(finalPrompt).toBe('Base prompt');
   });
 
@@ -130,13 +130,13 @@ describe('PromptComposer.vue', () => {
     const wrapper = mount(PromptComposer);
     await flush();
 
-    const firstItem = wrapper.find('[data-testid="lora-list"] > div');
+    const firstItem = wrapper.find('[data-testid="lora-list"] button');
     await firstItem.trigger('click');
     await nextTick();
-    // Validate reactive state restored
-    expect(wrapper.vm.activeLoras?.length || 0).toBeGreaterThan(0);
 
-    const removeBtn = wrapper.find('button.btn.btn-secondary.btn-xs:last-of-type');
+    expect(wrapper.find('[data-testid="composition"]').text()).not.toContain('No LoRAs in composition');
+
+    const removeBtn = wrapper.find('[data-testid="remove-entry"]');
     await removeBtn.trigger('click');
     await nextTick();
     expect(wrapper.find('[data-testid="composition"]').text()).toContain('No LoRAs in composition');
@@ -159,16 +159,16 @@ describe('PromptComposer.vue', () => {
     await flush();
 
     // Add lora and base prompt
-    await wrapper.find('[data-testid="lora-list"] > div').trigger('click');
-    await wrapper.find('textarea').setValue('Base');
+    await wrapper.find('[data-testid="lora-list"] button').trigger('click');
+    await wrapper.find('[data-testid="base-prompt"]').setValue('Base');
     await nextTick();
 
     // Save
-    const saveBtn = wrapper.findAll('button.btn.btn-secondary.w-full').at(1);
+    const saveBtn = wrapper.find('[data-testid="save-composition"]');
     await saveBtn.trigger('click');
 
     // Clear composition by removing item
-    await wrapper.find('button.btn.btn-secondary.btn-xs:last-of-type').trigger('click');
+    await wrapper.find('[data-testid="remove-entry"]').trigger('click');
     await nextTick();
     expect(wrapper.find('[data-testid="composition"]').text()).toContain('No LoRAs');
 
@@ -179,19 +179,20 @@ describe('PromptComposer.vue', () => {
       neg: ''
     }));
 
-    // Load (call component method directly to avoid selector ambiguity)
-    await wrapper.vm.loadComposition();
+    const loadBtn = wrapper.findAll('button').find((btn) => btn.text() === 'Load Composition');
+    expect(loadBtn).toBeDefined();
+    await loadBtn.trigger('click');
     await flush();
-    expect(wrapper.vm.activeLoras?.length || 0).toBeGreaterThan(0);
+    expect(wrapper.find('[data-testid="composition"]').text()).not.toContain('No LoRAs');
   });
 
   it('generates when base prompt is valid', async () => {
     const wrapper = mount(PromptComposer);
     await flush();
 
-    await wrapper.find('textarea').setValue('Hello');
+    await wrapper.find('[data-testid="base-prompt"]').setValue('Hello');
     await nextTick();
-    const generateBtn = wrapper.find('button.btn.btn-primary.w-full');
+    const generateBtn = wrapper.find('[data-testid="generate-image"]');
     await generateBtn.trigger('click');
     await flush();
     // Called at least once for /generate

--- a/tests/vue/PromptComposerActions.spec.ts
+++ b/tests/vue/PromptComposerActions.spec.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import { mount } from '@vue/test-utils';
+
+import PromptComposerActions from '../../app/frontend/src/components/PromptComposerActions.vue';
+
+describe('PromptComposerActions', () => {
+  const factory = (overrides = {}) =>
+    mount(PromptComposerActions, {
+      props: {
+        basePrompt: '',
+        negativePrompt: '',
+        finalPrompt: 'Full prompt',
+        basePromptError: '',
+        isGenerating: false,
+        canSave: true,
+        canGenerate: true,
+        ...overrides,
+      },
+    });
+
+  it('emits updates for prompts', async () => {
+    const wrapper = factory();
+    await wrapper.find('[data-testid="base-prompt"]').setValue('New base');
+    await wrapper.find('[data-testid="negative-prompt"]').setValue('bad');
+
+    expect(wrapper.emitted('update:basePrompt')?.[0]).toEqual(['New base']);
+    expect(wrapper.emitted('update:negativePrompt')?.[0]).toEqual(['bad']);
+  });
+
+  it('emits actions when buttons clicked', async () => {
+    const wrapper = factory();
+
+    await wrapper.find('[data-testid="copy-prompt"]').trigger('click');
+    await wrapper.find('[data-testid="save-composition"]').trigger('click');
+    await wrapper.find('[data-testid="generate-image"]').trigger('click');
+
+    expect(wrapper.emitted('copy')).toBeTruthy();
+    expect(wrapper.emitted('save')).toBeTruthy();
+    expect(wrapper.emitted('generate')).toBeTruthy();
+  });
+
+  it('disables buttons according to state', () => {
+    const wrapper = factory({ canSave: false, canGenerate: false, isGenerating: true });
+    expect(wrapper.find('[data-testid="save-composition"]').attributes('disabled')).toBeDefined();
+    expect(wrapper.find('[data-testid="generate-image"]').attributes('disabled')).toBeDefined();
+    expect(wrapper.text()).toContain('Generating…');
+  });
+});
+

--- a/tests/vue/PromptComposerAvailableList.spec.ts
+++ b/tests/vue/PromptComposerAvailableList.spec.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it, vi } from 'vitest';
+import { mount } from '@vue/test-utils';
+
+import PromptComposerAvailableList from '../../app/frontend/src/components/PromptComposerAvailableList.vue';
+
+describe('PromptComposerAvailableList', () => {
+  const baseProps = {
+    loras: [
+      { id: '1', name: 'Alpha', description: 'First', active: true },
+      { id: '2', name: 'Beta', description: 'Second', active: false },
+    ],
+    searchTerm: '',
+    activeOnly: false,
+    isLoading: false,
+    error: null,
+    isInComposition: vi.fn(() => false),
+  };
+
+  it('emits search and toggle events', async () => {
+    const wrapper = mount(PromptComposerAvailableList, { props: baseProps });
+
+    const search = wrapper.find('input[placeholder="Search LoRAs..."]');
+    await search.setValue('beta');
+    expect(wrapper.emitted('update:searchTerm')?.[0]).toEqual(['beta']);
+
+    const toggle = wrapper.find('input[type="checkbox"]');
+    await toggle.setValue(true);
+    expect(wrapper.emitted('update:activeOnly')?.[0]).toEqual([true]);
+  });
+
+  it('emits select when a lora is clicked', async () => {
+    const wrapper = mount(PromptComposerAvailableList, { props: baseProps });
+
+    const first = wrapper.find('[data-testid="lora-list"] button');
+    await first.trigger('click');
+
+    expect(wrapper.emitted('select')?.[0]?.[0]).toMatchObject({ id: '1', name: 'Alpha' });
+  });
+
+  it('shows loading and error states', () => {
+    const wrapper = mount(PromptComposerAvailableList, {
+      props: {
+        ...baseProps,
+        loras: [],
+        isLoading: true,
+        error: 'boom',
+      },
+    });
+
+    expect(wrapper.text()).toContain('Loading…');
+    expect(wrapper.text()).toContain('Failed to load LoRAs');
+  });
+
+  it('marks entries already in composition', () => {
+    const wrapper = mount(PromptComposerAvailableList, {
+      props: {
+        ...baseProps,
+        isInComposition: vi.fn((id: string) => id === '1'),
+      },
+    });
+
+    const first = wrapper.find('[data-testid="lora-list"] button');
+    expect(first.classes()).toContain('opacity-50');
+  });
+});
+

--- a/tests/vue/PromptComposerComposition.spec.ts
+++ b/tests/vue/PromptComposerComposition.spec.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import { mount } from '@vue/test-utils';
+
+import PromptComposerComposition from '../../app/frontend/src/components/PromptComposerComposition.vue';
+
+describe('PromptComposerComposition', () => {
+  const items = [
+    { id: '1', name: 'Alpha', weight: 1 },
+    { id: '2', name: 'Beta', weight: 0.5 },
+  ];
+
+  it('emits events for entry controls', async () => {
+    const wrapper = mount(PromptComposerComposition, { props: { items } });
+
+    const weight = wrapper.find('[data-testid="weight-slider"]');
+    await weight.setValue('1.25');
+    expect(wrapper.emitted('update-weight')?.[0]).toEqual([{ index: 0, weight: 1.25 }]);
+
+    const moveDown = wrapper.find('[data-testid="move-down"]');
+    await moveDown.trigger('click');
+    expect(wrapper.emitted('move-down')?.[0]).toEqual([0]);
+
+    const remove = wrapper.find('[data-testid="remove-entry"]');
+    await remove.trigger('click');
+    expect(wrapper.emitted('remove')?.[0]).toEqual([0]);
+  });
+
+  it('emits quick action events', async () => {
+    const wrapper = mount(PromptComposerComposition, { props: { items } });
+
+    const actions = wrapper.findAll('button.btn.btn-secondary.btn-sm');
+    await actions[0].trigger('click');
+    await actions[1].trigger('click');
+
+    expect(wrapper.emitted('balance')).toBeTruthy();
+    expect(wrapper.emitted('duplicate')).toBeTruthy();
+  });
+
+  it('shows placeholder when no items exist', () => {
+    const wrapper = mount(PromptComposerComposition, { props: { items: [] } });
+    expect(wrapper.text()).toContain('No LoRAs in composition');
+  });
+});
+

--- a/tests/vue/usePromptComposition.spec.ts
+++ b/tests/vue/usePromptComposition.spec.ts
@@ -1,0 +1,136 @@
+import { describe, expect, beforeEach, it, vi } from 'vitest';
+import { computed, nextTick, ref } from 'vue';
+import { mount } from '@vue/test-utils';
+
+const adaptersRef = ref([] as any[]);
+const errorRef = ref<unknown>(null);
+const loadingRef = ref(false);
+const fetchData = vi.fn(async () => {
+  adaptersRef.value = [
+    { id: 'alpha', name: 'Alpha', description: 'First adapter', active: true },
+    { id: 'beta', name: 'Beta', description: 'Second adapter', active: false },
+  ];
+  return adaptersRef.value;
+});
+
+const generationServiceMock = vi.hoisted(() => ({
+  createGenerationParams: vi.fn((payload: any) => payload),
+  requestGeneration: vi.fn(async () => {}),
+}));
+
+const browserMock = vi.hoisted(() => ({
+  copyToClipboard: vi.fn(async () => true),
+}));
+
+vi.mock('../../app/frontend/src/services/loraService', () => ({
+  useAdapterListApi: vi.fn(() => ({
+    adapters: computed(() => adaptersRef.value),
+    error: errorRef,
+    isLoading: loadingRef,
+    fetchData,
+  })),
+}));
+
+vi.mock('../../app/frontend/src/services/generationService', () => generationServiceMock);
+
+vi.mock('../../app/frontend/src/utils/browser', () => browserMock);
+
+const { createGenerationParams, requestGeneration } = generationServiceMock;
+const { copyToClipboard } = browserMock;
+
+import { usePromptComposition } from '../../app/frontend/src/composables/usePromptComposition';
+
+const flush = async () => {
+  await Promise.resolve();
+  await nextTick();
+  await Promise.resolve();
+  await nextTick();
+};
+
+const withSetup = () => {
+  let result: ReturnType<typeof usePromptComposition>;
+  mount({
+    template: '<div />',
+    setup() {
+      result = usePromptComposition();
+      return result;
+    },
+  });
+  return result!;
+};
+
+describe('usePromptComposition', () => {
+  beforeEach(() => {
+    adaptersRef.value = [];
+    errorRef.value = null;
+    loadingRef.value = false;
+    fetchData.mockClear();
+    createGenerationParams.mockClear();
+    requestGeneration.mockClear();
+    copyToClipboard.mockClear();
+    localStorage.clear();
+  });
+
+  it('loads adapters and filters them', async () => {
+    const state = withSetup();
+    await flush();
+
+    expect(fetchData).toHaveBeenCalled();
+    expect(state.filteredLoras.value).toHaveLength(2);
+
+    state.setSearchTerm('beta');
+    await nextTick();
+    expect(state.filteredLoras.value).toHaveLength(1);
+    expect(state.filteredLoras.value[0].name).toBe('Beta');
+
+    state.setActiveOnly(true);
+    await nextTick();
+    expect(state.filteredLoras.value).toHaveLength(0);
+  });
+
+  it('builds final prompt, copies and generates', async () => {
+    const state = withSetup();
+    await flush();
+
+    const first = state.filteredLoras.value[0];
+    state.addToComposition(first);
+    state.setBasePrompt('Shining stars');
+    state.setNegativePrompt('blurry');
+    await nextTick();
+
+    expect(state.finalPrompt.value).toContain('Shining stars');
+    expect(state.finalPrompt.value).toContain('<lora:Alpha:1.0>');
+
+    await state.copyPrompt();
+    expect(copyToClipboard).toHaveBeenCalledWith(state.finalPrompt.value);
+
+    await state.generateImage();
+    expect(createGenerationParams).toHaveBeenCalledWith({
+      prompt: state.finalPrompt.value,
+      negative_prompt: 'blurry',
+    });
+    expect(requestGeneration).toHaveBeenCalledWith(
+      expect.objectContaining({
+        loras: [expect.objectContaining({ id: 'alpha', weight: 1 })],
+      }),
+    );
+  });
+
+  it('persists and reloads compositions', async () => {
+    const state = withSetup();
+    await flush();
+
+    const first = state.filteredLoras.value[0];
+    state.addToComposition(first);
+    state.setBasePrompt('Persist base');
+    state.saveComposition();
+
+    state.clearComposition();
+    expect(state.activeLoras.value).toHaveLength(0);
+
+    state.loadComposition();
+    expect(state.activeLoras.value).toHaveLength(1);
+    expect(state.basePrompt.value).toBe('Persist base');
+  });
+});
+


### PR DESCRIPTION
## Summary
- replace the monolithic prompt composer with presentational child components wired together in PromptComposer.vue
- introduce a usePromptComposition composable that manages adapter loading, persistence, and generation API calls
- add focused unit tests for the new components and composable while updating the PromptComposer integration spec

## Testing
- npm run test:unit *(fails: existing GenerationStudio suite assertions unrelated to prompt composer)*
- npx vitest run tests/vue/PromptComposer.spec.js tests/vue/usePromptComposition.spec.ts tests/vue/PromptComposerAvailableList.spec.ts tests/vue/PromptComposerComposition.spec.ts tests/vue/PromptComposerActions.spec.ts


------
https://chatgpt.com/codex/tasks/task_e_68d14cbf24a48329a07a63d1e2f8ffa0