### PR TITLE
Refactor SDNext backend around session and storage abstractions

### DIFF
--- a/backend/delivery/__init__.py
+++ b/backend/delivery/__init__.py
@@ -6,9 +6,8 @@ from .base import DeliveryBackend, GenerationBackend, delivery_registry
 from .cli import CLIDeliveryBackend
 from .http import HTTPDeliveryBackend
 from .http_client import DeliveryHTTPClient
-from .image_persistence import ImagePersistence
 from .sdnext import SDNextGenerationBackend
-from .sdnext_client import SDNextClient
+from .sdnext_client import SDNextSession
 from .storage import FileSystemImageStorage
 
 
@@ -26,15 +25,12 @@ def initialize_delivery_system() -> None:
         password=settings.SDNEXT_PASSWORD,
     )
     storage = FileSystemImageStorage(settings.SDNEXT_OUTPUT_DIR)
-    sdnext_client = SDNextClient(http_client)
-    image_persistence = ImagePersistence(storage)
+    sdnext_session = SDNextSession(http_client)
     delivery_registry.register_generation_backend(
         "sdnext",
         SDNextGenerationBackend(
-            http_client=http_client,
+            session=sdnext_session,
             storage=storage,
-            client=sdnext_client,
-            image_persistence=image_persistence,
         ),
     )
 

--- a/backend/delivery/image_persistence.py
+++ b/backend/delivery/image_persistence.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Iterable, List, Optional
+from typing import Iterable, List, Optional, cast
 
 from backend.core.config import settings
 
@@ -26,20 +26,28 @@ class ImagePersistence:
         save_images: bool,
         return_format: str,
     ) -> List[str]:
+        if hasattr(self._storage, "persist_images"):
+            storage = cast(ImageStorage, self._storage)
+            return await storage.persist_images(
+                images,
+                job_id,
+                save_images=save_images,
+                return_format=return_format,
+            )
+
         processed: List[str] = []
 
         for index, img_b64 in enumerate(images):
             try:
-                if return_format == "base64":
+                if return_format == "base64" and not save_images:
                     processed.append(img_b64)
-                elif return_format == "file_path" or save_images:
-                    file_path = await self._storage.save_image(img_b64, job_id, index)
-                    if return_format == "file_path":
-                        processed.append(file_path)
-                    else:
-                        processed.append(img_b64)
+                    continue
+
+                file_path = await self._storage.save_image(img_b64, job_id, index)
+
+                if return_format == "file_path":
+                    processed.append(file_path)
                 elif return_format == "url":
-                    file_path = await self._storage.save_image(img_b64, job_id, index)
                     processed.append(f"file://{file_path}")
                 else:
                     processed.append(img_b64)

--- a/backend/delivery/sdnext.py
+++ b/backend/delivery/sdnext.py
@@ -1,6 +1,7 @@
 """SDNext generation delivery implementation."""
 
-import asyncio
+from __future__ import annotations
+
 from typing import Any, Dict, Optional
 from uuid import uuid4
 
@@ -9,8 +10,7 @@ from backend.schemas import SDNextGenerationResult
 
 from .base import GenerationBackend
 from .http_client import DeliveryHTTPClient
-from .image_persistence import ImagePersistence
-from .sdnext_client import SDNextClient, SDNextClientError
+from .sdnext_client import SDNextSession
 from .storage import FileSystemImageStorage, ImageStorage
 
 
@@ -19,18 +19,18 @@ class SDNextGenerationBackend(GenerationBackend):
 
     def __init__(
         self,
-        http_client: Optional[DeliveryHTTPClient] = None,
-        storage: Optional[ImageStorage] = None,
         *,
-        client: Optional[SDNextClient] = None,
-        image_persistence: Optional[ImagePersistence] = None,
+        http_client: Optional[DeliveryHTTPClient] = None,
+        session: Optional[SDNextSession] = None,
+        storage: Optional[ImageStorage] = None,
     ) -> None:
         """Initialize SDNext backend."""
+
         self.timeout = settings.SDNEXT_TIMEOUT
         self.poll_interval = settings.SDNEXT_POLL_INTERVAL
 
-        if client is not None:
-            self._client = client
+        if session is not None:
+            self._session = session
         else:
             delivery_client = http_client or DeliveryHTTPClient(
                 settings.SDNEXT_BASE_URL,
@@ -38,26 +38,23 @@ class SDNextGenerationBackend(GenerationBackend):
                 username=settings.SDNEXT_USERNAME,
                 password=settings.SDNEXT_PASSWORD,
             )
-            self._client = SDNextClient(delivery_client)
+            self._session = SDNextSession(delivery_client)
 
-        if image_persistence is not None:
-            self._image_persistence = image_persistence
-        else:
-            storage_backend = storage
-            if storage_backend is None:
-                storage_backend = FileSystemImageStorage(settings.SDNEXT_OUTPUT_DIR)
-            self._image_persistence = ImagePersistence(storage_backend)
+        self._storage = storage or FileSystemImageStorage(settings.SDNEXT_OUTPUT_DIR)
 
     async def close(self) -> None:
         """Close HTTP session."""
-        await self._client.close()
+
+        await self._session.close()
 
     def is_available(self) -> bool:
         """Check if SDNext backend is configured and available."""
-        return self._client.is_configured()
+
+        return self._session.is_configured()
 
     async def generate_image(self, prompt: str, params: Dict[str, Any]) -> SDNextGenerationResult:
         """Generate image using SDNext API."""
+
         job_id = str(uuid4())
 
         if not self.is_available():
@@ -67,50 +64,34 @@ class SDNextGenerationBackend(GenerationBackend):
                 error_message="SDNext backend not configured",
             )
 
-        # Check if API is available
-        if not await self._client.health_check():
+        if not await self._session.health_check():
             return SDNextGenerationResult(
                 job_id=job_id,
                 status="failed",
                 error_message="SDNext API not available",
             )
 
-        # Extract generation parameters
         gen_params = params.get("generation_params", {})
         save_images = params.get("save_images", True)
         return_format = params.get("return_format", "base64")
 
+        submission = await self._session.submit_txt2img(prompt, gen_params)
+        if not submission.ok:
+            return SDNextGenerationResult(
+                job_id=job_id,
+                status="failed",
+                error_message=submission.error or "SDNext request failed",
+            )
+
+        payload = submission.data or {}
+        images_payload = payload.get("images") or []
+
         try:
-            result = await self._client.submit_txt2img(prompt, gen_params)
-
-            images = []
-            if "images" in result and result["images"]:
-                images = await self._image_persistence.persist_images(
-                    result["images"],
-                    job_id,
-                    save_images=save_images,
-                    return_format=return_format,
-                )
-
-            return SDNextGenerationResult(
-                job_id=job_id,
-                status="completed",
-                images=images,
-                progress=1.0,
-                generation_info=result.get("info", {}),
-            )
-
-        except asyncio.TimeoutError:
-            return SDNextGenerationResult(
-                job_id=job_id,
-                status="failed",
-                error_message=f"Generation timeout after {self.timeout}s",
-            )
-        except SDNextClientError as exc:
-            return SDNextGenerationResult(
-                job_id=job_id,
-                status="failed",
-                error_message=str(exc),
+            images = await self._storage.persist_images(
+                images_payload,
+                job_id,
+                save_images=save_images,
+                return_format=return_format,
             )
         except Exception as exc:  # pragma: no cover - defensive
             return SDNextGenerationResult(
@@ -119,8 +100,17 @@ class SDNextGenerationBackend(GenerationBackend):
                 error_message=str(exc),
             )
 
+        return SDNextGenerationResult(
+            job_id=job_id,
+            status="completed",
+            images=images,
+            progress=1.0,
+            generation_info=payload.get("info", {}),
+        )
+
     async def check_progress(self, job_id: str) -> SDNextGenerationResult:
         """Check generation progress."""
+
         if not self.is_available():
             return SDNextGenerationResult(
                 job_id=job_id,
@@ -128,33 +118,27 @@ class SDNextGenerationBackend(GenerationBackend):
                 error_message="SDNext backend not configured",
             )
 
-        try:
-            progress_data = await self._client.get_progress()
-            progress = progress_data.get("progress", 0.0)
-
-            status = "running" if progress < 1.0 else "completed"
-            if progress == 0.0:
-                status = "pending"
-
-            return SDNextGenerationResult(
-                job_id=job_id,
-                status=status,
-                progress=progress,
-            )
-
-        except SDNextClientError:
+        response = await self._session.get_progress()
+        if not response.ok or response.data is None:
             return SDNextGenerationResult(
                 job_id=job_id,
                 status="unknown",
-                error_message="Could not check progress",
+                error_message=response.error or "Could not check progress",
             )
-        except Exception as exc:
-            return SDNextGenerationResult(
-                job_id=job_id,
-                status="failed",
-                error_message=str(exc),
-            )
+
+        progress = response.data.get("progress", 0.0)
+        status = "running" if progress < 1.0 else "completed"
+        if progress == 0.0:
+            status = "pending"
+
+        return SDNextGenerationResult(
+            job_id=job_id,
+            status=status,
+            progress=progress,
+        )
 
     def get_backend_name(self) -> str:
         """Return backend name."""
+
         return "sdnext"
+

--- a/backend/delivery/storage.py
+++ b/backend/delivery/storage.py
@@ -4,16 +4,28 @@ from __future__ import annotations
 
 import asyncio
 import base64
+import logging
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Optional
+from typing import Iterable, List, Optional
+
+
+logger = logging.getLogger(__name__)
 
 
 class ImageStorage:
-    """Abstract interface for persisting generated images."""
+    """Abstract interface for persisting and formatting generated images."""
 
-    async def save_image(self, img_b64: str, job_id: str, index: int) -> str:
-        """Persist a base64-encoded image and return its location."""
+    async def persist_images(
+        self,
+        images: Iterable[str],
+        job_id: str,
+        *,
+        save_images: bool,
+        return_format: str,
+    ) -> List[str]:
+        """Persist images and return processed representations."""
+
         raise NotImplementedError
 
 
@@ -21,7 +33,46 @@ class FileSystemImageStorage(ImageStorage):
     """Store generated images on the local filesystem."""
 
     def __init__(self, output_dir: Optional[str] = None) -> None:
-        self._output_dir = Path(output_dir) if output_dir else Path.cwd() / "generated_images"
+        self._output_dir = (
+            Path(output_dir)
+            if output_dir
+            else Path.cwd() / "generated_images"
+        )
+
+    async def persist_images(
+        self,
+        images: Iterable[str],
+        job_id: str,
+        *,
+        save_images: bool,
+        return_format: str,
+    ) -> List[str]:
+        processed: List[str] = []
+
+        for index, img_b64 in enumerate(images):
+            if return_format == "base64" and not save_images:
+                processed.append(img_b64)
+                continue
+
+            needs_file = save_images or return_format in {"file_path", "url"}
+            if not needs_file:
+                processed.append(img_b64)
+                continue
+
+            try:
+                file_path = await self.save_image(img_b64, job_id, index)
+            except Exception:  # pragma: no cover - defensive logging
+                logger.exception("Error persisting image %s for job %s", index, job_id)
+                continue
+
+            if return_format == "file_path":
+                processed.append(file_path)
+            elif return_format == "url":
+                processed.append(f"file://{file_path}")
+            else:
+                processed.append(img_b64)
+
+        return processed
 
     async def save_image(self, img_b64: str, job_id: str, index: int) -> str:
         output_path = self._output_dir

--- a/tests/test_sdnext_backend.py
+++ b/tests/test_sdnext_backend.py
@@ -2,31 +2,35 @@
 
 from __future__ import annotations
 
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Iterable, Optional
 
 import pytest
 
 from backend.delivery.sdnext import SDNextGenerationBackend
-from backend.delivery.sdnext_client import SDNextClientError
+from backend.delivery.sdnext_client import SDNextResponse
 
 
-class FakeSDNextClient:
+class FakeSDNextSession:
     def __init__(
         self,
         *,
         configured: bool = True,
         healthy: bool = True,
-        submit_result: Optional[Dict[str, Any]] = None,
-        submit_error: Optional[Exception] = None,
-        progress_result: Optional[Dict[str, Any]] = None,
-        progress_error: Optional[Exception] = None,
+        submit_response: Optional[SDNextResponse] = None,
+        progress_response: Optional[SDNextResponse] = None,
     ) -> None:
         self._configured = configured
         self._healthy = healthy
-        self._submit_result = submit_result or {"images": [], "info": {}}
-        self._submit_error = submit_error
-        self._progress_result = progress_result or {"progress": 0.0}
-        self._progress_error = progress_error
+        self._submit_response = submit_response or SDNextResponse(
+            ok=True,
+            status=200,
+            data={"images": [], "info": {}},
+        )
+        self._progress_response = progress_response or SDNextResponse(
+            ok=True,
+            status=200,
+            data={"progress": 0.0},
+        )
 
         self.submissions: list[tuple[str, Dict[str, Any]]] = []
         self.progress_checks = 0
@@ -41,95 +45,133 @@ class FakeSDNextClient:
     async def health_check(self) -> bool:
         return self._healthy
 
-    async def submit_txt2img(self, prompt: str, generation_params: Dict[str, Any]) -> Dict[str, Any]:
+    async def submit_txt2img(
+        self,
+        prompt: str,
+        generation_params: Dict[str, Any],
+    ) -> SDNextResponse:
         self.submissions.append((prompt, generation_params))
-        if self._submit_error is not None:
-            raise self._submit_error
-        return self._submit_result
+        return self._submit_response
 
-    async def get_progress(self) -> Dict[str, Any]:
+    async def get_progress(self) -> SDNextResponse:
         self.progress_checks += 1
-        if self._progress_error is not None:
-            raise self._progress_error
-        return self._progress_result
+        return self._progress_response
 
 
-class FakeImagePersistence:
-    def __init__(self, processed: Optional[list[str]] = None) -> None:
+class FakeImageStorage:
+    def __init__(self, processed: Optional[list[str]] = None, *, fail: bool = False) -> None:
         self.processed = processed or []
+        self.fail = fail
         self.calls: list[tuple[list[str], str, bool, str]] = []
 
     async def persist_images(
         self,
-        images: list[str],
+        images: Iterable[str],
         job_id: str,
         *,
         save_images: bool,
         return_format: str,
     ) -> list[str]:
         self.calls.append((list(images), job_id, save_images, return_format))
+        if self.fail:
+            raise RuntimeError("storage failure")
         return self.processed
 
 
 @pytest.mark.anyio("asyncio")
 async def test_generate_image_success_flow() -> None:
-    client = FakeSDNextClient(submit_result={"images": ["raw"], "info": {"mode": "test"}})
-    persistence = FakeImagePersistence(processed=["processed"])
-    backend = SDNextGenerationBackend(client=client, image_persistence=persistence)
+    session = FakeSDNextSession(
+        submit_response=SDNextResponse(
+            ok=True,
+            status=200,
+            data={"images": ["raw"], "info": {"mode": "test"}},
+        )
+    )
+    storage = FakeImageStorage(processed=["processed"])
+    backend = SDNextGenerationBackend(session=session, storage=storage)
 
-    result = await backend.generate_image("Prompt", {"generation_params": {"steps": 5}, "return_format": "base64"})
+    result = await backend.generate_image(
+        "Prompt",
+        {"generation_params": {"steps": 5}, "return_format": "base64"},
+    )
 
     assert result.status == "completed"
     assert result.images == ["processed"]
     assert result.generation_info == {"mode": "test"}
-    assert client.submissions == [("Prompt", {"steps": 5})]
-    assert len(persistence.calls) == 1
-    _, job_id, _, return_format = persistence.calls[0]
+    assert session.submissions == [("Prompt", {"steps": 5})]
+    assert len(storage.calls) == 1
+    images, job_id, _, return_format = storage.calls[0]
+    assert images == ["raw"]
     assert result.job_id == job_id
     assert return_format == "base64"
 
 
 @pytest.mark.anyio("asyncio")
-async def test_generate_image_client_error() -> None:
-    client = FakeSDNextClient(submit_error=SDNextClientError("bad request", status=400))
-    backend = SDNextGenerationBackend(client=client, image_persistence=FakeImagePersistence())
+async def test_generate_image_session_error() -> None:
+    session = FakeSDNextSession(
+        submit_response=SDNextResponse(ok=False, status=500, error="bad request"),
+    )
+    backend = SDNextGenerationBackend(session=session, storage=FakeImageStorage())
 
     result = await backend.generate_image("Prompt", {"generation_params": {}})
 
     assert result.status == "failed"
-    assert "bad request" in (result.error_message or "")
+    assert result.error_message == "bad request"
 
 
 @pytest.mark.anyio("asyncio")
 async def test_generate_image_health_check_failure() -> None:
-    client = FakeSDNextClient(healthy=False)
-    backend = SDNextGenerationBackend(client=client, image_persistence=FakeImagePersistence())
+    session = FakeSDNextSession(healthy=False)
+    backend = SDNextGenerationBackend(session=session, storage=FakeImageStorage())
 
     result = await backend.generate_image("Prompt", {"generation_params": {}})
 
     assert result.status == "failed"
     assert result.error_message == "SDNext API not available"
-    assert client.submissions == []
+    assert session.submissions == []
+
+
+@pytest.mark.anyio("asyncio")
+async def test_generate_image_storage_failure_returns_error() -> None:
+    session = FakeSDNextSession(
+        submit_response=SDNextResponse(
+            ok=True,
+            status=200,
+            data={"images": ["img"], "info": {}},
+        )
+    )
+    storage = FakeImageStorage(fail=True)
+    backend = SDNextGenerationBackend(session=session, storage=storage)
+
+    result = await backend.generate_image("Prompt", {"generation_params": {}})
+
+    assert result.status == "failed"
+    assert "storage failure" in (result.error_message or "")
 
 
 @pytest.mark.anyio("asyncio")
 async def test_progress_success_and_status_translation() -> None:
-    client = FakeSDNextClient(progress_result={"progress": 1.0})
-    backend = SDNextGenerationBackend(client=client, image_persistence=FakeImagePersistence())
+    session = FakeSDNextSession(
+        progress_response=SDNextResponse(ok=True, status=200, data={"progress": 1.0})
+    )
+    backend = SDNextGenerationBackend(session=session, storage=FakeImageStorage())
 
     result = await backend.check_progress("job-1")
 
     assert result.status == "completed"
     assert result.progress == 1.0
-    assert client.progress_checks == 1
+    assert session.progress_checks == 1
 
 
 @pytest.mark.anyio("asyncio")
-async def test_progress_client_error_produces_unknown_status() -> None:
-    client = FakeSDNextClient(progress_error=SDNextClientError("oops", status=500))
-    backend = SDNextGenerationBackend(client=client, image_persistence=FakeImagePersistence())
+async def test_progress_session_error_produces_unknown_status() -> None:
+    session = FakeSDNextSession(
+        progress_response=SDNextResponse(ok=False, status=500, error="oops"),
+    )
+    backend = SDNextGenerationBackend(session=session, storage=FakeImageStorage())
 
     result = await backend.check_progress("job-2")
 
     assert result.status == "unknown"
-    assert result.error_message == "Could not check progress"
+    assert result.error_message == "oops"
+


### PR DESCRIPTION
## Summary
- introduce an SDNextSession helper that wraps the delivery HTTP client and returns structured responses
- extend the filesystem storage strategy to persist and format images directly and wire it into the SDNext backend
- update the SDNext backend and tests to rely on the new collaborators and cover error handling paths

## Testing
- pytest tests/test_sdnext_backend.py tests/unit/delivery/test_sdnext_client.py tests/unit/delivery/test_image_persistence.py

------
https://chatgpt.com/codex/tasks/task_e_68d1f1333ee883299d38d4272f91ce99