### PR TITLE
Decouple SDNext backend HTTP and storage concerns

### DIFF
--- a/backend/delivery/http_client.py
+++ b/backend/delivery/http_client.py
@@ -1,0 +1,93 @@
+"""HTTP client helpers for delivery backends."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Optional
+
+import aiohttp
+
+
+class DeliveryHTTPClient:
+    """Helper for managing HTTP sessions to external delivery services."""
+
+    def __init__(
+        self,
+        base_url: Optional[str],
+        *,
+        timeout: int,
+        username: Optional[str] = None,
+        password: Optional[str] = None,
+        health_check_path: str = "/sdapi/v1/options",
+    ) -> None:
+        """Initialize the HTTP client helper."""
+        self._base_url = base_url.rstrip("/") if base_url else None
+        self._timeout = timeout
+        self._health_check_path = health_check_path
+        self._auth = None
+        if username and password:
+            self._auth = aiohttp.BasicAuth(username, password)
+        self._session: Optional[aiohttp.ClientSession] = None
+
+    @property
+    def timeout(self) -> int:
+        """Return the configured timeout."""
+        return self._timeout
+
+    def is_configured(self) -> bool:
+        """Return whether the client has a base URL configured."""
+        return self._base_url is not None
+
+    async def _get_session(self) -> aiohttp.ClientSession:
+        """Get or create the underlying :class:`aiohttp.ClientSession`."""
+        if self._session is None or self._session.closed:
+            timeout = aiohttp.ClientTimeout(total=self._timeout)
+            self._session = aiohttp.ClientSession(timeout=timeout, auth=self._auth)
+        return self._session
+
+    def _build_url(self, path: str) -> str:
+        if path.startswith("http://") or path.startswith("https://"):
+            return path
+        if not self._base_url:
+            raise RuntimeError("HTTP client base URL is not configured")
+        if not path.startswith("/"):
+            path = "/" + path
+        return f"{self._base_url}{path}"
+
+    async def request(
+        self,
+        method: str,
+        path: str,
+        **kwargs: Any,
+    ) -> aiohttp.client._RequestContextManager:
+        """Create a request context manager for the configured session."""
+        session = await self._get_session()
+        url = self._build_url(path)
+        return session.request(method, url, **kwargs)
+
+    async def health_check(self, path: Optional[str] = None) -> bool:
+        """Perform a simple GET request to confirm the service is responsive."""
+        if not self.is_configured():
+            return False
+
+        check_path = path or self._health_check_path
+
+        try:
+            request_ctx = await self.request("GET", check_path)
+            async with request_ctx as response:
+                return response.status == 200
+        except (asyncio.TimeoutError, aiohttp.ClientError, RuntimeError):
+            return False
+
+    async def close(self) -> None:
+        """Close the underlying HTTP session."""
+        if self._session and not self._session.closed:
+            await self._session.close()
+            self._session = None
+
+    async def __aenter__(self) -> "DeliveryHTTPClient":
+        await self._get_session()
+        return self
+
+    async def __aexit__(self, *exc_info: Any) -> None:
+        await self.close()

--- a/backend/delivery/sdnext.py
+++ b/backend/delivery/sdnext.py
@@ -1,103 +1,70 @@
 """SDNext generation delivery implementation."""
 
 import asyncio
-import base64
-from datetime import datetime, timezone
-from pathlib import Path
 from typing import Any, Dict, List, Optional
 from uuid import uuid4
-
-import aiohttp
 
 from backend.core.config import settings
 from backend.schemas import SDNextGenerationResult
 
 from .base import GenerationBackend
+from .http_client import DeliveryHTTPClient
+from .storage import FileSystemImageStorage, ImageStorage
 
 
 class SDNextGenerationBackend(GenerationBackend):
     """SDNext generation backend implementation."""
-    
-    def __init__(self):
+
+    def __init__(
+        self,
+        http_client: Optional[DeliveryHTTPClient] = None,
+        storage: Optional[ImageStorage] = None,
+    ) -> None:
         """Initialize SDNext backend."""
-        self.base_url = settings.SDNEXT_BASE_URL
-        self.username = settings.SDNEXT_USERNAME
-        self.password = settings.SDNEXT_PASSWORD
         self.timeout = settings.SDNEXT_TIMEOUT
         self.poll_interval = settings.SDNEXT_POLL_INTERVAL
-        self.output_dir = settings.SDNEXT_OUTPUT_DIR
-        
-        # Session for persistent connections
-        self._session: Optional[aiohttp.ClientSession] = None
-    
-    async def _get_session(self) -> aiohttp.ClientSession:
-        """Get or create HTTP session."""
-        if self._session is None or self._session.closed:
-            timeout = aiohttp.ClientTimeout(total=self.timeout)
-            auth = None
-            if self.username and self.password:
-                auth = aiohttp.BasicAuth(self.username, self.password)
-            
-            self._session = aiohttp.ClientSession(
-                timeout=timeout,
-                auth=auth,
-            )
-        return self._session
-    
+
+        self._http_client = http_client or DeliveryHTTPClient(
+            settings.SDNEXT_BASE_URL,
+            timeout=settings.SDNEXT_TIMEOUT,
+            username=settings.SDNEXT_USERNAME,
+            password=settings.SDNEXT_PASSWORD,
+        )
+        self._storage = storage or FileSystemImageStorage(settings.SDNEXT_OUTPUT_DIR)
+
     async def close(self) -> None:
         """Close HTTP session."""
-        if self._session and not self._session.closed:
-            await self._session.close()
-    
+        await self._http_client.close()
+
     def is_available(self) -> bool:
         """Check if SDNext backend is configured and available."""
-        return self.base_url is not None
-    
-    async def _health_check(self) -> bool:
-        """Check if SDNext API is responsive."""
-        if not self.is_available():
-            return False
-        
-        try:
-            session = await self._get_session()
-            url = f"{self.base_url}/sdapi/v1/options"
-            async with session.get(url) as response:
-                return response.status == 200
-        except Exception:
-            return False
-    
-    async def generate_image(self, prompt: str, params: Dict[str, Any]) -> SDNextGenerationResult:
-        """Generate image using SDNext API.
-        
-        Args:
-            prompt: The composed prompt
-            params: Generation parameters
-            
-        Returns:
-            SDNextGenerationResult with job status
+        return self._http_client.is_configured()
 
-        """
+    async def generate_image(self, prompt: str, params: Dict[str, Any]) -> SDNextGenerationResult:
+        """Generate image using SDNext API."""
+        job_id = str(uuid4())
+
         if not self.is_available():
             return SDNextGenerationResult(
-                job_id=str(uuid4()),
+                job_id=job_id,
                 status="failed",
                 error_message="SDNext backend not configured",
             )
-        
+
         # Check if API is available
-        if not await self._health_check():
+        if not await self._http_client.health_check():
             return SDNextGenerationResult(
-                job_id=str(uuid4()),
+                job_id=job_id,
                 status="failed",
                 error_message="SDNext API not available",
             )
-        
+
         # Extract generation parameters
         gen_params = params.get("generation_params", {})
         params.get("mode", "immediate")
         save_images = params.get("save_images", True)
         return_format = params.get("return_format", "base64")
-        
+
         # Prepare SDNext API payload
         payload = {
             "prompt": prompt,
@@ -111,17 +78,18 @@ class SDNextGenerationBackend(GenerationBackend):
             "batch_size": gen_params.get("batch_size", 1),
             "n_iter": gen_params.get("n_iter", 1),
         }
-        
+
         if gen_params.get("denoising_strength") is not None:
             payload["denoising_strength"] = gen_params["denoising_strength"]
-        
-        job_id = str(uuid4())
-        
+
         try:
-            session = await self._get_session()
-            url = f"{self.base_url}/sdapi/v1/txt2img"
-            
-            async with session.post(url, json=payload) as response:
+            request_ctx = await self._http_client.request(
+                "POST",
+                "/sdapi/v1/txt2img",
+                json=payload,
+            )
+
+            async with request_ctx as response:
                 if response.status != 200:
                     error_text = await response.text()
                     return SDNextGenerationResult(
@@ -129,19 +97,19 @@ class SDNextGenerationBackend(GenerationBackend):
                         status="failed",
                         error_message=f"SDNext API error: {response.status} - {error_text}",
                     )
-                
+
                 result = await response.json()
-                
+
                 # Process images
-                images = []
+                images: List[str] = []
                 if "images" in result and result["images"]:
                     images = await self._process_images(
-                        result["images"], 
-                        job_id, 
-                        save_images, 
+                        result["images"],
+                        job_id,
+                        save_images,
                         return_format,
                     )
-                
+
                 return SDNextGenerationResult(
                     job_id=job_id,
                     status="completed",
@@ -149,151 +117,93 @@ class SDNextGenerationBackend(GenerationBackend):
                     progress=1.0,
                     generation_info=result.get("info", {}),
                 )
-                
+
         except asyncio.TimeoutError:
             return SDNextGenerationResult(
                 job_id=job_id,
                 status="failed",
                 error_message=f"Generation timeout after {self.timeout}s",
             )
-        except Exception as exc:
+        except Exception as exc:  # pragma: no cover - defensive
             return SDNextGenerationResult(
                 job_id=job_id,
                 status="failed",
                 error_message=str(exc),
             )
-    
-    async def check_progress(self, job_id: str) -> SDNextGenerationResult:
-        """Check generation progress.
-        
-        Note: SDNext typically completes immediately, so this is mostly
-        for compatibility with the interface.
-        
-        Args:
-            job_id: Generation job ID
-            
-        Returns:
-            SDNextGenerationResult with current status
 
-        """
+    async def check_progress(self, job_id: str) -> SDNextGenerationResult:
+        """Check generation progress."""
         if not self.is_available():
             return SDNextGenerationResult(
                 job_id=job_id,
                 status="failed",
                 error_message="SDNext backend not configured",
             )
-        
+
         try:
-            session = await self._get_session()
-            url = f"{self.base_url}/sdapi/v1/progress"
-            
-            async with session.get(url) as response:
+            request_ctx = await self._http_client.request("GET", "/sdapi/v1/progress")
+
+            async with request_ctx as response:
                 if response.status != 200:
                     return SDNextGenerationResult(
                         job_id=job_id,
                         status="unknown",
                         error_message="Could not check progress",
                     )
-                
+
                 progress_data = await response.json()
                 progress = progress_data.get("progress", 0.0)
-                
+
                 status = "running" if progress < 1.0 else "completed"
                 if progress == 0.0:
                     status = "pending"
-                
+
                 return SDNextGenerationResult(
                     job_id=job_id,
                     status=status,
                     progress=progress,
                 )
-                
+
         except Exception as exc:
             return SDNextGenerationResult(
                 job_id=job_id,
                 status="failed",
                 error_message=str(exc),
             )
-    
+
     async def _process_images(
-        self, 
-        images: List[str], 
-        job_id: str, 
-        save_images: bool, 
+        self,
+        images: List[str],
+        job_id: str,
+        save_images: bool,
         return_format: str,
     ) -> List[str]:
-        """Process generated images according to format and save options.
-        
-        Args:
-            images: List of base64 encoded images
-            job_id: Generation job ID
-            save_images: Whether to save images to disk
-            return_format: "base64", "file_path", or "url"
-            
-        Returns:
-            List of processed image references
+        """Process generated images according to format and save options."""
+        processed: List[str] = []
 
-        """
-        processed = []
-        
         for i, img_b64 in enumerate(images):
             try:
                 if return_format == "base64":
                     processed.append(img_b64)
                 elif return_format == "file_path" or save_images:
-                    # Save to disk
-                    file_path = await self._save_image(img_b64, job_id, i)
+                    file_path = await self._storage.save_image(img_b64, job_id, i)
                     if return_format == "file_path":
                         processed.append(file_path)
                     else:
-                        processed.append(img_b64)  # Still return base64 if requested
+                        processed.append(img_b64)
                 elif return_format == "url":
-                    # For URL format, we'd need a web server serving the files
-                    # For now, save and return file path
-                    file_path = await self._save_image(img_b64, job_id, i)
+                    file_path = await self._storage.save_image(img_b64, job_id, i)
                     processed.append(f"file://{file_path}")
                 else:
-                    processed.append(img_b64)  # Default to base64
-                    
+                    processed.append(img_b64)
+
             except Exception as exc:
                 # Log error but continue with other images
                 print(f"Error processing image {i}: {exc}")
                 continue
-        
-        return processed
-    
-    async def _save_image(self, img_b64: str, job_id: str, index: int) -> str:
-        """Save base64 image to disk.
-        
-        Args:
-            img_b64: Base64 encoded image
-            job_id: Generation job ID
-            index: Image index
-            
-        Returns:
-            File path where image was saved
 
-        """
-        # Create output directory if specified
-        if self.output_dir:
-            output_path = Path(self.output_dir)
-        else:
-            output_path = Path.cwd() / "generated_images"
-        
-        output_path.mkdir(parents=True, exist_ok=True)
-        
-        # Generate filename with timestamp
-        timestamp = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
-        filename = f"{job_id}_{timestamp}_{index:03d}.png"
-        file_path = output_path / filename
-        
-        # Decode and save image
-        img_data = base64.b64decode(img_b64)
-        with open(file_path, "wb") as f:
-            f.write(img_data)
-        
-        return str(file_path)
-    
+        return processed
+
     def get_backend_name(self) -> str:
         """Return backend name."""
         return "sdnext"

--- a/backend/delivery/storage.py
+++ b/backend/delivery/storage.py
@@ -1,0 +1,37 @@
+"""Storage abstractions for generation outputs."""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+
+class ImageStorage:
+    """Abstract interface for persisting generated images."""
+
+    async def save_image(self, img_b64: str, job_id: str, index: int) -> str:
+        """Persist a base64-encoded image and return its location."""
+        raise NotImplementedError
+
+
+class FileSystemImageStorage(ImageStorage):
+    """Store generated images on the local filesystem."""
+
+    def __init__(self, output_dir: Optional[str] = None) -> None:
+        self._output_dir = Path(output_dir) if output_dir else Path.cwd() / "generated_images"
+
+    async def save_image(self, img_b64: str, job_id: str, index: int) -> str:
+        output_path = self._output_dir
+        output_path.mkdir(parents=True, exist_ok=True)
+
+        timestamp = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+        filename = f"{job_id}_{timestamp}_{index:03d}.png"
+        file_path = output_path / filename
+
+        img_data = base64.b64decode(img_b64)
+        await asyncio.to_thread(file_path.write_bytes, img_data)
+
+        return str(file_path)

--- a/tests/test_sdnext_backend.py
+++ b/tests/test_sdnext_backend.py
@@ -1,0 +1,110 @@
+"""Unit tests for the SDNext generation backend."""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from typing import Any, Dict, Optional
+
+import pytest
+
+from backend.delivery.sdnext import SDNextGenerationBackend
+from backend.delivery.storage import ImageStorage
+
+
+class _FakeResponse:
+    def __init__(self, status: int, json_data: Optional[Dict[str, Any]] = None, text: str = "") -> None:
+        self.status = status
+        self._json_data = json_data or {}
+        self._text = text
+
+    async def json(self) -> Dict[str, Any]:
+        return self._json_data
+
+    async def text(self) -> str:
+        return self._text
+
+
+class FakeHTTPClient:
+    def __init__(
+        self,
+        *,
+        status: int,
+        json_data: Optional[Dict[str, Any]] = None,
+        text: str = "",
+        health: bool = True,
+    ) -> None:
+        self._status = status
+        self._json_data = json_data or {}
+        self._text = text
+        self._health = health
+        self.requests = []
+        self.closed = False
+        self.health_checks = 0
+
+    def is_configured(self) -> bool:
+        return True
+
+    async def request(self, method: str, path: str, **kwargs: Any):
+        self.requests.append((method, path, kwargs))
+        response = _FakeResponse(self._status, self._json_data, self._text)
+
+        @asynccontextmanager
+        async def ctx():
+            yield response
+
+        return ctx()
+
+    async def health_check(self, path: Optional[str] = None) -> bool:  # noqa: ARG002 - path not used in fake
+        self.health_checks += 1
+        return self._health
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+class RecordingStorage(ImageStorage):
+    def __init__(self) -> None:
+        self.calls = []
+
+    async def save_image(self, img_b64: str, job_id: str, index: int) -> str:
+        self.calls.append((img_b64, job_id, index))
+        return "saved-path"
+
+
+class FailingStorage(ImageStorage):
+    def __init__(self) -> None:
+        self.calls = 0
+
+    async def save_image(self, img_b64: str, job_id: str, index: int) -> str:
+        self.calls += 1
+        raise RuntimeError("boom")
+
+
+@pytest.mark.anyio("asyncio")
+async def test_generate_image_api_error() -> None:
+    client = FakeHTTPClient(status=500, text="failure", json_data={})
+    storage = RecordingStorage()
+    backend = SDNextGenerationBackend(http_client=client, storage=storage)
+
+    result = await backend.generate_image("Prompt", {"generation_params": {}})
+
+    assert result.status == "failed"
+    assert "500" in (result.error_message or "")
+    assert storage.calls == []  # storage should not be invoked on API failure
+    assert client.requests[0][0] == "POST"
+    assert client.requests[0][1] == "/sdapi/v1/txt2img"
+
+
+@pytest.mark.anyio("asyncio")
+async def test_generate_image_storage_failure() -> None:
+    payload = {"images": ["aGVsbG8="], "info": {"mode": "test"}}
+    client = FakeHTTPClient(status=200, json_data=payload)
+    storage = FailingStorage()
+    backend = SDNextGenerationBackend(http_client=client, storage=storage)
+
+    result = await backend.generate_image("Prompt", {"generation_params": {}, "return_format": "file_path"})
+
+    assert result.status == "completed"
+    assert result.images == []
+    assert result.generation_info == payload["info"]
+    assert storage.calls == 1


### PR DESCRIPTION
## Summary
- add a reusable DeliveryHTTPClient helper to centralize session lifecycle, requests, and health checks
- extract a FileSystemImageStorage implementation so the SDNext backend can delegate persistence
- refactor SDNextGenerationBackend to use the new collaborators and add unit tests covering API failures vs. storage errors

## Testing
- pytest tests/test_sdnext_backend.py

------
https://chatgpt.com/codex/tasks/task_e_68d1c3fe8fb8832989ae00bba5a792e6