### PR TITLE
Refactor generation studio state and transport orchestration

### DIFF
--- a/app/frontend/src/composables/useGenerationUpdates.ts
+++ b/app/frontend/src/composables/useGenerationUpdates.ts
@@ -1,13 +1,13 @@
-import { onUnmounted, watch, type ComputedRef, type Ref } from 'vue';
+import { type ComputedRef, type Ref } from 'vue';
 import { storeToRefs } from 'pinia';
 
-import { useGenerationTransport, type GenerationNotificationAdapter } from '@/composables/useGenerationTransport';
+import type { GenerationNotificationAdapter } from '@/composables/useGenerationTransport';
 import {
-  DEFAULT_HISTORY_LIMIT,
   useGenerationConnectionStore,
   useGenerationQueueStore,
   useGenerationResultsStore,
 } from '@/stores/generation';
+import { createGenerationOrchestrator } from '@/services/generationOrchestrator';
 import type {
   GenerationQueueClient,
   GenerationWebSocketManager,
@@ -54,151 +54,21 @@ export const useGenerationUpdates = ({
   const resultsStore = useGenerationResultsStore();
   const connectionStore = useGenerationConnectionStore();
 
-  const { activeJobs, sortedActiveJobs, hasActiveJobs } = storeToRefs(queueStore);
+  const { activeJobs, sortedActiveJobs } = storeToRefs(queueStore);
   const { recentResults, historyLimit } = storeToRefs(resultsStore);
   const { isConnected, pollIntervalMs } = storeToRefs(connectionStore);
 
-  const transport = useGenerationTransport(
-    {
-      getBackendUrl: () => configuredBackendUrl.value,
-      queueClient: injectedQueueClient,
-      websocketManager: injectedWebsocketManager,
-      pollIntervalMs: pollIntervalMs.value,
-      logger: (...args: unknown[]) => {
-        notificationAdapter.debug?.(...args);
-      },
-    },
-    {
-      onSystemStatus: (payload) => {
-        connectionStore.applySystemStatusPayload(payload);
-      },
-      onQueueUpdate: (jobs) => {
-        queueStore.ingestQueue(jobs);
-      },
-      onProgress: (message) => {
-        queueStore.handleProgressMessage(message);
-      },
-      onComplete: (message) => {
-        const result = queueStore.handleCompletionMessage(message);
-        resultsStore.addResult(result);
-        return result;
-      },
-      onError: (message) => {
-        queueStore.handleErrorMessage(message);
-      },
-      onRecentResults: (results) => {
-        resultsStore.setResults(results);
-      },
-      onConnectionChange: (connected) => {
-        connectionStore.setConnectionState(connected);
-      },
-      shouldPollQueue: () => hasActiveJobs.value,
-      onNotify: (message, type = 'info') => {
-        notificationAdapter.notify(message, type);
-      },
-      logger: (...args: unknown[]) => {
-        notificationAdapter.debug?.(...args);
-      },
-    },
-  );
-
-  const loadSystemStatusData = (): Promise<void> => transport.refreshSystemStatus();
-  const loadActiveJobsData = (): Promise<void> => transport.refreshActiveJobs();
-  const loadRecentResultsData = (notifySuccess = false): Promise<void> =>
-    transport.refreshRecentResults(historyLimit.value, notifySuccess);
-
-  const initialize = async (): Promise<void> => {
-    const nextLimit = showHistory.value ? 50 : DEFAULT_HISTORY_LIMIT;
-    resultsStore.setHistoryLimit(nextLimit);
-    await transport.initializeUpdates(historyLimit.value);
-  };
-
-  const cleanup = (): void => {
-    transport.stopUpdates();
-  };
-
-  const startGeneration = async (
-    payload: GenerationRequestPayload,
-  ): Promise<GenerationStartResponse> => {
-    try {
-      const response = await transport.startGeneration(payload);
-
-      if (response.job_id) {
-        const createdAt = new Date().toISOString();
-        queueStore.enqueueJob({
-          id: response.job_id,
-          prompt: payload.prompt,
-          status: response.status,
-          progress: response.progress ?? 0,
-          startTime: createdAt,
-          created_at: createdAt,
-          width: payload.width,
-          height: payload.height,
-          steps: payload.steps,
-          total_steps: payload.steps,
-          cfg_scale: payload.cfg_scale,
-          seed: payload.seed,
-        });
-        notificationAdapter.notify('Generation started successfully', 'success');
-      }
-
-      return response;
-    } catch (error) {
-      notificationAdapter.notify('Error starting generation', 'error');
-      throw error;
-    }
-  };
-
-  const cancelJob = async (jobId: string): Promise<void> => {
-    try {
-      await transport.cancelJob(jobId);
-      queueStore.removeJob(jobId);
-    } catch (error) {
-      notificationAdapter.notify('Error cancelling generation', 'error');
-      throw error;
-    }
-  };
-
-  const clearQueue = async (): Promise<void> => {
-    const cancellableJobs = queueStore.getCancellableJobs();
-    if (cancellableJobs.length === 0) {
-      return;
-    }
-
-    await Promise.allSettled(cancellableJobs.map((job) => cancelJob(job.id)));
-  };
-
-  const deleteResult = async (resultId: string | number): Promise<void> => {
-    try {
-      await transport.deleteResult(resultId);
-      resultsStore.removeResult(resultId);
-    } catch (error) {
-      notificationAdapter.notify('Error deleting result', 'error');
-      throw error;
-    }
-  };
-
-  watch(showHistory, () => {
-    const nextLimit = showHistory.value ? 50 : DEFAULT_HISTORY_LIMIT;
-    resultsStore.setHistoryLimit(nextLimit);
-    void loadRecentResultsData();
-  });
-
-  watch(configuredBackendUrl, (next, previous) => {
-    if (next === previous) {
-      return;
-    }
-
-    transport.reconnectUpdates();
-    void transport.refreshAllData(historyLimit.value);
-  });
-
-  watch(pollIntervalMs, (next) => {
-    transport.setPollInterval(next);
-  });
-
-  onUnmounted(() => {
-    cleanup();
+  const orchestrator = createGenerationOrchestrator({
+    showHistory,
+    configuredBackendUrl,
+    notificationAdapter,
+    queueStore,
+    resultsStore,
+    connectionStore,
+    historyLimit,
+    pollIntervalMs,
+    queueClient: injectedQueueClient,
+    websocketManager: injectedWebsocketManager,
   });
 
   return {
@@ -206,15 +76,15 @@ export const useGenerationUpdates = ({
     recentResults,
     sortedActiveJobs,
     isConnected,
-    initialize,
-    cleanup,
-    loadSystemStatusData,
-    loadActiveJobsData,
-    loadRecentResultsData,
-    startGeneration,
-    cancelJob,
-    clearQueue,
-    deleteResult,
+    initialize: orchestrator.initialize,
+    cleanup: orchestrator.cleanup,
+    loadSystemStatusData: orchestrator.loadSystemStatusData,
+    loadActiveJobsData: orchestrator.loadActiveJobsData,
+    loadRecentResultsData: orchestrator.loadRecentResultsData,
+    startGeneration: orchestrator.startGeneration,
+    cancelJob: orchestrator.cancelJob,
+    clearQueue: orchestrator.clearQueue,
+    deleteResult: orchestrator.deleteResult,
   };
 };
 

--- a/app/frontend/src/services/generationOrchestrator.ts
+++ b/app/frontend/src/services/generationOrchestrator.ts
@@ -1,0 +1,218 @@
+import { onScopeDispose, watch, type Ref } from 'vue';
+import { storeToRefs } from 'pinia';
+
+import {
+  useGenerationTransport,
+  type GenerationNotificationAdapter,
+} from '@/composables/useGenerationTransport';
+import { DEFAULT_HISTORY_LIMIT } from '@/stores/generation/results';
+import type {
+  GenerationConnectionStore,
+  GenerationQueueStore,
+  GenerationResultsStore,
+} from '@/stores/generation';
+import type {
+  GenerationQueueClient,
+  GenerationWebSocketManager,
+} from '@/services/generationUpdates';
+import type {
+  GenerationJob,
+  GenerationRequestPayload,
+  GenerationStartResponse,
+} from '@/types';
+
+export interface GenerationOrchestratorOptions {
+  showHistory: Ref<boolean>;
+  configuredBackendUrl: Ref<string | null | undefined>;
+  notificationAdapter: GenerationNotificationAdapter;
+  queueStore: GenerationQueueStore;
+  resultsStore: GenerationResultsStore;
+  connectionStore: GenerationConnectionStore;
+  historyLimit: Ref<number>;
+  pollIntervalMs: Ref<number>;
+  queueClient?: GenerationQueueClient;
+  websocketManager?: GenerationWebSocketManager;
+}
+
+export interface GenerationOrchestrator {
+  initialize: () => Promise<void>;
+  cleanup: () => void;
+  loadSystemStatusData: () => Promise<void>;
+  loadActiveJobsData: () => Promise<void>;
+  loadRecentResultsData: (notifySuccess?: boolean) => Promise<void>;
+  startGeneration: (payload: GenerationRequestPayload) => Promise<GenerationStartResponse>;
+  cancelJob: (jobId: string) => Promise<void>;
+  clearQueue: () => Promise<void>;
+  deleteResult: (resultId: string | number) => Promise<void>;
+}
+
+export const createGenerationOrchestrator = ({
+  showHistory,
+  configuredBackendUrl,
+  notificationAdapter,
+  queueStore,
+  resultsStore,
+  connectionStore,
+  historyLimit,
+  pollIntervalMs,
+  queueClient,
+  websocketManager,
+}: GenerationOrchestratorOptions): GenerationOrchestrator => {
+  const { hasActiveJobs } = storeToRefs(queueStore);
+
+  const transport = useGenerationTransport(
+    {
+      getBackendUrl: () => configuredBackendUrl.value,
+      queueClient,
+      websocketManager,
+      pollIntervalMs: pollIntervalMs.value,
+      logger: (...args: unknown[]) => {
+        notificationAdapter.debug?.(...args);
+      },
+    },
+    {
+      onSystemStatus: (payload) => {
+        connectionStore.applySystemStatusPayload(payload);
+      },
+      onQueueUpdate: (jobs) => {
+        queueStore.ingestQueue(jobs);
+      },
+      onProgress: (message) => {
+        queueStore.handleProgressMessage(message);
+      },
+      onComplete: (message) => {
+        const result = queueStore.handleCompletionMessage(message);
+        resultsStore.addResult(result);
+        return result;
+      },
+      onError: (message) => {
+        queueStore.handleErrorMessage(message);
+      },
+      onRecentResults: (results) => {
+        resultsStore.setResults(results);
+      },
+      onConnectionChange: (connected) => {
+        connectionStore.setConnectionState(connected);
+      },
+      shouldPollQueue: () => hasActiveJobs.value,
+      onNotify: (message, type = 'info') => {
+        notificationAdapter.notify(message, type);
+      },
+      logger: (...args: unknown[]) => {
+        notificationAdapter.debug?.(...args);
+      },
+    },
+  );
+
+  const loadSystemStatusData = (): Promise<void> => transport.refreshSystemStatus();
+  const loadActiveJobsData = (): Promise<void> => transport.refreshActiveJobs();
+  const loadRecentResultsData = (notifySuccess = false): Promise<void> =>
+    transport.refreshRecentResults(historyLimit.value, notifySuccess);
+  const refreshAllData = (): Promise<void> => transport.refreshAllData(historyLimit.value);
+
+  const initialize = async (): Promise<void> => {
+    const nextLimit = showHistory.value ? 50 : DEFAULT_HISTORY_LIMIT;
+    resultsStore.setHistoryLimit(nextLimit);
+    await transport.initializeUpdates(historyLimit.value);
+  };
+
+  const cleanup = (): void => {
+    transport.stopUpdates();
+  };
+
+  const startGeneration = async (
+    payload: GenerationRequestPayload,
+  ): Promise<GenerationStartResponse> => {
+    try {
+      const response = await transport.startGeneration(payload);
+
+      if (response.job_id) {
+        const createdAt = new Date().toISOString();
+        queueStore.enqueueJob({
+          id: response.job_id,
+          prompt: payload.prompt,
+          status: response.status,
+          progress: response.progress ?? 0,
+          startTime: createdAt,
+          created_at: createdAt,
+          width: payload.width,
+          height: payload.height,
+          steps: payload.steps,
+          total_steps: payload.steps,
+          cfg_scale: payload.cfg_scale,
+          seed: payload.seed,
+        });
+        notificationAdapter.notify('Generation started successfully', 'success');
+      }
+
+      return response;
+    } catch (error) {
+      notificationAdapter.notify('Error starting generation', 'error');
+      throw error;
+    }
+  };
+
+  const cancelJob = async (jobId: string): Promise<void> => {
+    try {
+      await transport.cancelJob(jobId);
+      queueStore.removeJob(jobId);
+    } catch (error) {
+      notificationAdapter.notify('Error cancelling generation', 'error');
+      throw error;
+    }
+  };
+
+  const clearQueue = async (): Promise<void> => {
+    const cancellableJobs = queueStore.getCancellableJobs();
+    if (cancellableJobs.length === 0) {
+      return;
+    }
+
+    await Promise.allSettled(cancellableJobs.map((job: GenerationJob) => cancelJob(job.id)));
+  };
+
+  const deleteResult = async (resultId: string | number): Promise<void> => {
+    try {
+      await transport.deleteResult(resultId);
+      resultsStore.removeResult(resultId);
+    } catch (error) {
+      notificationAdapter.notify('Error deleting result', 'error');
+      throw error;
+    }
+  };
+
+  watch(showHistory, (next) => {
+    const nextLimit = next ? 50 : DEFAULT_HISTORY_LIMIT;
+    resultsStore.setHistoryLimit(nextLimit);
+    void loadRecentResultsData();
+  });
+
+  watch(configuredBackendUrl, (next, previous) => {
+    if (next === previous) {
+      return;
+    }
+
+    transport.reconnectUpdates();
+    void refreshAllData();
+  });
+
+  watch(pollIntervalMs, (next) => {
+    transport.setPollInterval(next);
+  });
+
+  onScopeDispose(() => {
+    transport.clear();
+  });
+
+  return {
+    initialize,
+    cleanup,
+    loadSystemStatusData,
+    loadActiveJobsData,
+    loadRecentResultsData,
+    startGeneration,
+    cancelJob,
+    clearQueue,
+    deleteResult,
+  };
+};

--- a/app/frontend/src/stores/generation/connection.ts
+++ b/app/frontend/src/stores/generation/connection.ts
@@ -64,3 +64,5 @@ export const useGenerationConnectionStore = defineStore('generation-connection',
     reset,
   };
 });
+
+export type GenerationConnectionStore = ReturnType<typeof useGenerationConnectionStore>;

--- a/app/frontend/src/stores/generation/form.ts
+++ b/app/frontend/src/stores/generation/form.ts
@@ -1,0 +1,88 @@
+import { ref } from 'vue';
+import { defineStore } from 'pinia';
+
+import type { GenerationFormState, GenerationResult } from '@/types';
+
+const DEFAULT_FORM_STATE: GenerationFormState = {
+  prompt: '',
+  negative_prompt: '',
+  steps: 20,
+  sampler_name: 'DPM++ 2M',
+  cfg_scale: 7.0,
+  width: 512,
+  height: 512,
+  seed: -1,
+  batch_size: 1,
+  batch_count: 1,
+  denoising_strength: null,
+};
+
+const createInitialParams = (): GenerationFormState => ({
+  ...DEFAULT_FORM_STATE,
+});
+
+export const useGenerationFormStore = defineStore('generation-form', () => {
+  const params = ref<GenerationFormState>(createInitialParams());
+  const isGenerating = ref(false);
+  const showHistory = ref(false);
+  const showModal = ref(false);
+  const selectedResult = ref<GenerationResult | null>(null);
+
+  const setGenerating = (value: boolean): void => {
+    isGenerating.value = value;
+  };
+
+  const setShowHistory = (value: boolean): void => {
+    showHistory.value = value;
+  };
+
+  const toggleHistory = (): void => {
+    showHistory.value = !showHistory.value;
+  };
+
+  const setShowModal = (value: boolean): void => {
+    showModal.value = value;
+    if (!value) {
+      selectedResult.value = null;
+    }
+  };
+
+  const selectResult = (result: GenerationResult | null): void => {
+    selectedResult.value = result;
+    showModal.value = result != null;
+  };
+
+  const updateParams = (updates: Partial<GenerationFormState>): void => {
+    params.value = { ...params.value, ...updates };
+  };
+
+  const resetParams = (): void => {
+    params.value = createInitialParams();
+  };
+
+  const reset = (): void => {
+    resetParams();
+    isGenerating.value = false;
+    showHistory.value = false;
+    showModal.value = false;
+    selectedResult.value = null;
+  };
+
+  return {
+    params,
+    isGenerating,
+    showHistory,
+    showModal,
+    selectedResult,
+    setGenerating,
+    setShowHistory,
+    toggleHistory,
+    setShowModal,
+    selectResult,
+    updateParams,
+    resetParams,
+    reset,
+  };
+});
+
+export type GenerationFormStore = ReturnType<typeof useGenerationFormStore>;

--- a/app/frontend/src/stores/generation/index.ts
+++ b/app/frontend/src/stores/generation/index.ts
@@ -1,3 +1,4 @@
 export * from './queue';
 export * from './results';
 export * from './connection';
+export * from './form';

--- a/app/frontend/src/stores/generation/queue.ts
+++ b/app/frontend/src/stores/generation/queue.ts
@@ -209,3 +209,5 @@ export const useGenerationQueueStore = defineStore('generation-queue', () => {
     reset,
   };
 });
+
+export type GenerationQueueStore = ReturnType<typeof useGenerationQueueStore>;

--- a/app/frontend/src/stores/generation/results.ts
+++ b/app/frontend/src/stores/generation/results.ts
@@ -55,3 +55,5 @@ export const useGenerationResultsStore = defineStore('generation-results', () =>
     reset,
   };
 });
+
+export type GenerationResultsStore = ReturnType<typeof useGenerationResultsStore>;


### PR DESCRIPTION
## Summary
- introduce a dedicated generation form Pinia store for prompt parameters and UI flags
- add a generation orchestrator service and wire `useGenerationStudio`/`useGenerationUpdates` through it
- update generation-related unit and integration tests to mock or exercise the orchestrator abstractions

## Testing
- npm run test:unit

------
https://chatgpt.com/codex/tasks/task_e_68d1f131098c832994065dc63a2c3317