### PR TITLE
Refactor delivery queue orchestration and persistence

### DIFF
--- a/backend/core/dependencies.py
+++ b/backend/core/dependencies.py
@@ -5,11 +5,15 @@ from sqlmodel import Session
 
 from backend.core.database import get_session
 from backend.services import ServiceContainer
+from backend.services.delivery_repository import DeliveryJobRepository
+from backend.services.queue import QueueOrchestrator, create_queue_orchestrator
 from backend.services.adapters import AdapterService
 from backend.services.composition import ComposeService
 from backend.services.deliveries import DeliveryService
 from backend.services.archive import ArchiveService
 from backend.services.recommendations import RecommendationService
+
+_QUEUE_ORCHESTRATOR: QueueOrchestrator = create_queue_orchestrator()
 
 
 def get_service_container(
@@ -17,7 +21,12 @@ def get_service_container(
 ) -> ServiceContainer:
     """Return a service container tied to the current database session."""
 
-    return ServiceContainer(db_session)
+    repository = DeliveryJobRepository(db_session)
+    return ServiceContainer(
+        db_session,
+        queue_orchestrator=_QUEUE_ORCHESTRATOR,
+        delivery_repository=repository,
+    )
 
 
 def get_adapter_service(

--- a/backend/services/delivery_repository.py
+++ b/backend/services/delivery_repository.py
@@ -1,0 +1,233 @@
+"""Persistence helpers for :class:`~backend.services.deliveries.DeliveryService`."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from typing import Any, Callable, Dict, List, Optional
+
+from sqlalchemy import func
+from sqlmodel import Session, select
+
+from backend.models import DeliveryJob
+
+_ACTIVE_STATUSES = {"pending", "running", "retrying"}
+
+
+class DeliveryJobMapper:
+    """Serialize and deserialize database columns for delivery jobs."""
+
+    def __init__(self, *, now: Optional[Callable[[], datetime]] = None) -> None:
+        self._now = now or (lambda: datetime.now(timezone.utc))
+
+    def serialize_params(self, params: Optional[Dict[str, Any]]) -> str:
+        """Convert job parameter payloads into a JSON string."""
+
+        return json.dumps(params or {})
+
+    def deserialize_params(self, params: Optional[str]) -> Dict[str, Any]:
+        """Convert the stored JSON params into a dictionary."""
+
+        if not params:
+            return {}
+
+        try:
+            data = json.loads(params)
+        except json.JSONDecodeError:  # pragma: no cover - defensive guard
+            return {}
+        if isinstance(data, dict):
+            return data
+        return {}
+
+    def serialize_result(
+        self,
+        result: Optional[Dict[str, Any]],
+        error: Optional[str],
+    ) -> Optional[str]:
+        """Merge result payloads and error messages into a JSON string."""
+
+        payload: Optional[Dict[str, Any]] = None
+        if result is not None:
+            payload = dict(result)
+
+        if error is not None:
+            if payload is None:
+                payload = {"error": error}
+            else:
+                payload["error"] = error
+
+        if payload is None:
+            return None
+
+        return json.dumps(payload)
+
+    def deserialize_result(self, result: Optional[str]) -> Optional[Dict[str, Any]]:
+        """Decode the stored result JSON blob."""
+
+        if not result:
+            return None
+
+        try:
+            data = json.loads(result)
+        except json.JSONDecodeError:  # pragma: no cover - defensive guard
+            return None
+        if isinstance(data, dict):
+            return data
+        return None
+
+    def apply_status(self, job: DeliveryJob, status: str) -> None:
+        """Update job status and lifecycle timestamps."""
+
+        job.status = status
+        now = self._now()
+        if status == "running" and job.started_at is None:
+            job.started_at = now
+        elif status in {"succeeded", "failed", "cancelled"} and job.finished_at is None:
+            job.finished_at = now
+
+    def build_activity(self, job: DeliveryJob) -> Dict[str, Any]:
+        """Create the activity feed payload for ``job``."""
+
+        status = job.status or "pending"
+        created_at = job.created_at or self._now()
+        return {
+            "id": job.id,
+            "type": status,
+            "status": status,
+            "message": f"Delivery job '{job.prompt}' {status}",
+            "mode": job.mode,
+            "prompt": job.prompt,
+            "timestamp": created_at.isoformat(),
+            "icon": self._status_icon(status),
+        }
+
+    @staticmethod
+    def _status_icon(status: str) -> str:
+        return {
+            "pending": "⏳",
+            "running": "🚀",
+            "retrying": "🔁",
+            "succeeded": "✅",
+            "failed": "⚠️",
+            "cancelled": "🚫",
+        }.get(status, "ℹ️")
+
+
+class DeliveryJobRepository:
+    """Repository for persisting and retrieving delivery jobs."""
+
+    def __init__(
+        self,
+        session: Session,
+        *,
+        mapper: Optional[DeliveryJobMapper] = None,
+    ) -> None:
+        self._session = session
+        self._mapper = mapper or DeliveryJobMapper()
+
+    @property
+    def mapper(self) -> DeliveryJobMapper:
+        return self._mapper
+
+    def create_job(
+        self,
+        prompt: str,
+        mode: str,
+        params: Optional[Dict[str, Any]] = None,
+    ) -> DeliveryJob:
+        job = DeliveryJob(
+            prompt=prompt,
+            mode=mode,
+            params=self._mapper.serialize_params(params or {}),
+        )
+        self._session.add(job)
+        self._session.commit()
+        self._session.refresh(job)
+        return job
+
+    def get_job(self, job_id: str) -> Optional[DeliveryJob]:
+        return self._session.get(DeliveryJob, job_id)
+
+    def list_jobs(
+        self,
+        *,
+        status: Optional[str] = None,
+        limit: int = 100,
+        offset: int = 0,
+    ) -> List[DeliveryJob]:
+        query = select(DeliveryJob)
+        if status:
+            query = query.where(DeliveryJob.status == status)
+
+        query = query.offset(offset).limit(limit).order_by(DeliveryJob.created_at.desc())
+        return list(self._session.exec(query).all())
+
+    def count_active_jobs(self) -> int:
+        result = self._session.exec(
+            select(func.count(DeliveryJob.id)).where(DeliveryJob.status.in_(_ACTIVE_STATUSES))
+        ).one()
+        return int(result or 0)
+
+    def get_queue_statistics(self) -> Dict[str, int]:
+        total_jobs = self._session.exec(select(func.count(DeliveryJob.id))).one() or 0
+        active_jobs = self.count_active_jobs()
+        running_jobs = (
+            self._session.exec(
+                select(func.count(DeliveryJob.id)).where(DeliveryJob.status == "running")
+            ).one()
+            or 0
+        )
+        failed_jobs = (
+            self._session.exec(
+                select(func.count(DeliveryJob.id)).where(DeliveryJob.status == "failed")
+            ).one()
+            or 0
+        )
+
+        return {
+            "total": int(total_jobs),
+            "active": int(active_jobs),
+            "running": int(running_jobs),
+            "failed": int(failed_jobs),
+        }
+
+    def get_recent_activity(self, *, limit: int = 10) -> List[Dict[str, Any]]:
+        query = (
+            select(DeliveryJob)
+            .order_by(DeliveryJob.created_at.desc())
+            .limit(max(1, limit))
+        )
+        jobs = list(self._session.exec(query).all())
+        return [self._mapper.build_activity(job) for job in jobs]
+
+    def update_job_status(
+        self,
+        job_id: str,
+        status: str,
+        result: Optional[Dict[str, Any]] = None,
+        error: Optional[str] = None,
+    ) -> Optional[DeliveryJob]:
+        job = self.get_job(job_id)
+        if job is None:
+            return None
+
+        serialized_result = self._mapper.serialize_result(result, error)
+        if serialized_result is not None:
+            job.result = serialized_result
+
+        self._mapper.apply_status(job, status)
+
+        self._session.add(job)
+        self._session.commit()
+        self._session.refresh(job)
+        return job
+
+    def get_job_params(self, job: DeliveryJob) -> Dict[str, Any]:
+        return self._mapper.deserialize_params(job.params)
+
+    def get_job_result(self, job: DeliveryJob) -> Optional[Dict[str, Any]]:
+        return self._mapper.deserialize_result(job.result)
+
+
+__all__ = ["DeliveryJobRepository", "DeliveryJobMapper"]
+

--- a/backend/services/websocket/persistence.py
+++ b/backend/services/websocket/persistence.py
@@ -10,6 +10,7 @@ from sqlmodel import Session
 
 from backend.core.database import get_session_context
 from backend.services.deliveries import DeliveryService
+from backend.services.delivery_repository import DeliveryJobRepository
 
 from .job_monitor import JobStateRepository, PersistedJobState
 
@@ -27,7 +28,8 @@ class DeliveryJobStateRepository(JobStateRepository):
 
     def get_job_state(self, job_id: str) -> Optional[PersistedJobState]:
         with self._session_factory() as session:
-            service = DeliveryService(session)
+            repository = DeliveryJobRepository(session)
+            service = DeliveryService(repository)
             job = service.get_job(job_id)
             if job is None:
                 return None

--- a/backend/workers/delivery_runner.py
+++ b/backend/workers/delivery_runner.py
@@ -9,6 +9,7 @@ from backend.core.database import get_session_context
 from backend.delivery.base import DeliveryRegistry
 from backend.schemas import SDNextGenerationParams
 from backend.services.deliveries import DeliveryService
+from backend.services.delivery_repository import DeliveryJobRepository
 
 _SUCCESS_STATUSES = {"ok", "completed", 200}
 
@@ -65,7 +66,8 @@ class DeliveryRunner:
         status: str = "failed"
 
         with get_session_context() as session:
-            service = DeliveryService(session)
+            repository = DeliveryJobRepository(session)
+            service = DeliveryService(repository)
             job = service.get_job(job_id)
             if job is None:
                 return
@@ -88,7 +90,8 @@ class DeliveryRunner:
                 status = "failed"
 
         with get_session_context() as session:
-            service = DeliveryService(session)
+            repository = DeliveryJobRepository(session)
+            service = DeliveryService(repository)
             service.update_job_status(job_id, status, result_payload)
 
         if error is not None and raise_on_error:

--- a/backend/workers/tasks.py
+++ b/backend/workers/tasks.py
@@ -23,6 +23,7 @@ except Exception:
 
 
 from backend.core.database import get_session_context
+from backend.services.queue import QueueOrchestrator
 from backend.workers.context import AsyncRunner, WorkerContext
 
 # Basic structured-ish logger for worker events
@@ -39,12 +40,14 @@ _worker_context: Optional[WorkerContext] = None
 
 def build_worker_context(
     *,
+    queue_orchestrator: Optional[QueueOrchestrator] = None,
     async_runner: Optional[AsyncRunner] = None,
     recommendation_gpu_available: Optional[bool] = None,
 ) -> WorkerContext:
     """Create a new :class:`WorkerContext` instance."""
 
     return WorkerContext.build_default(
+        queue_orchestrator=queue_orchestrator,
         async_runner=async_runner,
         recommendation_gpu_available=recommendation_gpu_available,
     )

--- a/tests/test_queue_configuration.py
+++ b/tests/test_queue_configuration.py
@@ -4,72 +4,69 @@ from __future__ import annotations
 
 from backend.core.config import settings
 from backend.services import ServiceContainer
-from backend.services.queue import (
-    BackgroundTaskQueueBackend,
-    RedisQueueBackend,
-    get_queue_backends,
-    reset_queue_backends,
-)
+from backend.services.queue import BackgroundTaskQueueBackend, QueueOrchestrator, RedisQueueBackend
 from backend.workers import tasks as worker_tasks
 from backend.workers.tasks import reset_worker_context, set_worker_context
-
-
-def _restore_queue_state(original_url: str | None) -> None:
-    """Restore settings and queue backends to their original state."""
-
-    settings.REDIS_URL = original_url
-    reset_queue_backends()
-    reset_worker_context()
 
 
 def test_queue_factory_shared_backend_with_redis(db_session) -> None:
     """API services and worker tasks should share the Redis queue backend."""
 
     original_url = settings.REDIS_URL
-    reset_queue_backends()
+    orchestrator: QueueOrchestrator | None = None
     try:
         settings.REDIS_URL = "redis://localhost:6379/0"
         reset_worker_context()
-        context = worker_tasks.build_worker_context()
+        orchestrator = QueueOrchestrator(redis_url_factory=lambda: settings.REDIS_URL)
+        orchestrator.reset()
+        context = worker_tasks.build_worker_context(queue_orchestrator=orchestrator)
         set_worker_context(context)
 
-        primary, fallback = get_queue_backends()
+        primary, fallback = orchestrator.get_backends()
         assert isinstance(primary, RedisQueueBackend)
         assert isinstance(fallback, BackgroundTaskQueueBackend)
 
-        container = ServiceContainer(db_session)
+        container = ServiceContainer(db_session, queue_orchestrator=orchestrator)
         deliveries_service = container.deliveries
 
-        assert deliveries_service._queue_backend is context.queue_backend
-        assert deliveries_service._fallback_queue_backend is context.fallback_queue_backend
+        assert deliveries_service.queue_orchestrator is orchestrator
+        assert context.queue_orchestrator is orchestrator
         assert context.primary_queue_backend is primary
         assert context.fallback_queue_backend is fallback
     finally:
-        _restore_queue_state(original_url)
+        settings.REDIS_URL = original_url
+        if orchestrator is not None:
+            orchestrator.reset()
+        reset_worker_context()
 
 
 def test_queue_factory_shared_backend_without_redis(db_session) -> None:
     """Fallback queue should be shared when Redis is not configured."""
 
     original_url = settings.REDIS_URL
-    reset_queue_backends()
+    orchestrator: QueueOrchestrator | None = None
     try:
         settings.REDIS_URL = None
         reset_worker_context()
-        context = worker_tasks.build_worker_context()
+        orchestrator = QueueOrchestrator(redis_url_factory=lambda: settings.REDIS_URL)
+        orchestrator.reset()
+        context = worker_tasks.build_worker_context(queue_orchestrator=orchestrator)
         set_worker_context(context)
 
-        primary, fallback = get_queue_backends()
+        primary, fallback = orchestrator.get_backends()
         assert primary is None
         assert isinstance(fallback, BackgroundTaskQueueBackend)
 
-        container = ServiceContainer(db_session)
+        container = ServiceContainer(db_session, queue_orchestrator=orchestrator)
         deliveries_service = container.deliveries
 
-        assert deliveries_service._queue_backend is None
-        assert deliveries_service._fallback_queue_backend is context.fallback_queue_backend
+        assert deliveries_service.queue_orchestrator is orchestrator
+        assert context.queue_orchestrator is orchestrator
         assert context.primary_queue_backend is None
         assert context.queue_backend is fallback
         assert context.fallback_queue_backend is fallback
     finally:
-        _restore_queue_state(original_url)
+        settings.REDIS_URL = original_url
+        if orchestrator is not None:
+            orchestrator.reset()
+        reset_worker_context()


### PR DESCRIPTION
## Summary
- add a DeliveryJobRepository/DeliveryJobMapper to centralize delivery job serialization, timestamp management, and activity feeds
- replace the prior queue globals with a QueueOrchestrator and refactor DeliveryService, ServiceContainer, and worker plumbing to depend on injected orchestrator/repository instances
- update API overrides and tests to work with the new orchestrator-driven enqueue paths

## Testing
- pytest *(fails: ImportError – backend.services.generation.statuses is missing DEFAULT_NORMALIZED_STATUS)*

------
https://chatgpt.com/codex/tasks/task_e_68d1fe2b3fc88329b296ef5a30725de9