### PR TITLE
Modularize recommendation bootstrap and persistence

### DIFF
--- a/backend/services/__init__.py
+++ b/backend/services/__init__.py
@@ -15,7 +15,10 @@ from .deliveries import DeliveryService
 from .generation import GenerationCoordinator, GenerationService
 from .queue import QueueBackend, get_queue_backends
 from .storage import StorageService
-from .recommendations import RecommendationService
+from .recommendations import (
+    RecommendationModelBootstrap,
+    RecommendationService,
+)
 from .system import SystemService
 from .websocket import WebSocketService, websocket_service
 
@@ -180,12 +183,18 @@ class ServiceContainer:
             raise ValueError("RecommendationService requires an active database session")
 
         if self._recommendation_gpu_available is None:
-            self._recommendation_gpu_available = RecommendationService.is_gpu_available()
+            self._recommendation_gpu_available = (
+                RecommendationModelBootstrap.is_gpu_available()
+            )
 
         if self._recommendation_service is None:
+            model_bootstrap = RecommendationModelBootstrap(
+                gpu_enabled=self._recommendation_gpu_available,
+            )
             self._recommendation_service = RecommendationService(
                 self.db_session,
                 gpu_enabled=self._recommendation_gpu_available,
+                model_bootstrap=model_bootstrap,
             )
 
         return self._recommendation_service

--- a/backend/services/recommendations/__init__.py
+++ b/backend/services/recommendations/__init__.py
@@ -1,5 +1,11 @@
 """Recommendation service package exports."""
 
+from .model_bootstrap import RecommendationModelBootstrap
+from .persistence_manager import RecommendationPersistenceManager
 from .service import RecommendationService
 
-__all__ = ['RecommendationService']
+__all__ = [
+    'RecommendationModelBootstrap',
+    'RecommendationPersistenceManager',
+    'RecommendationService',
+]

--- a/backend/services/recommendations/model_bootstrap.py
+++ b/backend/services/recommendations/model_bootstrap.py
@@ -1,0 +1,94 @@
+"""Model bootstrap helpers for the recommendation service."""
+
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+from .model_registry import RecommendationModelRegistry
+
+
+class RecommendationModelBootstrap:
+    """Handle GPU detection and model registry initialization."""
+
+    def __init__(
+        self,
+        *,
+        gpu_enabled: Optional[bool] = None,
+        logger: Optional[logging.Logger] = None,
+    ) -> None:
+        self._logger = logger or logging.getLogger(__name__)
+        self._device, self._gpu_enabled = self._detect_device(gpu_enabled)
+        self._model_registry: RecommendationModelRegistry | None = None
+
+    @property
+    def device(self) -> str:
+        """Return the preferred torch device for the recommendation models."""
+
+        return self._device
+
+    @property
+    def gpu_enabled(self) -> bool:
+        """Return whether GPU acceleration should be used."""
+
+        return self._gpu_enabled
+
+    def get_model_registry(self) -> RecommendationModelRegistry:
+        """Return a lazily created model registry instance."""
+
+        if self._model_registry is None:
+            self._model_registry = RecommendationModelRegistry(
+                device=self._device,
+                gpu_enabled=self._gpu_enabled,
+                logger=self._logger,
+            )
+        return self._model_registry
+
+    def set_model_registry(
+        self, registry: RecommendationModelRegistry
+    ) -> None:
+        """Inject a custom model registry implementation."""
+
+        self._model_registry = registry
+
+    def preload_models(self) -> None:
+        """Preload heavy models using the configured device."""
+
+        RecommendationModelRegistry.preload_models(
+            device=self._device,
+            gpu_enabled=self._gpu_enabled,
+        )
+
+    @classmethod
+    def preload_models_for_environment(
+        cls, *, gpu_enabled: Optional[bool] = None
+    ) -> None:
+        """Preload models for the detected runtime environment."""
+
+        bootstrap = cls(gpu_enabled=gpu_enabled)
+        bootstrap.preload_models()
+
+    @classmethod
+    def is_gpu_available(cls) -> bool:
+        """Detect GPU availability across CUDA, ROCm, and MPS runtimes."""
+
+        try:
+            import torch
+
+            if torch.cuda.is_available():
+                return True
+            if getattr(torch.version, "hip", None):
+                return True
+            if torch.backends.mps.is_available():
+                return True
+            return False
+        except ImportError:
+            return False
+
+    @classmethod
+    def _detect_device(cls, gpu_enabled: Optional[bool]) -> tuple[str, bool]:
+        if gpu_enabled is None:
+            gpu_enabled = cls.is_gpu_available()
+
+        return ("cuda" if gpu_enabled else "cpu", bool(gpu_enabled))
+

--- a/backend/services/recommendations/persistence_manager.py
+++ b/backend/services/recommendations/persistence_manager.py
@@ -1,0 +1,119 @@
+"""Persistence helpers for recommendation embeddings and indexes."""
+
+from __future__ import annotations
+
+import pickle
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Callable
+
+import numpy as np
+
+from backend.schemas.recommendations import IndexRebuildResponse
+
+from .components.interfaces import RecommendationEngineProtocol
+from .embedding_manager import EmbeddingManager
+
+
+class RecommendationPersistenceManager:
+    """Handle persistence of recommendation embeddings and indexes."""
+
+    def __init__(
+        self,
+        embedding_manager: EmbeddingManager,
+        engine_getter: Callable[[], RecommendationEngineProtocol],
+        *,
+        embedding_cache_dir: str | Path = "cache/embeddings",
+        index_cache_path: str | Path = "cache/similarity_index.pkl",
+        clock: Callable[[], float] = time.time,
+    ) -> None:
+        self._embedding_manager = embedding_manager
+        self._engine_getter = engine_getter
+        self._embedding_cache_dir = Path(embedding_cache_dir)
+        self._index_cache_path = Path(index_cache_path)
+        self._clock = clock
+
+        self._embedding_cache_dir.mkdir(parents=True, exist_ok=True)
+        self._index_cache_path.parent.mkdir(parents=True, exist_ok=True)
+
+    @property
+    def embedding_cache_dir(self) -> Path:
+        """Return the directory used for cached embeddings."""
+
+        return self._embedding_cache_dir
+
+    @embedding_cache_dir.setter
+    def embedding_cache_dir(self, value: str | Path) -> None:
+        path = Path(value)
+        path.mkdir(parents=True, exist_ok=True)
+        self._embedding_cache_dir = path
+
+    @property
+    def index_cache_path(self) -> Path:
+        """Return the persisted similarity index path."""
+
+        return self._index_cache_path
+
+    @index_cache_path.setter
+    def index_cache_path(self, value: str | Path) -> None:
+        path = Path(value)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        self._index_cache_path = path
+
+    async def rebuild_similarity_index(self, *, force: bool = False) -> IndexRebuildResponse:
+        """Rebuild the similarity index and persist it to disk."""
+
+        engine = self._engine_getter()
+        index_file = self._index_cache_path
+
+        if not force and getattr(engine, "lora_ids", None):
+            index_size = index_file.stat().st_size if index_file.exists() else 0
+            return IndexRebuildResponse(
+                status="skipped",
+                indexed_items=len(engine.lora_ids),
+                index_path=str(index_file),
+                index_size_bytes=index_size,
+                processing_time_seconds=0.0,
+                rebuilt_at=datetime.now(timezone.utc),
+                skipped=True,
+                skipped_reason="existing_index",
+            )
+
+        start_time = self._clock()
+
+        await self._embedding_manager.build_similarity_index()
+
+        indexed_items = len(getattr(engine, "lora_ids", []) or [])
+        index_size = 0
+        status = "empty"
+        skipped_reason = None
+
+        if indexed_items:
+            payload = {
+                "lora_ids": engine.lora_ids,
+                "semantic_embeddings": np.asarray(engine.semantic_embeddings),
+                "artistic_embeddings": np.asarray(engine.artistic_embeddings),
+                "technical_embeddings": np.asarray(engine.technical_embeddings),
+            }
+            with index_file.open("wb") as handle:
+                pickle.dump(payload, handle)
+            index_size = index_file.stat().st_size
+            status = "rebuilt"
+        else:
+            if index_file.exists():
+                index_file.unlink()
+
+        processing_time = self._clock() - start_time
+
+        return IndexRebuildResponse(
+            status=status,
+            indexed_items=indexed_items,
+            index_path=str(index_file),
+            index_size_bytes=index_size,
+            processing_time_seconds=processing_time,
+            rebuilt_at=datetime.now(timezone.utc),
+            skipped=False,
+            skipped_reason=skipped_reason,
+        )
+


### PR DESCRIPTION
## Summary
- extract the GPU/model bootstrapping code into a dedicated provider for the recommendation stack
- add a persistence manager to own similarity index storage and delegate from the service
- update the recommendation service wiring/tests to compose the new collaborators via dependency injection

## Testing
- pytest tests/test_recommendations.py

------
https://chatgpt.com/codex/tasks/task_e_68d1c3fceb70832987bedd046cf8bb0d