### PR TITLE
Refactor generation studio composable responsibilities

### DIFF
--- a/app/frontend/src/composables/useGenerationOrchestrator.ts
+++ b/app/frontend/src/composables/useGenerationOrchestrator.ts
@@ -1,0 +1,95 @@
+import { storeToRefs } from 'pinia'
+
+import type { GenerationNotificationAdapter } from '@/composables/useGenerationTransport'
+import { createGenerationOrchestrator } from '@/services/generationOrchestrator'
+import type {
+  GenerationQueueClient,
+  GenerationWebSocketManager,
+} from '@/services/generationUpdates'
+import {
+  useGenerationConnectionStore,
+  useGenerationFormStore,
+  useGenerationQueueStore,
+  useGenerationResultsStore,
+} from '@/stores/generation'
+import { useSettingsStore } from '@/stores/settings'
+import type { GenerationJob, GenerationRequestPayload } from '@/types'
+
+export interface UseGenerationOrchestratorOptions {
+  notify: GenerationNotificationAdapter['notify']
+  debug?: GenerationNotificationAdapter['debug']
+  queueClient?: GenerationQueueClient
+  websocketManager?: GenerationWebSocketManager
+}
+
+export const useGenerationOrchestrator = ({
+  notify,
+  debug,
+  queueClient,
+  websocketManager,
+}: UseGenerationOrchestratorOptions) => {
+  const formStore = useGenerationFormStore()
+  const queueStore = useGenerationQueueStore()
+  const resultsStore = useGenerationResultsStore()
+  const connectionStore = useGenerationConnectionStore()
+  const settingsStore = useSettingsStore()
+
+  const { showHistory } = storeToRefs(formStore)
+  const { backendUrl: configuredBackendUrl } = storeToRefs(settingsStore)
+  const { historyLimit, recentResults } = storeToRefs(resultsStore)
+  const { pollIntervalMs, systemStatus, isConnected } = storeToRefs(connectionStore)
+  const { activeJobs, sortedActiveJobs } = storeToRefs(queueStore)
+
+  const notificationAdapter: GenerationNotificationAdapter = {
+    notify,
+    debug,
+  }
+
+  const orchestrator = createGenerationOrchestrator({
+    showHistory,
+    configuredBackendUrl,
+    notificationAdapter,
+    queueStore,
+    resultsStore,
+    connectionStore,
+    historyLimit,
+    pollIntervalMs,
+    queueClient,
+    websocketManager,
+  })
+
+  const startGeneration = async (payload: GenerationRequestPayload) =>
+    orchestrator.startGeneration(payload)
+
+  const cancelJob = async (jobId: string) => orchestrator.cancelJob(jobId)
+
+  const clearQueue = async () => orchestrator.clearQueue()
+
+  const refreshResults = async (notifySuccess = false) =>
+    orchestrator.loadRecentResultsData(notifySuccess)
+
+  const deleteResult = async (resultId: string | number) =>
+    orchestrator.deleteResult(resultId)
+
+  const canCancelJob = (job: GenerationJob): boolean => queueStore.isJobCancellable(job)
+
+  return {
+    activeJobs,
+    sortedActiveJobs,
+    recentResults,
+    systemStatus,
+    isConnected,
+    initialize: orchestrator.initialize,
+    cleanup: orchestrator.cleanup,
+    loadSystemStatus: orchestrator.loadSystemStatusData,
+    loadActiveJobs: orchestrator.loadActiveJobsData,
+    startGeneration,
+    cancelJob,
+    clearQueue,
+    refreshResults,
+    deleteResult,
+    canCancelJob,
+  }
+}
+
+export type UseGenerationOrchestratorReturn = ReturnType<typeof useGenerationOrchestrator>

--- a/app/frontend/src/composables/useGenerationStudio.ts
+++ b/app/frontend/src/composables/useGenerationStudio.ts
@@ -1,207 +1,124 @@
-import { onMounted } from 'vue';
-import { storeToRefs } from 'pinia';
+import { onMounted } from 'vue'
 
-import { useGenerationPersistence } from '@/composables/useGenerationPersistence';
-import { toGenerationRequestPayload } from '@/services/generationService';
-import { useAppStore } from '@/stores/app';
-import {
-  useGenerationFormStore,
-  useGenerationConnectionStore,
-  useGenerationQueueStore,
-  useGenerationResultsStore,
-} from '@/stores/generation';
-import type { GenerationNotificationAdapter } from '@/composables/useGenerationTransport';
-import { useSettingsStore } from '@/stores/settings';
-import { createGenerationOrchestrator } from '@/services/generationOrchestrator';
-import type { GenerationJob, GenerationResult, NotificationType } from '@/types';
+import { useGenerationPersistence } from '@/composables/useGenerationPersistence'
+import { useGenerationOrchestrator } from '@/composables/useGenerationOrchestrator'
+import { useGenerationUI } from '@/composables/useGenerationUI'
+import { useNotifications } from '@/composables/useNotifications'
+import { toGenerationRequestPayload } from '@/services/generationService'
+import { useGenerationFormStore } from '@/stores/generation'
+import type { NotificationType } from '@/types'
 
 export const useGenerationStudio = () => {
-  const appStore = useAppStore();
-  const formStore = useGenerationFormStore();
-  const queueStore = useGenerationQueueStore();
-  const resultsStore = useGenerationResultsStore();
-  const connectionStore = useGenerationConnectionStore();
-  const settingsStore = useSettingsStore();
+  const formStore = useGenerationFormStore()
 
-  const { params, isGenerating, showHistory, showModal, selectedResult } = storeToRefs(formStore);
-  const { backendUrl: configuredBackendUrl } = storeToRefs(settingsStore);
-  const { systemStatus, isConnected, pollIntervalMs } = storeToRefs(connectionStore);
-  const { activeJobs, sortedActiveJobs } = storeToRefs(queueStore);
-  const { recentResults, historyLimit } = storeToRefs(resultsStore);
+  const { addNotification } = useNotifications()
 
   const logDebug = (...args: unknown[]): void => {
     if (import.meta.env.DEV) {
-      console.info('[GenerationStudio]', ...args);
+      console.info('[GenerationStudio]', ...args)
     }
-  };
+  }
 
-  const notificationAdapter: GenerationNotificationAdapter = {
-    notify: (message: string, type: NotificationType = 'success') => {
-      logDebug(`[${type.toUpperCase()}] ${message}`);
-      appStore.addNotification(message, type);
-    },
-    debug: logDebug,
-  };
+  const notify = (message: string, type: NotificationType = 'success') => {
+    logDebug(`[${type.toUpperCase()}] ${message}`)
+    addNotification(message, type)
+  }
 
-  const { loadSavedParams, saveParams, savePreset, loadFromComposer, useRandomPrompt } =
-    useGenerationPersistence({
-      params,
-      showToast: notificationAdapter.notify,
-    });
-
-  const orchestrator = createGenerationOrchestrator({
+  const {
+    params: uiParams,
+    isGenerating,
     showHistory,
-    configuredBackendUrl,
-    notificationAdapter,
-    queueStore,
-    resultsStore,
-    connectionStore,
-    historyLimit,
-    pollIntervalMs,
-  });
+    showModal,
+    selectedResult,
+    recentResults,
+    showImageModal,
+    hideImageModal,
+    reuseParameters,
+    formatTime,
+    getJobStatusClasses,
+    getJobStatusText,
+    getSystemStatusClasses,
+  } = useGenerationUI({ notify })
+
+  const {
+    loadSavedParams,
+    saveParams,
+    savePreset,
+    loadFromComposer,
+    useRandomPrompt,
+  } = useGenerationPersistence({
+    params: uiParams,
+    showToast: notify,
+  })
+
+  const {
+    activeJobs,
+    sortedActiveJobs,
+    systemStatus,
+    isConnected,
+    initialize,
+    startGeneration: orchestrateStart,
+    cancelJob,
+    clearQueue,
+    refreshResults: refreshRecentResults,
+    deleteResult: orchestrateDelete,
+    canCancelJob,
+  } = useGenerationOrchestrator({
+    notify,
+    debug: logDebug,
+  })
 
   const startGeneration = async (): Promise<void> => {
-    const trimmedPrompt = params.value.prompt.trim();
+    const trimmedPrompt = uiParams.value.prompt.trim()
     if (!trimmedPrompt) {
-      notificationAdapter.notify('Please enter a prompt', 'error');
-      return;
+      notify('Please enter a prompt', 'error')
+      return
     }
 
-    formStore.setGenerating(true);
+    formStore.setGenerating(true)
 
     try {
-      params.value.prompt = trimmedPrompt;
-      const payload = toGenerationRequestPayload({ ...params.value, prompt: trimmedPrompt });
-      await orchestrator.startGeneration(payload);
-      saveParams(params.value);
+      uiParams.value.prompt = trimmedPrompt
+      const payload = toGenerationRequestPayload({ ...uiParams.value, prompt: trimmedPrompt })
+      await orchestrateStart(payload)
+      saveParams(uiParams.value)
     } finally {
-      formStore.setGenerating(false);
+      formStore.setGenerating(false)
     }
-  };
+  }
 
-  const cancelJob = async (jobId: string): Promise<void> => {
-    await orchestrator.cancelJob(jobId);
-  };
-
-  const clearQueue = async (): Promise<void> => {
+  const clearQueueWithConfirmation = async (): Promise<void> => {
     if (activeJobs.value.length === 0) {
-      return;
+      return
     }
 
     if (!window.confirm('Are you sure you want to clear the entire generation queue?')) {
-      return;
+      return
     }
 
-    await orchestrator.clearQueue();
-  };
-
-  const showImageModal = (result: GenerationResult | null): void => {
-    if (!result) {
-      return;
-    }
-    formStore.selectResult(result);
-  };
-
-  const hideImageModal = (): void => {
-    formStore.setShowModal(false);
-  };
-
-  const reuseParameters = (result: GenerationResult): void => {
-    if (typeof result.prompt === 'string') {
-      params.value.prompt = result.prompt;
-    }
-    params.value.negative_prompt = typeof result.negative_prompt === 'string' ? result.negative_prompt : '';
-    if (typeof result.width === 'number') {
-      params.value.width = result.width;
-    }
-    if (typeof result.height === 'number') {
-      params.value.height = result.height;
-    }
-    if (typeof result.steps === 'number') {
-      params.value.steps = result.steps;
-    }
-    if (typeof result.cfg_scale === 'number') {
-      params.value.cfg_scale = result.cfg_scale;
-    }
-    if (typeof result.seed === 'number') {
-      params.value.seed = result.seed;
-    }
-
-    notificationAdapter.notify('Parameters loaded from result', 'success');
-  };
+    await clearQueue()
+  }
 
   const deleteResult = async (resultId: string | number): Promise<void> => {
     if (!window.confirm('Are you sure you want to delete this result?')) {
-      return;
+      return
     }
 
-    await orchestrator.deleteResult(resultId);
-  };
+    await orchestrateDelete(resultId)
+  }
 
   const refreshResults = async (): Promise<void> => {
-    await orchestrator.loadRecentResultsData(true);
-  };
-
-  const formatTime = (dateString?: string): string => {
-    if (!dateString) {
-      return 'Unknown';
-    }
-
-    try {
-      const date = new Date(dateString);
-      const now = new Date();
-      const diff = Math.floor((now.getTime() - date.getTime()) / 1000);
-
-      if (diff < 60) return `${diff}s ago`;
-      if (diff < 3600) return `${Math.floor(diff / 60)}m ago`;
-      if (diff < 86400) return `${Math.floor(diff / 3600)}h ago`;
-      return `${Math.floor(diff / 86400)}d ago`;
-    } catch {
-      return 'Unknown';
-    }
-  };
-
-  const STATUS_CLASS_MAP: Record<GenerationJob['status'], string> = {
-    processing: 'bg-blue-100 text-blue-800',
-    queued: 'bg-yellow-100 text-yellow-800',
-    completed: 'bg-green-100 text-green-800',
-    failed: 'bg-red-100 text-red-800',
-  };
-
-  const STATUS_TEXT_MAP: Record<GenerationJob['status'], string> = {
-    processing: 'Processing',
-    queued: 'Queued',
-    completed: 'Completed',
-    failed: 'Failed',
-  };
-
-  const getJobStatusClasses = (status: GenerationJob['status']): string => STATUS_CLASS_MAP[status];
-
-  const getJobStatusText = (status: GenerationJob['status']): string => STATUS_TEXT_MAP[status];
-
-  const canCancelJob = (job: GenerationJob): boolean => queueStore.isJobCancellable(job);
-
-  const getSystemStatusClasses = (status?: string): string => {
-    switch (status) {
-      case 'healthy':
-        return 'text-green-600';
-      case 'degraded':
-        return 'text-yellow-600';
-      case 'unhealthy':
-        return 'text-red-600';
-      default:
-        return 'text-gray-600';
-    }
-  };
+    await refreshRecentResults(true)
+  }
 
   onMounted(async () => {
-    logDebug('Initializing Generation Studio composable...');
-    await orchestrator.initialize();
-    loadSavedParams();
-  });
+    logDebug('Initializing Generation Studio composable...')
+    await initialize()
+    loadSavedParams()
+  })
 
   return {
-    params,
+    params: uiParams,
     systemStatus,
     isGenerating,
     showHistory,
@@ -213,7 +130,7 @@ export const useGenerationStudio = () => {
     isConnected,
     startGeneration,
     cancelJob,
-    clearQueue,
+    clearQueue: clearQueueWithConfirmation,
     refreshResults,
     loadFromComposer,
     useRandomPrompt,
@@ -227,7 +144,7 @@ export const useGenerationStudio = () => {
     getJobStatusText,
     canCancelJob,
     getSystemStatusClasses,
-  };
-};
+  }
+}
 
-export type UseGenerationStudioReturn = ReturnType<typeof useGenerationStudio>;
+export type UseGenerationStudioReturn = ReturnType<typeof useGenerationStudio>

--- a/app/frontend/src/utils/status.ts
+++ b/app/frontend/src/utils/status.ts
@@ -11,9 +11,13 @@ export const normalizeJobStatus = (status?: string | null): NormalizedJobStatus 
   }
 
   const normalizedKey = status.toLowerCase();
-  return (
-    JOB_STATUS_NORMALIZATION_MAP[normalizedKey] ?? DEFAULT_NORMALIZED_JOB_STATUS
-  );
+  if (Object.prototype.hasOwnProperty.call(JOB_STATUS_NORMALIZATION_MAP, normalizedKey)) {
+    return JOB_STATUS_NORMALIZATION_MAP[
+      normalizedKey as keyof typeof JOB_STATUS_NORMALIZATION_MAP
+    ];
+  }
+
+  return DEFAULT_NORMALIZED_JOB_STATUS;
 };
 
 export { NORMALIZED_JOB_STATUSES };


### PR DESCRIPTION
## Summary
- introduce a useGenerationOrchestrator composable that wraps the transport orchestrator and exposes queue/result actions
- add a useGenerationUI composable for modal helpers, parameter reuse, and formatting utilities bound to form/results stores
- refactor useGenerationStudio to compose the new hooks and tighten status normalization typing

## Testing
- npm run type-check
- npm run test:unit

------
https://chatgpt.com/codex/tasks/task_e_68d1fe370a3c8329b36c4a6087103543