### PR TITLE
Refactor LoraCard into presentational subcomponents

### DIFF
--- a/app/frontend/src/components/LoraCard.vue
+++ b/app/frontend/src/components/LoraCard.vue
@@ -1,279 +1,50 @@
 <template>
-  <div class="lora-card-wrapper" :class="viewMode === 'grid' ? 'lora-card-grid' : 'lora-card-list'">
-    
-    <div v-if="viewMode === 'grid'" class="lora-card-grid-inner">
-      <!-- Selection checkbox for bulk mode -->
-      <div v-show="bulkMode" class="lora-card-checkbox-container">
-        <input 
-          type="checkbox" 
-          :checked="isSelected"
-          @change="$emit('toggle-selection', lora.id)"
-          class="form-checkbox"
-        >
-      </div>
-      
-      <!-- LoRA Image/Preview -->
-      <div class="lora-card-preview-container">
-        <div class="lora-card-preview-aspect">
-          <img 
-            v-if="lora.preview_image" 
-            :src="lora.preview_image" 
-            :alt="lora.name"
-            class="lora-card-preview-image"
-          >
-          <div v-else class="lora-card-preview-placeholder">
-            <svg class="w-8 h-8 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" 
-                    d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10"></path>
-            </svg>
-          </div>
-        </div>
-        
-        <!-- Status Badge -->
-        <div class="lora-card-status-badge-container">
-          <span :class="['status-badge', isActive ? 'status-active' : 'status-inactive']">
-            {{ isActive ? 'Active' : 'Inactive' }}
-          </span>
-        </div>
-        
-        <!-- Quality Score -->
-        <div v-if="typeof lora.quality_score === 'number'" class="lora-card-quality-score-container">
-          <div class="quality-score-badge">
-            <span class="text-white text-xs">⭐ {{ lora.quality_score?.toFixed(1) }}</span>
-          </div>
-        </div>
-      </div>
-      
-      <!-- Card Content -->
-      <div class="lora-card-content">
-        <!-- Header -->
-        <div class="lora-card-header">
-          <h3 class="lora-card-title">
-            {{ lora.name }}
-          </h3>
-          <!-- Quick Actions Dropdown -->
-          <div class="relative">
-            <button 
-              @click="showActions = !showActions" 
-              class="lora-card-actions-btn"
-              aria-haspopup="menu"
-              :aria-expanded="showActions"
-              aria-label="Open actions menu"
-            >
-              <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 20 20">
-                <path d="M10 6a2 2 0 110-4 2 2 0 010 4zM10 12a2 2 0 110-4 2 2 0 010 4zM10 18a2 2 0 110-4 2 2 0 010 4z"></path>
-              </svg>
-            </button>
-            <div 
-              v-show="showActions" 
-              ref="actionsMenuRef"
-              class="lora-card-actions-menu"
-              role="menu"
-              aria-label="LoRA actions"
-            >
-              <div class="py-1">
-                <a :href="`/loras/${lora.id}`" class="lora-card-menu-item">
-                  View Details
-                </a>
-                <button @click="toggleActive" class="lora-card-menu-item w-full text-left">
-                  {{ lora.active ? 'Deactivate' : 'Activate' }}
-                </button>
-                <button @click="getRecommendations" class="lora-card-menu-item w-full text-left">
-                  Find Similar
-                </button>
-                <button @click="generatePreview" class="lora-card-menu-item w-full text-left">
-                  Generate Preview
-                </button>
-                <div class="lora-card-menu-divider"></div>
-                <button @click="deleteLoraHandler" class="lora-card-menu-item-danger w-full text-left">
-                  Delete
-                </button>
-              </div>
-            </div>
-          </div>
-        </div>
-        
-        <!-- Version and Type -->
-        <div class="lora-card-meta">
-          <span v-if="lora.version" class="text-xs text-gray-500">v{{ lora.version }}</span>
-          <span v-if="lora.type" class="tag tag-blue">
-            {{ lora.type }}
-          </span>
-        </div>
-        
-        <!-- Description -->
-        <p v-if="lora.description" class="lora-card-description">
-          {{ lora.description }}
-        </p>
-        
-        <!-- Tags -->
-        <div v-if="(lora.tags?.length ?? 0) > 0" class="lora-card-tags">
-          <span v-for="tag in (lora.tags ?? []).slice(0, 3)" :key="tag" class="tag">
-            {{ tag }}
-          </span>
-          <span v-if="(lora.tags?.length ?? 0) > 3" class="text-xs text-gray-500">
-            +{{ (lora.tags?.length ?? 0) - 3 }} more
-          </span>
-        </div>
-        
-        <!-- Weight Control -->
-        <div v-if="isActive" class="lora-card-weight-control">
-          <label class="form-label text-xs">Weight</label>
-          <input 
-            type="range" 
-            v-model.number="weight" 
-            @input="updateWeight"
-            min="0" max="2" step="0.1" 
-            class="form-range w-full"
-          >
-          <div class="flex justify-between text-xs text-gray-500">
-            <span>0</span>
-            <span class="font-medium">{{ weight }}</span>
-            <span>2.0</span>
-          </div>
-        </div>
-        
-        <!-- Action Buttons -->
-        <div class="lora-card-actions">
-          <button 
-            @click="toggleActive" 
-            :class="lora.active ? 'btn-secondary' : 'btn-primary'"
-            class="btn flex-1"
-          >
-            {{ lora.active ? 'Deactivate' : 'Activate' }}
-          </button>
-          <button @click="getRecommendations" class="btn btn-secondary px-3">
-            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" 
-                    d="M13 10V3L4 14h7v7l9-11h-7z"></path>
-            </svg>
-          </button>
-        </div>
-      </div>
-    </div>
-
-    <!-- List View -->
-    <div v-else class="lora-card-list-inner">
-      <div class="p-4">
-        <div class="flex items-center space-x-4">
-          <!-- Selection checkbox for bulk mode -->
-          <div v-show="bulkMode">
-            <input 
-              type="checkbox" 
-              :checked="isSelected"
-              @change="$emit('toggle-selection', lora.id)"
-              class="form-checkbox"
-            >
-          </div>
-          
-          <!-- Thumbnail -->
-          <div class="flex-shrink-0">
-            <div class="lora-card-list-thumbnail">
-              <img 
-                v-if="lora.preview_image" 
-                :src="lora.preview_image" 
-                :alt="lora.name"
-                class="w-full h-full object-cover"
-              >
-              <div v-else class="lora-card-preview-placeholder">
-                <svg class="w-6 h-6 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" 
-                        d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10"></path>
-                </svg>
-              </div>
-            </div>
-          </div>
-          
-          <!-- Content -->
-          <div class="flex-1 min-w-0">
-            <div class="flex items-center justify-between">
-              <div class="flex items-center space-x-3">
-                <h3 class="lora-card-title text-sm">
-                  {{ lora.name }}
-                </h3>
-                <span v-if="lora.version" class="text-xs text-gray-500">v{{ lora.version }}</span>
-                <span :class="['status-badge', lora.active ? 'status-active' : 'status-inactive']">
-                  {{ lora.active ? 'Active' : 'Inactive' }}
-                </span>
-              </div>
-              
-              <!-- Weight Control (if active) -->
-              <div v-if="isActive" class="flex items-center space-x-3">
-                <div class="flex items-center space-x-2">
-                  <span class="text-xs text-gray-600">Weight:</span>
-                  <input 
-                    type="range" 
-                    v-model.number="weight" 
-                    @input="updateWeight"
-                    min="0" max="2" step="0.1" 
-                    class="w-20"
-                  >
-                  <span class="text-xs font-medium w-8">{{ weight }}</span>
-                </div>
-              </div>
-            </div>
-            
-            <!-- Description and Tags -->
-            <div class="mt-1 flex items-center space-x-4">
-              <p v-if="lora.description" class="lora-card-description text-sm flex-1">
-                {{ lora.description }}
-              </p>
-              
-              <div v-if="(lora.tags?.length ?? 0) > 0" class="flex space-x-1">
-                <span v-for="tag in (lora.tags ?? []).slice(0, 2)" :key="tag" class="tag">
-                  {{ tag }}
-                </span>
-                <span v-if="(lora.tags?.length ?? 0) > 2" class="text-xs text-gray-500">
-                  +{{ (lora.tags?.length ?? 0) - 2 }}
-                </span>
-              </div>
-            </div>
-          </div>
-          
-          <!-- Actions -->
-          <div class="flex items-center space-x-2">
-            <button 
-              @click="toggleActive" 
-              :class="lora.active ? 'btn-secondary' : 'btn-primary'"
-              class="btn btn-sm"
-            >
-              {{ lora.active ? 'Deactivate' : 'Activate' }}
-            </button>
-            <a :href="`/loras/${lora.id}`" class="text-blue-600 hover:text-blue-800 text-sm font-medium">
-              View →
-            </a>
-          </div>
-        </div>
-      </div>
-    </div>
+  <div class="lora-card-wrapper" :class="viewClass">
+    <LoraCardGrid
+      v-if="isGridView"
+      :card="cardViewModel"
+      :bulk-mode="bulkMode"
+      :is-selected="isSelected"
+      :is-active="isActive"
+      :weight="weight"
+      @toggle-selection="emit('toggle-selection', $event)"
+      @toggle-active="handleToggleActive"
+      @recommendations="handleRecommendations"
+      @generate-preview="handleGeneratePreview"
+      @delete="handleDelete"
+      @change-weight="handleWeightChange"
+    />
+    <LoraCardList
+      v-else
+      :card="cardViewModel"
+      :bulk-mode="bulkMode"
+      :is-selected="isSelected"
+      :is-active="isActive"
+      :weight="weight"
+      @toggle-selection="emit('toggle-selection', $event)"
+      @toggle-active="handleToggleActive"
+      @change-weight="handleWeightChange"
+    />
   </div>
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted, onUnmounted, ref, watch } from 'vue';
-import { useBackendBase } from '@/utils/backend';
-import {
-  buildRecommendationsUrl,
-  deleteLora as deleteLoraRequest,
-  triggerPreviewGeneration,
-  toggleLoraActiveState,
-  updateLoraWeight,
-} from '@/services/loraService';
-import type {
-  LoraGallerySelectionState,
-  LoraListItem,
-  LoraUpdatePayload,
-} from '@/types';
+import { computed, toRef } from 'vue';
+import LoraCardGrid from './LoraCardGrid.vue';
+import LoraCardList from './LoraCardList.vue';
+import { useLoraCardActions } from '@/composables/useLoraCardActions';
+import type { LoraGallerySelectionState, LoraListItem, LoraUpdatePayload } from '@/types';
 
-type NotificationType = 'success' | 'error' | 'warning' | 'info';
-
-type WindowWithExtras = Window & {
-  htmx?: {
-    trigger: (target: Element | Document, event: string, detail?: unknown) => void;
-  };
-  DevLogger?: {
-    error?: (...args: unknown[]) => void;
-  };
+type LoraCardViewModel = {
+  id: string;
+  name: string;
+  version?: string | null;
+  type?: string | null;
+  description?: string | null;
+  previewImage?: string | null;
+  tags: string[];
+  detailsUrl: string;
+  qualityScore: number | null;
 };
 
 const props = withDefaults(defineProps<{
@@ -288,129 +59,43 @@ const props = withDefaults(defineProps<{
 });
 
 const emit = defineEmits<{
-  'toggle-selection': [string];
-  update: [LoraUpdatePayload];
-  delete: [string];
+  (e: 'toggle-selection', id: string): void;
+  (e: 'update', payload: LoraUpdatePayload): void;
+  (e: 'delete', id: string): void;
 }>();
 
-const windowExtras = window as WindowWithExtras;
+const loraRef = toRef(props, 'lora');
 
-const apiBaseUrl = useBackendBase();
-
-// Local state
-const showActions = ref(false);
-const actionsMenuRef = ref<HTMLDivElement | null>(null);
-const weight = ref<number>(props.lora.weight ?? 1.0);
-const isActive = ref<boolean>(Boolean(props.lora.active));
-
-const showNotification = (message: string, type: NotificationType = 'info') => {
-  if (windowExtras.htmx) {
-    windowExtras.htmx.trigger(document.body, 'show-notification', {
-      detail: { message, type },
-    });
-  }
-};
-
-// Watch for prop changes to sync local state
-watch(
-  () => props.lora.active,
-  (newActive) => {
-    isActive.value = Boolean(newActive);
-  },
-);
-
-watch(
-  () => props.lora.weight,
-  (newWeight) => {
-    if (typeof newWeight === 'number') {
-      weight.value = newWeight;
-    }
-  },
-);
-
-// Click outside handler
-const handleClickOutside = (event: MouseEvent) => {
-  const target = event.target;
-  if (actionsMenuRef.value && target instanceof Node && !actionsMenuRef.value.contains(target)) {
-    showActions.value = false;
-  }
-};
-
-// Methods
-const updateWeight = async () => {
-  try {
-    const updated = await updateLoraWeight(apiBaseUrl.value, props.lora.id, weight.value);
-    const nextWeight = updated?.weight ?? weight.value;
-    weight.value = nextWeight;
-    emit('update', {
-      id: props.lora.id,
-      weight: nextWeight,
-      type: 'weight',
-    });
-  } catch (error) {
-    windowExtras.DevLogger?.error?.('Failed to update LoRA weight:', error);
-    showNotification('Failed to update weight.', 'error');
-    weight.value = props.lora.weight ?? weight.value;
-  }
-};
-
-const toggleActive = async () => {
-  try {
-    const nextState = !isActive.value;
-    await toggleLoraActiveState(apiBaseUrl.value, props.lora.id, nextState);
-    isActive.value = nextState;
-    emit('update', {
-      id: props.lora.id,
-      active: nextState,
-      type: 'active',
-    });
-  } catch (error) {
-    windowExtras.DevLogger?.error?.('Failed to toggle LoRA active state:', error);
-    showNotification('Failed to toggle active state.', 'error');
-  }
-};
-
-const getRecommendations = () => {
-  try {
-    const targetUrl = buildRecommendationsUrl(props.lora.id);
-    window.location.href = targetUrl;
-  } catch (error) {
-    windowExtras.DevLogger?.error?.('Error navigating to recommendations:', error);
-    showNotification('Unable to open recommendations.', 'error');
-  }
-};
-
-const generatePreview = async () => {
-  try {
-    await triggerPreviewGeneration(apiBaseUrl.value, props.lora.id);
-    showNotification('Preview generation started.', 'info');
-  } catch (error) {
-    windowExtras.DevLogger?.error?.('Preview generation not available:', error);
-    showNotification('Preview generation not available yet.', 'info');
-  }
-};
-
-const deleteLoraHandler = async () => {
-  if (!confirm(`Are you sure you want to delete "${props.lora.name}"?`)) {
-    return;
-  }
-
-  try {
-    await deleteLoraRequest(apiBaseUrl.value, props.lora.id);
-    emit('delete', props.lora.id);
-    showNotification('LoRA deleted.', 'success');
-  } catch (error) {
-    windowExtras.DevLogger?.error?.('Error deleting LoRA:', error);
-    showNotification('Error deleting LoRA.', 'error');
-  }
-};
-
-// Lifecycle
-onMounted(() => {
-  document.addEventListener('click', handleClickOutside);
+const {
+  isActive,
+  weight,
+  detailsUrl,
+  qualityScore,
+  handleToggleActive,
+  handleWeightChange,
+  handleRecommendations,
+  handleGeneratePreview,
+  handleDelete,
+} = useLoraCardActions({
+  lora: loraRef,
+  emitUpdate: (payload) => emit('update', payload),
+  emitDelete: (id) => emit('delete', id),
 });
 
-onUnmounted(() => {
-  document.removeEventListener('click', handleClickOutside);
-});
+const cardViewModel = computed<LoraCardViewModel>(() => ({
+  id: loraRef.value.id,
+  name: loraRef.value.name,
+  version: loraRef.value.version,
+  type: loraRef.value.type,
+  description: loraRef.value.description,
+  previewImage: loraRef.value.preview_image,
+  tags: loraRef.value.tags ?? [],
+  detailsUrl: detailsUrl.value,
+  qualityScore: qualityScore.value,
+}));
+
+const isGridView = computed(() => props.viewMode === 'grid');
+const viewClass = computed(() => (isGridView.value ? 'lora-card-grid' : 'lora-card-list'));
+const bulkMode = computed(() => Boolean(props.bulkMode));
+const isSelected = computed(() => Boolean(props.isSelected));
 </script>

--- a/app/frontend/src/components/LoraCardGrid.vue
+++ b/app/frontend/src/components/LoraCardGrid.vue
@@ -1,0 +1,220 @@
+<template>
+  <div class="lora-card-grid-inner">
+    <div v-show="bulkMode" class="lora-card-checkbox-container">
+      <input
+        type="checkbox"
+        :checked="isSelected"
+        @change="emit('toggle-selection', card.id)"
+        class="form-checkbox"
+      >
+    </div>
+
+    <div class="lora-card-preview-container">
+      <div class="lora-card-preview-aspect">
+        <img
+          v-if="card.previewImage"
+          :src="card.previewImage"
+          :alt="card.name"
+          class="lora-card-preview-image"
+        >
+        <div v-else class="lora-card-preview-placeholder">
+          <svg class="w-8 h-8 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                  d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10" />
+          </svg>
+        </div>
+      </div>
+
+      <div class="lora-card-status-badge-container">
+        <span :class="['status-badge', isActive ? 'status-active' : 'status-inactive']">
+          {{ isActive ? 'Active' : 'Inactive' }}
+        </span>
+      </div>
+
+      <div v-if="typeof card.qualityScore === 'number'" class="lora-card-quality-score-container">
+        <div class="quality-score-badge">
+          <span class="text-white text-xs">⭐ {{ card.qualityScore?.toFixed(1) }}</span>
+        </div>
+      </div>
+    </div>
+
+    <div class="lora-card-content">
+      <div class="lora-card-header">
+        <h3 class="lora-card-title">
+          {{ card.name }}
+        </h3>
+        <div ref="actionsContainerRef" class="relative">
+          <button
+            @click="toggleActions"
+            class="lora-card-actions-btn"
+            aria-haspopup="menu"
+            :aria-expanded="showActions"
+            aria-label="Open actions menu"
+          >
+            <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 20 20">
+              <path d="M10 6a2 2 0 110-4 2 2 0 010 4zM10 12a2 2 0 110-4 2 2 0 010 4zM10 18a2 2 0 110-4 2 2 0 010 4z" />
+            </svg>
+          </button>
+          <div
+            v-show="showActions"
+            class="lora-card-actions-menu"
+            role="menu"
+            aria-label="LoRA actions"
+          >
+            <div class="py-1">
+              <a :href="card.detailsUrl" class="lora-card-menu-item">
+                View Details
+              </a>
+              <button @click="handleAction('toggle-active')" class="lora-card-menu-item w-full text-left">
+                {{ isActive ? 'Deactivate' : 'Activate' }}
+              </button>
+              <button @click="handleAction('recommendations')" class="lora-card-menu-item w-full text-left">
+                Find Similar
+              </button>
+              <button @click="handleAction('generate-preview')" class="lora-card-menu-item w-full text-left">
+                Generate Preview
+              </button>
+              <div class="lora-card-menu-divider" />
+              <button @click="handleAction('delete')" class="lora-card-menu-item-danger w-full text-left">
+                Delete
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="lora-card-meta">
+        <span v-if="card.version" class="text-xs text-gray-500">v{{ card.version }}</span>
+        <span v-if="card.type" class="tag tag-blue">
+          {{ card.type }}
+        </span>
+      </div>
+
+      <p v-if="card.description" class="lora-card-description">
+        {{ card.description }}
+      </p>
+
+      <div v-if="card.tags.length > 0" class="lora-card-tags">
+        <span v-for="tag in card.tags.slice(0, 3)" :key="tag" class="tag">
+          {{ tag }}
+        </span>
+        <span v-if="card.tags.length > 3" class="text-xs text-gray-500">
+          +{{ card.tags.length - 3 }} more
+        </span>
+      </div>
+
+      <div v-if="isActive" class="lora-card-weight-control">
+        <label class="form-label text-xs">Weight</label>
+        <input
+          type="range"
+          :value="weight"
+          @input="onWeightInput"
+          min="0"
+          max="2"
+          step="0.1"
+          class="form-range w-full"
+        >
+        <div class="flex justify-between text-xs text-gray-500">
+          <span>0</span>
+          <span class="font-medium">{{ weight }}</span>
+          <span>2.0</span>
+        </div>
+      </div>
+
+      <div class="lora-card-actions">
+        <button
+          @click="emit('toggle-active')"
+          :class="isActive ? 'btn-secondary' : 'btn-primary'"
+          class="btn flex-1"
+        >
+          {{ isActive ? 'Deactivate' : 'Activate' }}
+        </button>
+        <button @click="emit('recommendations')" class="btn btn-secondary px-3">
+          <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                  d="M13 10V3L4 14h7v7l9-11h-7z" />
+          </svg>
+        </button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { onMounted, onUnmounted, ref } from 'vue';
+
+type LoraCardViewModel = {
+  id: string;
+  name: string;
+  version?: string | null;
+  type?: string | null;
+  description?: string | null;
+  previewImage?: string | null;
+  tags: string[];
+  detailsUrl: string;
+  qualityScore: number | null;
+};
+
+const props = defineProps<{
+  card: LoraCardViewModel;
+  bulkMode: boolean;
+  isSelected: boolean;
+  isActive: boolean;
+  weight: number;
+}>();
+
+const emit = defineEmits<{
+  (e: 'toggle-selection', id: string): void;
+  (e: 'toggle-active'): void;
+  (e: 'recommendations'): void;
+  (e: 'generate-preview'): void;
+  (e: 'delete'): void;
+  (e: 'change-weight', value: number): void;
+}>();
+
+const showActions = ref(false);
+const actionsContainerRef = ref<HTMLDivElement | null>(null);
+
+const toggleActions = () => {
+  showActions.value = !showActions.value;
+};
+
+const closeActions = () => {
+  showActions.value = false;
+};
+
+const handleClickOutside = (event: MouseEvent) => {
+  const target = event.target;
+  if (target instanceof Node && actionsContainerRef.value && !actionsContainerRef.value.contains(target)) {
+    closeActions();
+  }
+};
+
+const onWeightInput = (event: Event) => {
+  const target = event.target as HTMLInputElement | null;
+  if (!target) return;
+  const nextWeight = Number.parseFloat(target.value);
+  emit('change-weight', Number.isFinite(nextWeight) ? nextWeight : props.weight);
+};
+
+const handleAction = (action: 'toggle-active' | 'recommendations' | 'generate-preview' | 'delete') => {
+  closeActions();
+  if (action === 'toggle-active') {
+    emit('toggle-active');
+  } else if (action === 'recommendations') {
+    emit('recommendations');
+  } else if (action === 'generate-preview') {
+    emit('generate-preview');
+  } else {
+    emit('delete');
+  }
+};
+
+onMounted(() => {
+  document.addEventListener('click', handleClickOutside);
+});
+
+onUnmounted(() => {
+  document.removeEventListener('click', handleClickOutside);
+});
+</script>

--- a/app/frontend/src/components/LoraCardList.vue
+++ b/app/frontend/src/components/LoraCardList.vue
@@ -1,0 +1,126 @@
+<template>
+  <div class="lora-card-list-inner">
+    <div class="p-4">
+      <div class="flex items-center space-x-4">
+        <div v-show="bulkMode">
+          <input
+            type="checkbox"
+            :checked="isSelected"
+            @change="emit('toggle-selection', card.id)"
+            class="form-checkbox"
+          >
+        </div>
+
+        <div class="flex-shrink-0">
+          <div class="lora-card-list-thumbnail">
+            <img
+              v-if="card.previewImage"
+              :src="card.previewImage"
+              :alt="card.name"
+              class="w-full h-full object-cover"
+            >
+            <div v-else class="lora-card-preview-placeholder">
+              <svg class="w-6 h-6 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                      d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10" />
+              </svg>
+            </div>
+          </div>
+        </div>
+
+        <div class="flex-1 min-w-0">
+          <div class="flex items-center justify-between">
+            <div class="flex items-center space-x-3">
+              <h3 class="lora-card-title text-sm">
+                {{ card.name }}
+              </h3>
+              <span v-if="card.version" class="text-xs text-gray-500">v{{ card.version }}</span>
+              <span :class="['status-badge', isActive ? 'status-active' : 'status-inactive']">
+                {{ isActive ? 'Active' : 'Inactive' }}
+              </span>
+            </div>
+
+            <div v-if="isActive" class="flex items-center space-x-3">
+              <div class="flex items-center space-x-2">
+                <span class="text-xs text-gray-600">Weight:</span>
+                <input
+                  type="range"
+                  :value="weight"
+                  @input="onWeightInput"
+                  min="0"
+                  max="2"
+                  step="0.1"
+                  class="w-20"
+                >
+                <span class="text-xs font-medium w-8">{{ weight }}</span>
+              </div>
+            </div>
+          </div>
+
+          <div class="mt-1 flex items-center space-x-4">
+            <p v-if="card.description" class="lora-card-description text-sm flex-1">
+              {{ card.description }}
+            </p>
+
+            <div v-if="card.tags.length > 0" class="flex space-x-1">
+              <span v-for="tag in card.tags.slice(0, 2)" :key="tag" class="tag">
+                {{ tag }}
+              </span>
+              <span v-if="card.tags.length > 2" class="text-xs text-gray-500">
+                +{{ card.tags.length - 2 }}
+              </span>
+            </div>
+          </div>
+        </div>
+
+        <div class="flex items-center space-x-2">
+          <button
+            @click="emit('toggle-active')"
+            :class="isActive ? 'btn-secondary' : 'btn-primary'"
+            class="btn btn-sm"
+          >
+            {{ isActive ? 'Deactivate' : 'Activate' }}
+          </button>
+          <a :href="card.detailsUrl" class="text-blue-600 hover:text-blue-800 text-sm font-medium">
+            View →
+          </a>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+type LoraCardViewModel = {
+  id: string;
+  name: string;
+  version?: string | null;
+  type?: string | null;
+  description?: string | null;
+  previewImage?: string | null;
+  tags: string[];
+  detailsUrl: string;
+  qualityScore: number | null;
+};
+
+const props = defineProps<{
+  card: LoraCardViewModel;
+  bulkMode: boolean;
+  isSelected: boolean;
+  isActive: boolean;
+  weight: number;
+}>();
+
+const emit = defineEmits<{
+  (e: 'toggle-selection', id: string): void;
+  (e: 'toggle-active'): void;
+  (e: 'change-weight', value: number): void;
+}>();
+
+const onWeightInput = (event: Event) => {
+  const target = event.target as HTMLInputElement | null;
+  if (!target) return;
+  const nextWeight = Number.parseFloat(target.value);
+  emit('change-weight', Number.isFinite(nextWeight) ? nextWeight : props.weight);
+};
+</script>

--- a/app/frontend/src/composables/useLoraCardActions.ts
+++ b/app/frontend/src/composables/useLoraCardActions.ts
@@ -1,0 +1,137 @@
+import { computed, ref, watch, type Ref } from 'vue';
+import { useBackendBase } from '@/utils/backend';
+import {
+  buildRecommendationsUrl,
+  deleteLora as deleteLoraRequest,
+  toggleLoraActiveState,
+  triggerPreviewGeneration,
+  updateLoraWeight,
+} from '@/services/loraService';
+import type { LoraListItem, LoraUpdatePayload } from '@/types';
+
+type NotificationType = 'success' | 'error' | 'warning' | 'info';
+
+type WindowWithExtras = Window & {
+  htmx?: {
+    trigger: (target: Element | Document, event: string, detail?: unknown) => void;
+  };
+  DevLogger?: {
+    error?: (...args: unknown[]) => void;
+  };
+};
+
+type UseLoraCardActionsOptions = {
+  lora: Ref<LoraListItem>;
+  emitUpdate: (payload: LoraUpdatePayload) => void;
+  emitDelete: (id: string) => void;
+};
+
+const windowExtras = window as WindowWithExtras;
+
+const showNotification = (message: string, type: NotificationType = 'info') => {
+  if (windowExtras.htmx) {
+    windowExtras.htmx.trigger(document.body, 'show-notification', {
+      detail: { message, type },
+    });
+  }
+};
+
+export const useLoraCardActions = ({ lora, emitUpdate, emitDelete }: UseLoraCardActionsOptions) => {
+  const apiBaseUrl = useBackendBase();
+
+  const weight = ref<number>(lora.value.weight ?? 1.0);
+  const isActive = ref<boolean>(Boolean(lora.value.active));
+
+  watch(
+    () => lora.value.weight,
+    (nextWeight) => {
+      if (typeof nextWeight === 'number') {
+        weight.value = nextWeight;
+      }
+    },
+  );
+
+  watch(
+    () => lora.value.active,
+    (nextActive) => {
+      isActive.value = Boolean(nextActive);
+    },
+  );
+
+  const detailsUrl = computed(() => `/loras/${lora.value.id}`);
+  const qualityScore = computed(() => (typeof lora.value.quality_score === 'number' ? lora.value.quality_score : null));
+
+  const handleToggleActive = async () => {
+    try {
+      const nextState = !isActive.value;
+      await toggleLoraActiveState(apiBaseUrl.value, lora.value.id, nextState);
+      isActive.value = nextState;
+      emitUpdate({ id: lora.value.id, active: nextState, type: 'active' });
+    } catch (error) {
+      windowExtras.DevLogger?.error?.('Failed to toggle LoRA active state:', error);
+      showNotification('Failed to toggle active state.', 'error');
+    }
+  };
+
+  const handleWeightChange = async (nextWeight: number) => {
+    weight.value = nextWeight;
+
+    try {
+      const updated = await updateLoraWeight(apiBaseUrl.value, lora.value.id, nextWeight);
+      const resolvedWeight = updated?.weight ?? nextWeight;
+      weight.value = resolvedWeight;
+      emitUpdate({ id: lora.value.id, weight: resolvedWeight, type: 'weight' });
+    } catch (error) {
+      windowExtras.DevLogger?.error?.('Failed to update LoRA weight:', error);
+      showNotification('Failed to update weight.', 'error');
+      weight.value = lora.value.weight ?? weight.value;
+    }
+  };
+
+  const handleRecommendations = () => {
+    try {
+      const targetUrl = buildRecommendationsUrl(lora.value.id);
+      window.location.href = targetUrl;
+    } catch (error) {
+      windowExtras.DevLogger?.error?.('Error navigating to recommendations:', error);
+      showNotification('Unable to open recommendations.', 'error');
+    }
+  };
+
+  const handleGeneratePreview = async () => {
+    try {
+      await triggerPreviewGeneration(apiBaseUrl.value, lora.value.id);
+      showNotification('Preview generation started.', 'info');
+    } catch (error) {
+      windowExtras.DevLogger?.error?.('Preview generation not available:', error);
+      showNotification('Preview generation not available yet.', 'info');
+    }
+  };
+
+  const handleDelete = async () => {
+    if (!confirm(`Are you sure you want to delete "${lora.value.name}"?`)) {
+      return;
+    }
+
+    try {
+      await deleteLoraRequest(apiBaseUrl.value, lora.value.id);
+      emitDelete(lora.value.id);
+      showNotification('LoRA deleted.', 'success');
+    } catch (error) {
+      windowExtras.DevLogger?.error?.('Error deleting LoRA:', error);
+      showNotification('Error deleting LoRA.', 'error');
+    }
+  };
+
+  return {
+    isActive,
+    weight,
+    detailsUrl,
+    qualityScore,
+    handleToggleActive,
+    handleWeightChange,
+    handleRecommendations,
+    handleGeneratePreview,
+    handleDelete,
+  };
+};


### PR DESCRIPTION
## Summary
- split the LoraCard UI into dedicated grid/list presentational components that accept view models and emit events
- extract shared API and notification handling into a new useLoraCardActions composable
- refactor the main LoraCard component to orchestrate the composable and subcomponents, reducing template duplication

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d1fe1a37208329a7af541dc7abd3ea