### PR TITLE
Refactor generation router to use coordinator service

### DIFF
--- a/backend/services/__init__.py
+++ b/backend/services/__init__.py
@@ -12,7 +12,7 @@ from .analytics import AnalyticsService
 from .archive import ArchiveExportPlanner, ArchiveImportExecutor, ArchiveService
 from .composition import ComposeService
 from .deliveries import DeliveryService
-from .generation import GenerationService
+from .generation import GenerationCoordinator, GenerationService
 from .queue import QueueBackend, get_queue_backends
 from .storage import StorageService
 from .system import SystemService
@@ -50,6 +50,7 @@ class ServiceContainer:
         self._delivery_service: Optional[DeliveryService] = None
         self._compose_service: Optional[ComposeService] = None
         self._generation_service: Optional[GenerationService] = None
+        self._generation_coordinator: Optional[GenerationCoordinator] = None
         self._websocket_service: Optional[WebSocketService] = None
         self._system_service: Optional[SystemService] = None
         self._archive_service: Optional[ArchiveService] = None
@@ -128,7 +129,19 @@ class ServiceContainer:
         if self._generation_service is None:
             self._generation_service = GenerationService()
         return self._generation_service
-    
+
+    @property
+    def generation_coordinator(self) -> GenerationCoordinator:
+        """Get generation coordinator helper."""
+
+        if self._generation_coordinator is None:
+            self._generation_coordinator = GenerationCoordinator(
+                self.deliveries,
+                self.websocket,
+                self.generation,
+            )
+        return self._generation_coordinator
+
     @property
     def websocket(self) -> WebSocketService:
         """Get WebSocket service instance."""


### PR DESCRIPTION
## Summary
- add a `GenerationCoordinator` helper that owns delivery scheduling, job serialization, and websocket fan-out duties
- expose the coordinator through the service container and update the generation router to reuse the shared logic
- extend generation job tests to cover the coordinator scheduling, broadcast, and serialization behaviors

## Testing
- pytest tests/test_generation_jobs.py

------
https://chatgpt.com/codex/tasks/task_e_68d15857ce248329be0d61b7eadf65be