### PR TITLE
Use service container for recommendation services

### DIFF
--- a/backend/core/dependencies.py
+++ b/backend/core/dependencies.py
@@ -40,17 +40,11 @@ def get_compose_service() -> ComposeService:
     return container.compose
 
 
-def _is_gpu_available() -> bool:
-    """Proxy GPU availability check to the recommendation service helper."""
-    return RecommendationService.is_gpu_available()
-
-
 def get_recommendation_service(
-    db_session: Session = Depends(get_session),  # noqa: B008 - FastAPI DI
+    container: ServiceContainer = Depends(get_service_container),  # noqa: B008 - FastAPI DI
 ) -> RecommendationService:
     """Return a RecommendationService instance."""
-    gpu_enabled = _is_gpu_available()
-    return RecommendationService(db_session=db_session, gpu_enabled=gpu_enabled)
+    return container.recommendations
 
 
 def get_archive_service(


### PR DESCRIPTION
## Summary
- add a cached recommendations property to ServiceContainer that reuses a single GPU availability probe
- update dependency injection helpers and worker tasks to resolve RecommendationService instances through ServiceContainer
- adjust recommendation tests to build services via the container with deterministic GPU detection

## Testing
- pytest tests/test_recommendations.py

------
https://chatgpt.com/codex/tasks/task_e_68d15c3b7d908329a6d6c825e2e5ee3c