### PR TITLE
Refactor worker context and async recommendation tasks

### DIFF
--- a/backend/services/__init__.py
+++ b/backend/services/__init__.py
@@ -38,6 +38,7 @@ class ServiceContainer:
         *,
         queue_backend: Optional[QueueBackend] = None,
         fallback_queue_backend: Optional[QueueBackend] = None,
+        recommendation_gpu_available: Optional[bool] = None,
     ):
         """Initialize service container.
 
@@ -57,7 +58,7 @@ class ServiceContainer:
         self._archive_service: Optional[ArchiveService] = None
         self._analytics_service: Optional[AnalyticsService] = None
         self._recommendation_service: Optional[RecommendationService] = None
-        self._recommendation_gpu_available: Optional[bool] = None
+        self._recommendation_gpu_available: Optional[bool] = recommendation_gpu_available
         self._queue_backend = queue_backend
         self._fallback_queue_backend = fallback_queue_backend
     

--- a/backend/workers/context.py
+++ b/backend/workers/context.py
@@ -1,0 +1,114 @@
+"""Shared context and helpers for worker processes and tasks."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from typing import Any, Callable, Coroutine, Optional, TypeVar
+
+from sqlmodel import Session
+
+from backend.delivery.base import delivery_registry
+from backend.services import ServiceContainer
+from backend.services.queue import QueueBackend, RedisQueueBackend, get_queue_backends
+from backend.services.recommendations import RecommendationService
+from backend.workers.delivery_runner import DeliveryRunner
+
+T = TypeVar("T")
+AsyncRunner = Callable[[Coroutine[Any, Any, T]], T]
+
+
+def _default_async_runner(coro: Coroutine[Any, Any, T]) -> T:
+    """Execute a coroutine to completion using ``asyncio.run``."""
+
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return asyncio.run(coro)
+    raise RuntimeError(
+        "An event loop is already running; provide a custom async_runner to the "
+        "WorkerContext to schedule background work.",
+    )
+
+
+@dataclass
+class WorkerContext:
+    """Aggregate shared worker dependencies in a single object."""
+
+    queue_backend: QueueBackend
+    fallback_queue_backend: QueueBackend
+    primary_queue_backend: Optional[RedisQueueBackend]
+    delivery_runner: DeliveryRunner
+    recommendation_gpu_available: bool
+    _async_runner: AsyncRunner
+
+    def __init__(
+        self,
+        *,
+        queue_backend: QueueBackend,
+        fallback_queue_backend: QueueBackend,
+        primary_queue_backend: Optional[RedisQueueBackend] = None,
+        delivery_runner: Optional[DeliveryRunner] = None,
+        recommendation_gpu_available: Optional[bool] = None,
+        async_runner: Optional[AsyncRunner] = None,
+    ) -> None:
+        self.queue_backend = queue_backend
+        self.fallback_queue_backend = fallback_queue_backend
+        self.primary_queue_backend = primary_queue_backend
+        self.delivery_runner = delivery_runner or DeliveryRunner(delivery_registry)
+        self.recommendation_gpu_available = (
+            recommendation_gpu_available
+            if recommendation_gpu_available is not None
+            else RecommendationService.is_gpu_available()
+        )
+        self._async_runner = async_runner or _default_async_runner
+
+    @classmethod
+    def build_default(
+        cls,
+        *,
+        async_runner: Optional[AsyncRunner] = None,
+        recommendation_gpu_available: Optional[bool] = None,
+    ) -> "WorkerContext":
+        """Create a context using the shared queue backend factory."""
+
+        primary, fallback = get_queue_backends()
+
+        queue_backend = primary or fallback
+        if queue_backend is None:  # pragma: no cover - defensive guard
+            raise RuntimeError("No queue backend is available for worker context")
+
+        return cls(
+            queue_backend=queue_backend,
+            fallback_queue_backend=fallback,
+            primary_queue_backend=primary if isinstance(primary, RedisQueueBackend) else None,
+            recommendation_gpu_available=recommendation_gpu_available,
+            async_runner=async_runner,
+        )
+
+    def run_async(self, coro: Coroutine[Any, Any, T]) -> T:
+        """Execute ``coro`` using the configured asynchronous runner."""
+
+        return self._async_runner(coro)
+
+    @property
+    def rq_queue(self):
+        """Return the underlying RQ queue when Redis is configured."""
+
+        if isinstance(self.queue_backend, RedisQueueBackend):
+            try:
+                return self.queue_backend.queue
+            except Exception:  # pragma: no cover - defensive fallback
+                return None
+        return None
+
+    def create_service_container(self, db_session: Optional[Session]) -> ServiceContainer:
+        """Instantiate a service container sharing this context's dependencies."""
+
+        return ServiceContainer(
+            db_session,
+            queue_backend=self.queue_backend,
+            fallback_queue_backend=self.fallback_queue_backend,
+            recommendation_gpu_available=self.recommendation_gpu_available,
+        )
+

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -11,9 +11,13 @@ from rq import Queue, SimpleWorker  # noqa: E402
 from backend.core.config import settings  # noqa: E402
 from backend.core.database import get_session_context, init_db  # noqa: E402
 from backend.models.deliveries import DeliveryJob  # noqa: E402
-from backend.services.queue import reset_queue_backends  # noqa: E402
+from backend.services.queue import RedisQueueBackend, reset_queue_backends  # noqa: E402
 from backend.workers import tasks as worker_tasks  # noqa: E402
-from backend.workers.tasks import enqueue_delivery  # noqa: E402
+from backend.workers.tasks import (  # noqa: E402
+    enqueue_delivery,
+    reset_worker_context,
+    set_worker_context,
+)
 
 
 def test_worker_process_cycle(tmp_path, monkeypatch):
@@ -24,12 +28,14 @@ def test_worker_process_cycle(tmp_path, monkeypatch):
     reset_queue_backends()
     try:
         settings.REDIS_URL = "redis://localhost:6379/0"
-        worker_tasks.initialize_queue_backends()
+        reset_worker_context()
+        context = worker_tasks.build_worker_context()
+        assert isinstance(context.queue_backend, RedisQueueBackend)
 
         # patch the queue in tasks to use a fake connection
         fake_q = Queue("default", connection=fake_redis)
-        monkeypatch.setattr(worker_tasks, "q", fake_q)
-        monkeypatch.setattr(worker_tasks.queue_backend, "_queue", fake_q, raising=False)
+        monkeypatch.setattr(context.queue_backend, "_queue", fake_q, raising=False)
+        set_worker_context(context)
 
         # Ensure DB initialized in a temp directory to avoid collisions. The DB
         # is created in the module path, so ensure init_db runs (it will create
@@ -37,7 +43,13 @@ def test_worker_process_cycle(tmp_path, monkeypatch):
         init_db()
 
         # enqueue a simple CLI delivery
-        did = enqueue_delivery("hello", "cli", {"template": "t"}, max_retries=1)
+        did = enqueue_delivery(
+            "hello",
+            "cli",
+            {"template": "t"},
+            max_retries=1,
+            context=context,
+        )
         assert did is not None
 
         # Run a SimpleWorker to process queued jobs synchronously
@@ -53,8 +65,8 @@ def test_worker_process_cycle(tmp_path, monkeypatch):
             assert dj.status in ("succeeded", "failed", "retrying")
     finally:
         settings.REDIS_URL = original_url
+        reset_worker_context()
         reset_queue_backends()
-        worker_tasks.initialize_queue_backends()
 
 
 # duplicate test removed; the single test above exercises the worker cycle


### PR DESCRIPTION
## Summary
- add a WorkerContext helper that encapsulates queue selection, GPU detection, and service container wiring
- update worker task entry points to use the shared context and expose async-friendly embedding helpers
- refresh worker-related tests to construct the context explicitly and validate queue sharing

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d19245f6d08329ae64d11befa2dff1