### PR TITLE
Refactor recommendation feature extraction helpers

### DIFF
--- a/backend/services/recommendations/components/feature_extractor.py
+++ b/backend/services/recommendations/components/feature_extractor.py
@@ -3,13 +3,16 @@
 from __future__ import annotations
 
 import logging
-import re
-from typing import Any, Dict, List, Optional, Sequence
-
-import numpy as np
+from typing import Any, Dict, Optional
 
 from .embedder import LoRASemanticEmbedder
 from .interfaces import FeatureExtractorProtocol, SemanticEmbedderProtocol
+from .scoring import ScoreCalculator, ScoreCalculatorProtocol
+from .sentiment_style import (
+    SentimentStyleAnalyzer,
+    SentimentStyleAnalyzerProtocol,
+)
+from .text_features import KeywordExtractor, KeywordExtractorProtocol
 
 
 class GPULoRAFeatureExtractor(FeatureExtractorProtocol):
@@ -20,6 +23,9 @@ class GPULoRAFeatureExtractor(FeatureExtractorProtocol):
         *,
         device: str = "cuda",
         semantic_embedder: SemanticEmbedderProtocol | None = None,
+        keyword_extractor: KeywordExtractorProtocol | None = None,
+        sentiment_style_analyzer: SentimentStyleAnalyzerProtocol | None = None,
+        score_calculator: ScoreCalculatorProtocol | None = None,
         logger: Optional[logging.Logger] = None,
     ) -> None:
         """Initialize feature extractor."""
@@ -31,57 +37,16 @@ class GPULoRAFeatureExtractor(FeatureExtractorProtocol):
             logger=self._logger,
         )
 
-        self._keyword_extractor: Any | None = None
-        self._sentiment_analyzer: Any | None = None
-        self._style_classifier: Any | None = None
-
-    def _load_advanced_models(self) -> None:
-        """Load advanced NLP models if available."""
-        if self._keyword_extractor is None:
-            try:
-                from keybert import KeyBERT
-
-                self._keyword_extractor = KeyBERT(
-                    model="sentence-transformers/all-mpnet-base-v2",
-                )
-                self._logger.info("KeyBERT loaded for keyword extraction")
-            except ImportError:
-                self._logger.debug(
-                    "KeyBERT not available, using fallback keyword extraction",
-                )
-                self._keyword_extractor = "fallback"
-
-        if self._sentiment_analyzer is None:
-            try:
-                from transformers import pipeline
-
-                self._sentiment_analyzer = pipeline(
-                    "sentiment-analysis",
-                    model="cardiffnlp/twitter-roberta-base-sentiment-latest",
-                    device=0 if self.device == "cuda" else -1,
-                )
-                self._logger.info("Sentiment analyzer loaded")
-            except ImportError:
-                self._logger.debug(
-                    "Transformers not available, using fallback sentiment analysis",
-                )
-                self._sentiment_analyzer = "fallback"
-
-        if self._style_classifier is None:
-            try:
-                from transformers import pipeline
-
-                self._style_classifier = pipeline(
-                    "zero-shot-classification",
-                    model="facebook/bart-large-mnli",
-                    device=0 if self.device == "cuda" else -1,
-                )
-                self._logger.info("Style classifier loaded")
-            except ImportError:
-                self._logger.debug(
-                    "Style classifier not available, using fallback classification",
-                )
-                self._style_classifier = "fallback"
+        self.keyword_extractor = keyword_extractor or KeywordExtractor(
+            logger=self._logger,
+        )
+        self.sentiment_style_analyzer = (
+            sentiment_style_analyzer
+            or SentimentStyleAnalyzer(device=device, logger=self._logger)
+        )
+        self.score_calculator = score_calculator or ScoreCalculator(
+            logger=self._logger,
+        )
 
     def extract_advanced_features(self, lora: Any) -> Dict[str, Any]:
         """Extract comprehensive features using available models."""
@@ -96,289 +61,14 @@ class GPULoRAFeatureExtractor(FeatureExtractorProtocol):
             }
         )
 
-        self._load_advanced_models()
-
         description = getattr(lora, "description", "") or ""
         if description:
-            if self._keyword_extractor != "fallback":
-                try:
-                    keywords = self._keyword_extractor.extract_keywords(
-                        description,
-                        keyphrase_ngram_range=(1, 3),
-                        stop_words="english",
-                        top_k=10,
-                    )
-                    features["extracted_keywords"] = [kw[0] for kw in keywords]
-                    features["keyword_scores"] = [kw[1] for kw in keywords]
-                except Exception:
-                    features.update(self._fallback_keyword_extraction(description))
-            else:
-                features.update(self._fallback_keyword_extraction(description))
+            features.update(self.keyword_extractor.extract(description))
+            features.update(
+                self.sentiment_style_analyzer.analyze_sentiment(description)
+            )
+            features.update(self.sentiment_style_analyzer.classify_style(description))
 
-            if self._sentiment_analyzer != "fallback":
-                try:
-                    sentiment = self._sentiment_analyzer(description[:512])
-                    features["sentiment_label"] = sentiment[0]["label"]
-                    features["sentiment_score"] = sentiment[0]["score"]
-                except Exception:
-                    features.update(self._fallback_sentiment_analysis(description))
-            else:
-                features.update(self._fallback_sentiment_analysis(description))
-
-            if self._style_classifier != "fallback":
-                try:
-                    art_styles = [
-                        "anime",
-                        "realistic",
-                        "cartoon",
-                        "abstract",
-                        "photographic",
-                        "digital art",
-                        "painting",
-                        "sketch",
-                        "3D render",
-                        "pixel art",
-                    ]
-                    style_result = self._style_classifier(description[:512], art_styles)
-                    features["predicted_style"] = style_result["labels"][0]
-                    features["style_confidence"] = style_result["scores"][0]
-                except Exception:
-                    features.update(self._fallback_style_classification(description))
-            else:
-                features.update(self._fallback_style_classification(description))
-
-        features.update(
-            {
-                "tags_vector": self._encode_tags_advanced(getattr(lora, "tags", None)),
-                "sd_version_vector": self._encode_sd_version(
-                    getattr(lora, "sd_version", None)
-                ),
-                "author_vector": self._encode_author_advanced(
-                    getattr(lora, "author_username", None)
-                ),
-                "quality_score": self._calculate_enhanced_quality_score(
-                    getattr(lora, "stats", None)
-                ),
-                "popularity_score": self._calculate_popularity_score(
-                    getattr(lora, "stats", None)
-                ),
-                "community_engagement": self._calculate_engagement_score(
-                    getattr(lora, "stats", None)
-                ),
-                "file_size_normalized": self._normalize_file_size(
-                    getattr(lora, "primary_file_size_kb", None)
-                ),
-                "recency_score": self._calculate_recency_score(
-                    getattr(lora, "published_at", None)
-                ),
-                "maturity_score": self._calculate_maturity_score(
-                    getattr(lora, "created_at", None)
-                ),
-                "nsfw_level_normalized": (
-                    getattr(lora, "nsfw_level", 0) / 10.0
-                    if getattr(lora, "nsfw_level", None)
-                    else 0.0
-                ),
-                "supports_generation": float(
-                    bool(getattr(lora, "supports_generation", False))
-                ),
-                "sd_compatibility_score": self._calculate_sd_compatibility(
-                    getattr(lora, "sd_version", None)
-                ),
-                "user_activation_frequency": 0.0,
-                "user_success_rate": 0.5,
-                "recent_usage_trend": 0.0,
-            }
-        )
+        features.update(self.score_calculator.compute(lora))
 
         return features
-
-    def _fallback_keyword_extraction(self, text: str) -> Dict[str, Any]:
-        words = re.findall(r"\b\w+\b", text.lower())
-        word_freq: Dict[str, int] = {}
-        for word in words:
-            if len(word) > 3:
-                word_freq[word] = word_freq.get(word, 0) + 1
-
-        top_keywords = sorted(word_freq.items(), key=lambda x: x[1], reverse=True)[:10]
-
-        return {
-            "extracted_keywords": [kw[0] for kw in top_keywords],
-            "keyword_scores": [kw[1] / len(words) for kw in top_keywords]
-            if words
-            else [],
-        }
-
-    def _fallback_sentiment_analysis(self, text: str) -> Dict[str, Any]:
-        positive_words = [
-            "good",
-            "great",
-            "excellent",
-            "amazing",
-            "beautiful",
-            "perfect",
-        ]
-        negative_words = [
-            "bad",
-            "terrible",
-            "awful",
-            "horrible",
-            "ugly",
-            "poor",
-        ]
-
-        text_lower = text.lower()
-        pos_count = sum(1 for word in positive_words if word in text_lower)
-        neg_count = sum(1 for word in negative_words if word in text_lower)
-
-        if pos_count > neg_count:
-            return {"sentiment_label": "POSITIVE", "sentiment_score": 0.7}
-        if neg_count > pos_count:
-            return {"sentiment_label": "NEGATIVE", "sentiment_score": 0.7}
-        return {"sentiment_label": "NEUTRAL", "sentiment_score": 0.5}
-
-    def _fallback_style_classification(self, text: str) -> Dict[str, Any]:
-        style_keywords = {
-            "anime": ["anime", "manga", "japanese", "kawaii"],
-            "realistic": ["realistic", "photorealistic", "photo", "real"],
-            "cartoon": ["cartoon", "comic", "toon"],
-            "digital art": ["digital", "cg", "computer"],
-            "painting": ["painting", "paint", "oil", "watercolor"],
-        }
-
-        text_lower = text.lower()
-        style_scores: Dict[str, int] = {}
-
-        for style, keywords in style_keywords.items():
-            score = sum(1 for keyword in keywords if keyword in text_lower)
-            if score > 0:
-                style_scores[style] = score
-
-        if style_scores:
-            best_style = max(style_scores, key=style_scores.get)
-            confidence = style_scores[best_style] / max(len(text.split()), 1)
-            return {
-                "predicted_style": best_style,
-                "style_confidence": min(confidence, 1.0),
-            }
-        return {"predicted_style": "unknown", "style_confidence": 0.0}
-
-    def _encode_tags_advanced(self, tags: Optional[Sequence[str]]) -> List[float]:
-        if not tags:
-            return [0.0] * 10
-
-        common_categories = [
-            "character",
-            "style",
-            "anime",
-            "realistic",
-            "fantasy",
-            "portrait",
-            "landscape",
-            "nsfw",
-            "safe",
-            "concept",
-        ]
-
-        vector: List[float] = []
-        for category in common_categories:
-            score = sum(1 for tag in tags if category in tag.lower())
-            vector.append(min(score / len(tags), 1.0))
-
-        return vector
-
-    def _encode_sd_version(self, sd_version: Optional[str]) -> List[float]:
-        if not sd_version:
-            return [0.0, 0.0, 0.0]
-
-        version_lower = sd_version.lower()
-        if "xl" in version_lower or "sdxl" in version_lower:
-            return [0.0, 0.0, 1.0]
-        if "2." in version_lower or "sd2" in version_lower:
-            return [0.0, 1.0, 0.0]
-        return [1.0, 0.0, 0.0]
-
-    def _encode_author_advanced(self, author: Optional[str]) -> float:
-        if not author:
-            return 0.0
-        return min(len(author) / 20.0, 1.0)
-
-    def _calculate_enhanced_quality_score(self, stats: Optional[Dict[str, Any]]) -> float:
-        if not stats:
-            return 0.5
-
-        rating = stats.get("rating", 0)
-        download_count = stats.get("downloadCount", 0)
-        favorite_count = stats.get("favoriteCount", 0)
-
-        quality = 0.0
-        if rating > 0:
-            quality += (rating / 5.0) * 0.6
-
-        if download_count > 0:
-            popularity = min(np.log10(download_count + 1) / 5.0, 1.0)
-            quality += popularity * 0.3
-
-        if favorite_count > 0:
-            favorites = min(np.log10(favorite_count + 1) / 3.0, 1.0)
-            quality += favorites * 0.1
-
-        return min(quality, 1.0)
-
-    def _calculate_popularity_score(self, stats: Optional[Dict[str, Any]]) -> float:
-        if not stats:
-            return 0.0
-        downloads = stats.get("downloadCount", 0)
-        return min(np.log10(downloads + 1) / 6.0, 1.0)
-
-    def _calculate_engagement_score(self, stats: Optional[Dict[str, Any]]) -> float:
-        if not stats:
-            return 0.0
-        comments = stats.get("commentCount", 0)
-        favorites = stats.get("favoriteCount", 0)
-        engagement = comments * 0.6 + favorites * 0.4
-        return min(np.log10(engagement + 1) / 3.0, 1.0)
-
-    def _normalize_file_size(self, size_kb: Optional[int]) -> float:
-        if not size_kb:
-            return 0.5
-        return min(size_kb / (500 * 1024), 1.0)
-
-    def _calculate_recency_score(self, published_at: Any) -> float:
-        if not published_at:
-            return 0.0
-        try:
-            from datetime import datetime, timezone
-
-            now = datetime.now(timezone.utc)
-            if getattr(published_at, "tzinfo", None) is None:
-                published_at = published_at.replace(tzinfo=timezone.utc)
-            days_old = (now - published_at).days
-            return max(0.0, 1.0 - (days_old / 365.0))
-        except Exception:
-            return 0.5
-
-    def _calculate_maturity_score(self, created_at: Any) -> float:
-        if not created_at:
-            return 0.0
-        try:
-            from datetime import datetime, timezone
-
-            now = datetime.now(timezone.utc)
-            if getattr(created_at, "tzinfo", None) is None:
-                created_at = created_at.replace(tzinfo=timezone.utc)
-            days_old = (now - created_at).days
-            return min(days_old / 180.0, 1.0)
-        except Exception:
-            return 0.5
-
-    def _calculate_sd_compatibility(self, sd_version: Optional[str]) -> float:
-        if not sd_version:
-            return 0.5
-
-        version_lower = sd_version.lower()
-        if "xl" in version_lower or "sdxl" in version_lower:
-            return 1.0
-        if "2." in version_lower:
-            return 0.7
-        return 0.8

--- a/backend/services/recommendations/components/scoring.py
+++ b/backend/services/recommendations/components/scoring.py
@@ -1,0 +1,180 @@
+"""Numeric scoring helpers for recommendation feature extraction."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, Optional, Sequence, Protocol
+
+import numpy as np
+
+
+class ScoreCalculatorProtocol(Protocol):
+    """Minimal protocol for numeric feature calculation helpers."""
+
+    def compute(self, lora: Any) -> Dict[str, Any]:  # pragma: no cover - interface
+        """Return the derived numeric metrics for the provided LoRA object."""
+
+
+class ScoreCalculator(ScoreCalculatorProtocol):
+    """Calculate derived metrics from LoRA metadata and statistics."""
+
+    _COMMON_TAG_CATEGORIES = [
+        "character",
+        "style",
+        "anime",
+        "realistic",
+        "fantasy",
+        "portrait",
+        "landscape",
+        "nsfw",
+        "safe",
+        "concept",
+    ]
+
+    def __init__(self, *, logger: logging.Logger | None = None) -> None:
+        self._logger = logger or logging.getLogger(__name__)
+
+    def compute(self, lora: Any) -> Dict[str, Any]:
+        stats = getattr(lora, "stats", None)
+        tags = getattr(lora, "tags", None)
+        sd_version = getattr(lora, "sd_version", None)
+        author = getattr(lora, "author_username", None)
+
+        return {
+            "tags_vector": self._encode_tags(tags),
+            "sd_version_vector": self._encode_sd_version(sd_version),
+            "author_vector": self._encode_author(author),
+            "quality_score": self._quality_score(stats),
+            "popularity_score": self._popularity_score(stats),
+            "community_engagement": self._engagement_score(stats),
+            "file_size_normalized": self._normalize_file_size(
+                getattr(lora, "primary_file_size_kb", None)
+            ),
+            "recency_score": self._recency_score(getattr(lora, "published_at", None)),
+            "maturity_score": self._maturity_score(getattr(lora, "created_at", None)),
+            "nsfw_level_normalized": (
+                getattr(lora, "nsfw_level", 0) / 10.0 if getattr(lora, "nsfw_level", None) else 0.0
+            ),
+            "supports_generation": float(bool(getattr(lora, "supports_generation", False))),
+            "sd_compatibility_score": self._sd_compatibility(sd_version),
+            "user_activation_frequency": 0.0,
+            "user_success_rate": 0.5,
+            "recent_usage_trend": 0.0,
+        }
+
+    def _encode_tags(self, tags: Optional[Sequence[str]]) -> list[float]:
+        if not tags:
+            return [0.0] * len(self._COMMON_TAG_CATEGORIES)
+
+        vector: list[float] = []
+        for category in self._COMMON_TAG_CATEGORIES:
+            score = sum(1 for tag in tags if category in tag.lower())
+            vector.append(min(score / len(tags), 1.0))
+
+        return vector
+
+    def _encode_sd_version(self, sd_version: Optional[str]) -> list[float]:
+        if not sd_version:
+            return [0.0, 0.0, 0.0]
+
+        version_lower = sd_version.lower()
+        if "xl" in version_lower or "sdxl" in version_lower:
+            return [0.0, 0.0, 1.0]
+        if "2." in version_lower or "sd2" in version_lower:
+            return [0.0, 1.0, 0.0]
+        return [1.0, 0.0, 0.0]
+
+    def _encode_author(self, author: Optional[str]) -> float:
+        if not author:
+            return 0.0
+        return min(len(author) / 20.0, 1.0)
+
+    def _quality_score(self, stats: Optional[Dict[str, Any]]) -> float:
+        if not stats:
+            return 0.5
+
+        rating = stats.get("rating", 0)
+        download_count = stats.get("downloadCount", 0)
+        favorite_count = stats.get("favoriteCount", 0)
+
+        quality = 0.0
+        if rating > 0:
+            quality += (rating / 5.0) * 0.6
+
+        if download_count > 0:
+            popularity = min(np.log10(download_count + 1) / 5.0, 1.0)
+            quality += popularity * 0.3
+
+        if favorite_count > 0:
+            favorites = min(np.log10(favorite_count + 1) / 3.0, 1.0)
+            quality += favorites * 0.1
+
+        return min(quality, 1.0)
+
+    def _popularity_score(self, stats: Optional[Dict[str, Any]]) -> float:
+        if not stats:
+            return 0.0
+        downloads = stats.get("downloadCount", 0)
+        return min(np.log10(downloads + 1) / 6.0, 1.0)
+
+    def _engagement_score(self, stats: Optional[Dict[str, Any]]) -> float:
+        if not stats:
+            return 0.0
+        comments = stats.get("commentCount", 0)
+        favorites = stats.get("favoriteCount", 0)
+        engagement = comments * 0.6 + favorites * 0.4
+        return min(np.log10(engagement + 1) / 3.0, 1.0)
+
+    def _normalize_file_size(self, size_kb: Optional[int]) -> float:
+        if not size_kb:
+            return 0.5
+        try:
+            return float(min(size_kb / (500 * 1024), 1.0))
+        except Exception:  # pragma: no cover - defensive branch
+            self._logger.debug("Failed to normalize file size", exc_info=True)
+            return 0.5
+
+    def _recency_score(self, published_at: Any) -> float:
+        if not published_at:
+            return 0.0
+        try:
+            from datetime import datetime, timezone
+
+            now = datetime.now(timezone.utc)
+            if getattr(published_at, "tzinfo", None) is None:
+                published_at = published_at.replace(tzinfo=timezone.utc)
+            days_old = (now - published_at).days
+            return max(0.0, 1.0 - (days_old / 365.0))
+        except Exception:  # pragma: no cover - defensive branch
+            self._logger.debug("Failed to compute recency score", exc_info=True)
+            return 0.5
+
+    def _maturity_score(self, created_at: Any) -> float:
+        if not created_at:
+            return 0.0
+        try:
+            from datetime import datetime, timezone
+
+            now = datetime.now(timezone.utc)
+            if getattr(created_at, "tzinfo", None) is None:
+                created_at = created_at.replace(tzinfo=timezone.utc)
+            days_old = (now - created_at).days
+            return min(days_old / 180.0, 1.0)
+        except Exception:  # pragma: no cover - defensive branch
+            self._logger.debug("Failed to compute maturity score", exc_info=True)
+            return 0.5
+
+    def _sd_compatibility(self, sd_version: Optional[str]) -> float:
+        if not sd_version:
+            return 0.5
+
+        version_lower = sd_version.lower()
+        if "xl" in version_lower or "sdxl" in version_lower:
+            return 1.0
+        if "2." in version_lower:
+            return 0.7
+        return 0.8
+
+
+__all__ = ["ScoreCalculator", "ScoreCalculatorProtocol"]
+

--- a/backend/services/recommendations/components/sentiment_style.py
+++ b/backend/services/recommendations/components/sentiment_style.py
@@ -1,0 +1,167 @@
+"""Sentiment and style analysis helpers for recommendation features."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, Protocol
+
+
+class SentimentStyleAnalyzerProtocol(Protocol):
+    """Minimal protocol for combined sentiment and style analysis."""
+
+    def analyze_sentiment(self, text: str) -> Dict[str, Any]:  # pragma: no cover - interface
+        """Return sentiment metadata for the supplied text."""
+
+    def classify_style(self, text: str) -> Dict[str, Any]:  # pragma: no cover - interface
+        """Return artistic style predictions for the supplied text."""
+
+
+class SentimentStyleAnalyzer(SentimentStyleAnalyzerProtocol):
+    """Analyzer that tries to use transformers pipelines with robust fallbacks."""
+
+    _ART_STYLES = [
+        "anime",
+        "realistic",
+        "cartoon",
+        "abstract",
+        "photographic",
+        "digital art",
+        "painting",
+        "sketch",
+        "3D render",
+        "pixel art",
+    ]
+
+    def __init__(self, *, device: str = "cuda", logger: logging.Logger | None = None) -> None:
+        self._device = device
+        self._logger = logger or logging.getLogger(__name__)
+        self._sentiment_pipeline: Any | None = None
+        self._style_pipeline: Any | None = None
+
+    def analyze_sentiment(self, text: str) -> Dict[str, Any]:
+        if not text:
+            return {"sentiment_label": "NEUTRAL", "sentiment_score": 0.5}
+
+        self._ensure_sentiment_pipeline()
+        if self._sentiment_pipeline == "fallback":
+            return self._fallback_sentiment(text)
+
+        try:
+            sentiment = self._sentiment_pipeline(text[:512])
+            return {
+                "sentiment_label": sentiment[0]["label"],
+                "sentiment_score": sentiment[0]["score"],
+            }
+        except Exception:  # pragma: no cover - defensive branch
+            self._logger.debug("Falling back to heuristic sentiment analysis", exc_info=True)
+            return self._fallback_sentiment(text)
+
+    def classify_style(self, text: str) -> Dict[str, Any]:
+        if not text:
+            return {"predicted_style": "unknown", "style_confidence": 0.0}
+
+        self._ensure_style_pipeline()
+        if self._style_pipeline == "fallback":
+            return self._fallback_style(text)
+
+        try:
+            style_result = self._style_pipeline(text[:512], self._ART_STYLES)
+            return {
+                "predicted_style": style_result["labels"][0],
+                "style_confidence": style_result["scores"][0],
+            }
+        except Exception:  # pragma: no cover - defensive branch
+            self._logger.debug("Falling back to heuristic style classification", exc_info=True)
+            return self._fallback_style(text)
+
+    def _ensure_sentiment_pipeline(self) -> None:
+        if self._sentiment_pipeline is not None:
+            return
+
+        try:
+            from transformers import pipeline
+
+            self._sentiment_pipeline = pipeline(
+                "sentiment-analysis",
+                model="cardiffnlp/twitter-roberta-base-sentiment-latest",
+                device=0 if self._device == "cuda" else -1,
+            )
+            self._logger.info("Sentiment analysis pipeline loaded")
+        except ImportError:
+            self._logger.debug("Transformers unavailable, using sentiment fallback heuristics")
+            self._sentiment_pipeline = "fallback"
+
+    def _ensure_style_pipeline(self) -> None:
+        if self._style_pipeline is not None:
+            return
+
+        try:
+            from transformers import pipeline
+
+            self._style_pipeline = pipeline(
+                "zero-shot-classification",
+                model="facebook/bart-large-mnli",
+                device=0 if self._device == "cuda" else -1,
+            )
+            self._logger.info("Style classification pipeline loaded")
+        except ImportError:
+            self._logger.debug("Transformers unavailable, using style fallback heuristics")
+            self._style_pipeline = "fallback"
+
+    def _fallback_sentiment(self, text: str) -> Dict[str, Any]:
+        positive_words = [
+            "good",
+            "great",
+            "excellent",
+            "amazing",
+            "beautiful",
+            "perfect",
+        ]
+        negative_words = [
+            "bad",
+            "terrible",
+            "awful",
+            "horrible",
+            "ugly",
+            "poor",
+        ]
+
+        text_lower = text.lower()
+        pos_count = sum(1 for word in positive_words if word in text_lower)
+        neg_count = sum(1 for word in negative_words if word in text_lower)
+
+        if pos_count > neg_count:
+            return {"sentiment_label": "POSITIVE", "sentiment_score": 0.7}
+        if neg_count > pos_count:
+            return {"sentiment_label": "NEGATIVE", "sentiment_score": 0.7}
+        return {"sentiment_label": "NEUTRAL", "sentiment_score": 0.5}
+
+    def _fallback_style(self, text: str) -> Dict[str, Any]:
+        style_keywords = {
+            "anime": ["anime", "manga", "japanese", "kawaii"],
+            "realistic": ["realistic", "photorealistic", "photo", "real"],
+            "cartoon": ["cartoon", "comic", "toon"],
+            "digital art": ["digital", "cg", "computer"],
+            "painting": ["painting", "paint", "oil", "watercolor"],
+        }
+
+        text_lower = text.lower()
+        style_scores: Dict[str, int] = {}
+
+        for style, keywords in style_keywords.items():
+            score = sum(1 for keyword in keywords if keyword in text_lower)
+            if score > 0:
+                style_scores[style] = score
+
+        if style_scores:
+            best_style = max(style_scores, key=style_scores.get)
+            confidence = style_scores[best_style] / max(len(text.split()), 1)
+            return {
+                "predicted_style": best_style,
+                "style_confidence": min(confidence, 1.0),
+            }
+        return {"predicted_style": "unknown", "style_confidence": 0.0}
+
+
+__all__ = ["SentimentStyleAnalyzer", "SentimentStyleAnalyzerProtocol"]
+

--- a/backend/services/recommendations/components/text_features.py
+++ b/backend/services/recommendations/components/text_features.py
@@ -1,0 +1,78 @@
+"""Keyword extraction helpers for recommendation features."""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import Any, Dict, List, Sequence, Protocol
+
+
+class KeywordExtractorProtocol(Protocol):
+    """Minimal protocol for keyword extraction helpers."""
+
+    def extract(self, text: str) -> Dict[str, Sequence[Any]]:  # pragma: no cover - interface
+        """Return keyword strings and their scores for the provided text."""
+
+
+class KeywordExtractor(KeywordExtractorProtocol):
+    """Keyword extractor that prefers KeyBERT but falls back to heuristics."""
+
+    def __init__(self, *, logger: logging.Logger | None = None) -> None:
+        self._logger = logger or logging.getLogger(__name__)
+        self._model: Any | None = None
+
+    def extract(self, text: str) -> Dict[str, List[Any]]:
+        """Extract keywords for *text*, applying a robust fallback if necessary."""
+
+        if not text:
+            return {"extracted_keywords": [], "keyword_scores": []}
+
+        self._ensure_model()
+        if self._model == "fallback":
+            return self._fallback(text)
+
+        try:
+            keywords = self._model.extract_keywords(
+                text,
+                keyphrase_ngram_range=(1, 3),
+                stop_words="english",
+                top_k=10,
+            )
+            return {
+                "extracted_keywords": [kw[0] for kw in keywords],
+                "keyword_scores": [kw[1] for kw in keywords],
+            }
+        except Exception:  # pragma: no cover - defensive branch
+            self._logger.debug("Falling back to heuristic keyword extraction", exc_info=True)
+            return self._fallback(text)
+
+    def _ensure_model(self) -> None:
+        if self._model is not None:
+            return
+
+        try:
+            from keybert import KeyBERT
+
+            self._model = KeyBERT(model="sentence-transformers/all-mpnet-base-v2")
+            self._logger.info("KeyBERT loaded for keyword extraction")
+        except ImportError:
+            self._logger.debug("KeyBERT unavailable, using keyword fallback heuristics")
+            self._model = "fallback"
+
+    def _fallback(self, text: str) -> Dict[str, List[Any]]:
+        words = re.findall(r"\b\w+\b", text.lower())
+        word_freq: Dict[str, int] = {}
+        for word in words:
+            if len(word) > 3:
+                word_freq[word] = word_freq.get(word, 0) + 1
+
+        top_keywords = sorted(word_freq.items(), key=lambda x: x[1], reverse=True)[:10]
+
+        return {
+            "extracted_keywords": [kw[0] for kw in top_keywords],
+            "keyword_scores": [kw[1] / len(words) for kw in top_keywords] if words else [],
+        }
+
+
+__all__ = ["KeywordExtractor", "KeywordExtractorProtocol"]
+

--- a/tests/unit/python/test_recommendation_components.py
+++ b/tests/unit/python/test_recommendation_components.py
@@ -3,17 +3,40 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
+from pathlib import Path
 from types import SimpleNamespace
 import logging
+import sys
+import types
 
 import numpy as np
 import pytest
+
+# Avoid importing backend.services.__init__ which pulls heavy dependencies.
+if "backend.services" not in sys.modules:
+    services_stub = types.ModuleType("backend.services")
+    services_stub.__path__ = [
+        str(Path(__file__).resolve().parents[3] / "backend" / "services")
+    ]
+    from importlib.machinery import ModuleSpec
+
+    services_stub.__spec__ = ModuleSpec(
+        name="backend.services",
+        loader=None,
+        is_package=True,
+    )
+    sys.modules["backend.services"] = services_stub
 
 from backend.services.recommendations.components import (
     GPULoRAFeatureExtractor,
     LoRARecommendationEngine,
     LoRASemanticEmbedder,
 )
+from backend.services.recommendations.components.scoring import ScoreCalculator
+from backend.services.recommendations.components.sentiment_style import (
+    SentimentStyleAnalyzer,
+)
+from backend.services.recommendations.components.text_features import KeywordExtractor
 
 
 def test_fallback_embedder_generates_normalized_vectors() -> None:
@@ -66,8 +89,107 @@ class _FeatureExtractorStub:
         self.semantic_embedder = semantic_embedder
 
 
-def test_feature_extractor_uses_fallback_paths() -> None:
-    """Ensure fallback feature extraction logic populates expected metadata."""
+def test_keyword_extractor_uses_fallback_when_model_missing() -> None:
+    """KeyBERT is optional, and the heuristic fallback should still work."""
+
+    extractor = KeywordExtractor(logger=logging.getLogger("test_keyword_extractor"))
+    extractor._model = "fallback"
+    result = extractor.extract("Beautiful anime hero with vibrant colors and glowing eyes")
+
+    assert result["extracted_keywords"]
+    assert all(score <= 1.0 for score in result["keyword_scores"])
+
+
+def test_keyword_extractor_handles_empty_text() -> None:
+    """Empty strings should not raise and must return empty collections."""
+
+    extractor = KeywordExtractor(logger=logging.getLogger("test_keyword_empty"))
+    assert extractor.extract("") == {"extracted_keywords": [], "keyword_scores": []}
+
+
+def test_sentiment_style_analyzer_fallback_positive_signal() -> None:
+    """Positive adjectives should trigger the fallback positive sentiment."""
+
+    analyzer = SentimentStyleAnalyzer(device="cpu", logger=logging.getLogger("test_sentiment"))
+    analyzer._sentiment_pipeline = "fallback"
+    analyzer._style_pipeline = "fallback"
+    sentiment = analyzer.analyze_sentiment("This model is amazing and beautiful with perfect lighting")
+    style = analyzer.classify_style("Beautiful anime hero with vibrant colors")
+
+    assert sentiment["sentiment_label"] == "POSITIVE"
+    assert 0.0 < sentiment["sentiment_score"] <= 1.0
+    assert style["predicted_style"] in {"anime", "unknown"}
+
+
+def test_sentiment_style_analyzer_handles_neutral_text() -> None:
+    """Text without keywords should default to neutral and unknown style."""
+
+    analyzer = SentimentStyleAnalyzer(device="cpu", logger=logging.getLogger("test_sentiment_neutral"))
+    analyzer._sentiment_pipeline = "fallback"
+    analyzer._style_pipeline = "fallback"
+    sentiment = analyzer.analyze_sentiment("The quick brown fox jumps over the lazy dog")
+    style = analyzer.classify_style("The quick brown fox jumps over the lazy dog")
+
+    assert sentiment["sentiment_label"] == "NEUTRAL"
+    assert style["predicted_style"] == "unknown"
+
+
+def test_score_calculator_defaults_for_missing_stats() -> None:
+    """When metadata is missing the calculator should fall back to defaults."""
+
+    calculator = ScoreCalculator(logger=logging.getLogger("test_score_defaults"))
+    lora = SimpleNamespace(
+        stats=None,
+        tags=None,
+        sd_version=None,
+        author_username=None,
+        primary_file_size_kb=None,
+        published_at=None,
+        created_at=None,
+        nsfw_level=None,
+        supports_generation=False,
+    )
+
+    result = calculator.compute(lora)
+
+    assert result["quality_score"] == 0.5
+    assert result["tags_vector"] == [0.0] * 10
+    assert result["sd_version_vector"] == [0.0, 0.0, 0.0]
+    assert result["supports_generation"] == 0.0
+
+
+def test_score_calculator_populates_metrics_from_data() -> None:
+    """Provide realistic stats to ensure the calculator emits rich metrics."""
+
+    now = datetime.now(timezone.utc)
+    calculator = ScoreCalculator(logger=logging.getLogger("test_score_values"))
+    lora = SimpleNamespace(
+        stats={
+            "rating": 4.6,
+            "downloadCount": 2000,
+            "favoriteCount": 500,
+            "commentCount": 50,
+        },
+        tags=["anime", "portrait"],
+        sd_version="SDXL",
+        author_username="artist_name",
+        primary_file_size_kb=256000,
+        published_at=now,
+        created_at=now,
+        nsfw_level=4,
+        supports_generation=True,
+    )
+
+    result = calculator.compute(lora)
+
+    assert result["quality_score"] >= 0.0
+    assert result["sd_version_vector"] == [0.0, 0.0, 1.0]
+    assert result["supports_generation"] == 1.0
+    assert result["nsfw_level_normalized"] == pytest.approx(0.4)
+
+
+def test_feature_extractor_orchestrates_helpers() -> None:
+    """The feature extractor should orchestrate helpers in a predictable order."""
 
     embeddings = {
         "adapter": {
@@ -77,38 +199,76 @@ def test_feature_extractor_uses_fallback_paths() -> None:
         }
     }
     semantic_embedder = _SemanticEmbedderStub(embeddings)
+
+    class _KeywordExtractorFake:
+        def __init__(self) -> None:
+            self.calls: list[str] = []
+
+        def extract(self, text: str) -> dict[str, list[float]]:
+            self.calls.append(text)
+            return {"extracted_keywords": ["hero"], "keyword_scores": [0.8]}
+
+    class _SentimentStyleFake:
+        def __init__(self) -> None:
+            self.calls: list[str] = []
+
+        def analyze_sentiment(self, text: str) -> dict[str, float | str]:
+            self.calls.append(f"sentiment:{text}")
+            return {"sentiment_label": "POSITIVE", "sentiment_score": 0.9}
+
+        def classify_style(self, text: str) -> dict[str, float | str]:
+            self.calls.append(f"style:{text}")
+            return {"predicted_style": "anime", "style_confidence": 0.7}
+
+    class _ScoreCalculatorFake:
+        def __init__(self) -> None:
+            self.calls: list[str] = []
+
+        def compute(self, lora: SimpleNamespace) -> dict[str, float | list[float]]:
+            self.calls.append(lora.id)
+            return {
+                "quality_score": 0.75,
+                "tags_vector": [1.0] * 10,
+                "sd_version_vector": [1.0, 0.0, 0.0],
+                "author_vector": 0.5,
+                "community_engagement": 0.2,
+                "popularity_score": 0.3,
+                "file_size_normalized": 0.4,
+                "recency_score": 0.5,
+                "maturity_score": 0.6,
+                "nsfw_level_normalized": 0.0,
+                "supports_generation": 1.0,
+                "sd_compatibility_score": 0.8,
+                "user_activation_frequency": 0.0,
+                "user_success_rate": 0.5,
+                "recent_usage_trend": 0.0,
+            }
+
+    keyword_fake = _KeywordExtractorFake()
+    sentiment_fake = _SentimentStyleFake()
+    score_fake = _ScoreCalculatorFake()
+
     extractor = GPULoRAFeatureExtractor(
         device="cpu",
         semantic_embedder=semantic_embedder,
+        keyword_extractor=keyword_fake,
+        sentiment_style_analyzer=sentiment_fake,
+        score_calculator=score_fake,
         logger=logging.getLogger("test_feature_extractor"),
     )
 
-    extractor._keyword_extractor = "fallback"
-    extractor._sentiment_analyzer = "fallback"
-    extractor._style_classifier = "fallback"
-    extractor._load_advanced_models = lambda: None
-
     lora = SimpleNamespace(
         id="adapter",
-        description="Beautiful anime character with vibrant colors",
-        tags=["anime", "style"],
-        trained_words=["hero"],
-        triggers=["hero"],
-        activation_text=None,
-        archetype=None,
-        stats={
-            "downloadCount": 25,
-            "favoriteCount": 5,
-            "rating": 4.2,
-            "commentCount": 3,
-        },
-        primary_file_size_kb=51200,
-        published_at=datetime.now(timezone.utc),
-        created_at=datetime.now(timezone.utc),
+        description="Beautiful anime hero with vibrant colors",
+        stats=None,
+        tags=None,
+        sd_version="SD1.5",
+        author_username="tester",
+        primary_file_size_kb=None,
+        published_at=None,
+        created_at=None,
         nsfw_level=0,
         supports_generation=True,
-        sd_version="SD1.5",
-        author_username="test_author",
     )
 
     features = extractor.extract_advanced_features(lora)
@@ -116,11 +276,14 @@ def test_feature_extractor_uses_fallback_paths() -> None:
     assert features["semantic_embedding"].shape == (4,)
     assert features["artistic_embedding"].shape == (3,)
     assert features["technical_embedding"].shape == (2,)
-    assert features["extracted_keywords"]
+    assert features["extracted_keywords"] == ["hero"]
     assert features["sentiment_label"] == "POSITIVE"
-    assert features["predicted_style"] != ""
-    assert len(features["tags_vector"]) == 10
-    assert features["sd_compatibility_score"] == pytest.approx(0.8)
+    assert features["predicted_style"] == "anime"
+    assert features["quality_score"] == 0.75
+
+    assert keyword_fake.calls == [lora.description]
+    assert sentiment_fake.calls == [f"sentiment:{lora.description}", f"style:{lora.description}"]
+    assert score_fake.calls == ["adapter"]
 
 
 def test_recommendation_engine_applies_boosts() -> None:


### PR DESCRIPTION
## Summary
- split feature extraction responsibilities into dedicated keyword, sentiment/style, and scoring helpers
- refactored `GPULoRAFeatureExtractor` to orchestrate helpers with dependency injection defaults
- expanded unit tests to cover helper fallbacks and extractor orchestration behaviour

## Testing
- `pytest --confcutdir=tests/unit/python tests/unit/python/test_recommendation_components.py`


------
https://chatgpt.com/codex/tasks/task_e_68d1d1ac4d008329a6bce778b5502c8d