### PR TITLE
Refactor generation transport into queue client and socket hooks

### DIFF
--- a/app/frontend/src/composables/useGenerationQueueClient.ts
+++ b/app/frontend/src/composables/useGenerationQueueClient.ts
@@ -1,0 +1,185 @@
+import { ref, shallowRef } from 'vue';
+
+import {
+  createGenerationQueueClient,
+  DEFAULT_POLL_INTERVAL,
+  type GenerationQueueClient,
+} from '@/services/generationUpdates';
+import type {
+  GenerationRequestPayload,
+  GenerationResult,
+  GenerationStartResponse,
+  NotificationType,
+  SystemStatusPayload,
+  SystemStatusState,
+} from '@/types';
+import type { GenerationJobInput } from '@/stores/generation';
+
+const ensureArray = <T>(value: unknown): T[] => (Array.isArray(value) ? value : []);
+
+interface QueueClientOptions {
+  getBackendUrl: () => string | null | undefined;
+  queueClient?: GenerationQueueClient;
+  pollIntervalMs?: number;
+}
+
+interface QueueClientCallbacks {
+  onSystemStatus?: (payload: SystemStatusPayload | Partial<SystemStatusState>) => void;
+  onQueueUpdate?: (jobs: GenerationJobInput[]) => void;
+  onRecentResults?: (results: GenerationResult[]) => void;
+  shouldPollQueue?: () => boolean;
+  onNotify?: (message: string, type?: NotificationType) => void;
+  logger?: (...args: unknown[]) => void;
+}
+
+export const useGenerationQueueClient = (
+  options: QueueClientOptions,
+  callbacks: QueueClientCallbacks,
+) => {
+  const queueClientRef = shallowRef<GenerationQueueClient | null>(options.queueClient ?? null);
+  const pollInterval = ref(options.pollIntervalMs ?? DEFAULT_POLL_INTERVAL);
+  const pollTimer = ref<number | null>(null);
+
+  const logDebug = (...args: unknown[]): void => {
+    if (typeof callbacks.logger === 'function') {
+      callbacks.logger(...args);
+    }
+  };
+
+  const notify = (message: string, type: NotificationType = 'info'): void => {
+    callbacks.onNotify?.(message, type);
+  };
+
+  const getQueueClient = (): GenerationQueueClient => {
+    if (!queueClientRef.value) {
+      queueClientRef.value = createGenerationQueueClient({
+        getBackendUrl: options.getBackendUrl,
+      });
+    }
+    return queueClientRef.value;
+  };
+
+  const refreshSystemStatus = async (): Promise<void> => {
+    try {
+      const status = await getQueueClient().fetchSystemStatus();
+      if (status) {
+        callbacks.onSystemStatus?.(status);
+      }
+    } catch (error) {
+      console.error('Failed to refresh system status:', error);
+      throw error;
+    }
+  };
+
+  const refreshActiveJobs = async (): Promise<void> => {
+    try {
+      const active = await getQueueClient().fetchActiveJobs();
+      callbacks.onQueueUpdate?.(ensureArray<GenerationJobInput>(active));
+    } catch (error) {
+      console.error('Failed to refresh active jobs:', error);
+      throw error;
+    }
+  };
+
+  const refreshRecentResults = async (limit: number, notifySuccess = false): Promise<void> => {
+    try {
+      const recent = await getQueueClient().fetchRecentResults(limit);
+      callbacks.onRecentResults?.(ensureArray(recent));
+      if (notifySuccess) {
+        notify('Results refreshed', 'success');
+      }
+    } catch (error) {
+      console.error('Failed to refresh recent results:', error);
+      if (notifySuccess) {
+        notify('Failed to refresh results', 'error');
+      }
+      throw error;
+    }
+  };
+
+  const refreshAllData = async (historyLimit: number): Promise<void> => {
+    await Promise.all([
+      refreshSystemStatus(),
+      refreshActiveJobs(),
+      refreshRecentResults(historyLimit),
+    ]);
+  };
+
+  const startPolling = (): void => {
+    if (typeof window === 'undefined' || pollTimer.value != null) {
+      return;
+    }
+
+    pollTimer.value = window.setInterval(async () => {
+      try {
+        if (callbacks.shouldPollQueue?.()) {
+          await refreshActiveJobs();
+        }
+        await refreshSystemStatus();
+      } catch (error) {
+        console.error('Failed to refresh generation data during polling:', error);
+        logDebug('Queue polling cycle failed', error);
+      }
+    }, pollInterval.value);
+  };
+
+  const stopPolling = (): void => {
+    if (typeof window === 'undefined' || pollTimer.value == null) {
+      return;
+    }
+
+    window.clearInterval(pollTimer.value);
+    pollTimer.value = null;
+  };
+
+  const setPollInterval = (nextInterval: number): void => {
+    const numeric = Math.floor(Number(nextInterval));
+    pollInterval.value = Number.isFinite(numeric) && numeric > 0 ? numeric : DEFAULT_POLL_INTERVAL;
+
+    if (pollTimer.value != null) {
+      stopPolling();
+      startPolling();
+    }
+  };
+
+  const initialize = async (historyLimit: number): Promise<void> => {
+    await refreshAllData(historyLimit);
+    startPolling();
+  };
+
+  const startGeneration = async (
+    payload: GenerationRequestPayload,
+  ): Promise<GenerationStartResponse> => getQueueClient().startGeneration(payload);
+
+  const cancelJob = async (jobId: string): Promise<void> => {
+    await getQueueClient().cancelJob(jobId);
+    notify('Generation cancelled', 'success');
+  };
+
+  const deleteResult = async (resultId: string | number): Promise<void> => {
+    await getQueueClient().deleteResult(resultId);
+    notify('Result deleted', 'success');
+  };
+
+  const clear = (): void => {
+    stopPolling();
+    queueClientRef.value = null;
+  };
+
+  return {
+    pollInterval,
+    setPollInterval,
+    initialize,
+    stopPolling,
+    refreshSystemStatus,
+    refreshActiveJobs,
+    refreshRecentResults,
+    refreshAllData,
+    startGeneration,
+    cancelJob,
+    deleteResult,
+    clear,
+  };
+};
+
+export type UseGenerationQueueClientReturn = ReturnType<typeof useGenerationQueueClient>;

--- a/app/frontend/src/composables/useGenerationSocketBridge.ts
+++ b/app/frontend/src/composables/useGenerationSocketBridge.ts
@@ -1,0 +1,97 @@
+import { shallowRef } from 'vue';
+
+import {
+  createGenerationWebSocketManager,
+  type GenerationWebSocketManager,
+} from '@/services/generationUpdates';
+import type {
+  GenerationCompleteMessage,
+  GenerationErrorMessage,
+  GenerationProgressMessage,
+  SystemStatusPayload,
+  SystemStatusState,
+} from '@/types';
+import type { GenerationJobInput } from '@/stores/generation';
+
+const ensureArray = <T>(value: unknown): T[] => (Array.isArray(value) ? value : []);
+
+interface SocketBridgeOptions {
+  getBackendUrl: () => string | null | undefined;
+  websocketManager?: GenerationWebSocketManager;
+  logger?: (...args: unknown[]) => void;
+}
+
+interface SocketBridgeCallbacks {
+  onProgress?: (message: GenerationProgressMessage) => void;
+  onComplete?: (message: GenerationCompleteMessage) => void;
+  onError?: (message: GenerationErrorMessage) => void;
+  onQueueUpdate?: (jobs: GenerationJobInput[]) => void;
+  onSystemStatus?: (payload: SystemStatusPayload | Partial<SystemStatusState>) => void;
+  onConnectionChange?: (connected: boolean) => void;
+}
+
+export const useGenerationSocketBridge = (
+  options: SocketBridgeOptions,
+  callbacks: SocketBridgeCallbacks,
+) => {
+  const websocketManagerRef = shallowRef<GenerationWebSocketManager | null>(
+    options.websocketManager ?? null,
+  );
+
+  const ensureWebSocketManager = (): GenerationWebSocketManager => {
+    if (websocketManagerRef.value) {
+      return websocketManagerRef.value;
+    }
+
+    websocketManagerRef.value = createGenerationWebSocketManager({
+      getBackendUrl: options.getBackendUrl,
+      logger: options.logger,
+      onProgress: (message) => {
+        callbacks.onProgress?.(message);
+      },
+      onComplete: (message) => {
+        callbacks.onComplete?.(message);
+      },
+      onError: (message) => {
+        callbacks.onError?.(message);
+      },
+      onQueueUpdate: (jobs) => {
+        callbacks.onQueueUpdate?.(ensureArray<GenerationJobInput>(jobs));
+      },
+      onSystemStatus: (payload) => {
+        callbacks.onSystemStatus?.(payload);
+      },
+      onConnectionChange: (connected) => {
+        callbacks.onConnectionChange?.(connected);
+      },
+    });
+
+    return websocketManagerRef.value;
+  };
+
+  const start = (): void => {
+    ensureWebSocketManager().start();
+  };
+
+  const stop = (): void => {
+    websocketManagerRef.value?.stop();
+  };
+
+  const reconnect = (): void => {
+    ensureWebSocketManager().reconnect();
+  };
+
+  const clear = (): void => {
+    stop();
+    websocketManagerRef.value = null;
+  };
+
+  return {
+    start,
+    stop,
+    reconnect,
+    clear,
+  };
+};
+
+export type UseGenerationSocketBridgeReturn = ReturnType<typeof useGenerationSocketBridge>;


### PR DESCRIPTION
## Summary
- extract REST polling and refresh handling into a new `useGenerationQueueClient` composable
- create a `useGenerationSocketBridge` hook that encapsulates websocket lifecycle wiring
- update `useGenerationTransport` to compose the new hooks and keep the orchestrator API unchanged

## Testing
- npm run test:unit

------
https://chatgpt.com/codex/tasks/task_e_68d1fe22b0f88329934647c84bf0ac10