### PR TITLE
Refactor recommendation service composition

### DIFF
--- a/backend/services/__init__.py
+++ b/backend/services/__init__.py
@@ -22,6 +22,9 @@ from .recommendations import (
     RecommendationPersistenceManager,
     RecommendationPersistenceService,
     RecommendationRepository,
+    RecommendationConfig,
+    SimilarLoraUseCase,
+    PromptRecommendationUseCase,
     RecommendationService,
 )
 from .system import SystemService
@@ -209,6 +212,19 @@ class ServiceContainer:
             )
             persistence_service = RecommendationPersistenceService(persistence_manager)
             metrics_tracker = RecommendationMetricsTracker()
+            config = RecommendationConfig(persistence_service)
+            similar_use_case = SimilarLoraUseCase(
+                repository=repository,
+                embedding_workflow=embedding_manager,
+                engine_provider=model_registry.get_recommendation_engine,
+                metrics=metrics_tracker,
+            )
+            prompt_use_case = PromptRecommendationUseCase(
+                repository=repository,
+                embedder_provider=model_registry.get_semantic_embedder,
+                metrics=metrics_tracker,
+                device=model_bootstrap.device,
+            )
 
             self._recommendation_service = RecommendationService(
                 bootstrap=model_bootstrap,
@@ -216,6 +232,9 @@ class ServiceContainer:
                 embedding_workflow=embedding_manager,
                 persistence_service=persistence_service,
                 metrics_tracker=metrics_tracker,
+                similar_lora_use_case=similar_use_case,
+                prompt_recommendation_use_case=prompt_use_case,
+                config=config,
             )
 
         return self._recommendation_service

--- a/backend/services/recommendations/__init__.py
+++ b/backend/services/recommendations/__init__.py
@@ -7,6 +7,8 @@ from .persistence_manager import RecommendationPersistenceManager
 from .persistence_service import RecommendationPersistenceService
 from .repository import RecommendationRepository
 from .service import RecommendationService
+from .config import RecommendationConfig
+from .use_cases import SimilarLoraUseCase, PromptRecommendationUseCase
 
 __all__ = [
     'EmbeddingManager',
@@ -17,4 +19,7 @@ __all__ = [
     'RecommendationPersistenceService',
     'RecommendationRepository',
     'RecommendationService',
+    'RecommendationConfig',
+    'SimilarLoraUseCase',
+    'PromptRecommendationUseCase',
 ]

--- a/backend/services/recommendations/config.py
+++ b/backend/services/recommendations/config.py
@@ -1,0 +1,32 @@
+"""Configuration helpers for the recommendation domain."""
+
+from __future__ import annotations
+
+from .interfaces import RecommendationPersistenceService
+
+
+class RecommendationConfig:
+    """Expose tunable persistence paths for recommendations."""
+
+    def __init__(self, persistence: RecommendationPersistenceService) -> None:
+        self._persistence = persistence
+
+    @property
+    def index_cache_path(self) -> str:
+        """Return the persisted similarity index path."""
+
+        return self._persistence.index_cache_path
+
+    @index_cache_path.setter
+    def index_cache_path(self, value: str) -> None:
+        self._persistence.index_cache_path = value
+
+    @property
+    def embedding_cache_dir(self) -> str:
+        """Return the embedding cache directory path."""
+
+        return self._persistence.embedding_cache_dir
+
+    @embedding_cache_dir.setter
+    def embedding_cache_dir(self, value: str) -> None:
+        self._persistence.embedding_cache_dir = value

--- a/backend/services/recommendations/use_cases.py
+++ b/backend/services/recommendations/use_cases.py
@@ -1,0 +1,105 @@
+"""Focused use cases for recommendation flows."""
+
+from __future__ import annotations
+
+import time
+from typing import Any, Callable, Dict, List, Optional, Sequence
+
+from backend.schemas.recommendations import RecommendationItem
+
+from .components.interfaces import SemanticEmbedderProtocol
+from .interfaces import (
+    EmbeddingWorkflow,
+    RecommendationMetricsTracker,
+    RecommendationRepository,
+)
+from .strategies import (
+    get_recommendations_for_prompt as prompt_strategy,
+    get_similar_loras as similar_loras_strategy,
+)
+
+
+class SimilarLoraUseCase:
+    """Resolve LoRA similarity queries against the recommendation engine."""
+
+    def __init__(
+        self,
+        *,
+        repository: RecommendationRepository,
+        embedding_workflow: EmbeddingWorkflow,
+        engine_provider: Callable[[], Any],
+        metrics: RecommendationMetricsTracker,
+    ) -> None:
+        self._repository = repository
+        self._embedding_workflow = embedding_workflow
+        self._engine_provider = engine_provider
+        self._metrics = metrics
+
+    async def execute(
+        self,
+        *,
+        target_lora_id: str,
+        limit: int,
+        similarity_threshold: float,
+        weights: Optional[Dict[str, float]],
+    ) -> List[RecommendationItem]:
+        """Return LoRAs similar to ``target_lora_id`` while capturing metrics."""
+
+        start = time.perf_counter()
+        try:
+            engine = self._engine_provider()
+            return await similar_loras_strategy(
+                target_lora_id=target_lora_id,
+                limit=limit,
+                similarity_threshold=similarity_threshold,
+                weights=weights,
+                repository=self._repository,
+                embedding_manager=self._embedding_workflow,
+                engine=engine,
+            )
+        finally:
+            elapsed_ms = (time.perf_counter() - start) * 1000
+            self._metrics.record_query(elapsed_ms)
+
+
+class PromptRecommendationUseCase:
+    """Generate prompt-centric LoRA recommendations."""
+
+    def __init__(
+        self,
+        *,
+        repository: RecommendationRepository,
+        embedder_provider: Callable[[], SemanticEmbedderProtocol],
+        metrics: RecommendationMetricsTracker,
+        device: str,
+    ) -> None:
+        self._repository = repository
+        self._embedder_provider = embedder_provider
+        self._metrics = metrics
+        self._device = device
+
+    async def execute(
+        self,
+        *,
+        prompt: str,
+        active_loras: Optional[Sequence[str]],
+        limit: int,
+        style_preference: Optional[str],
+    ) -> List[RecommendationItem]:
+        """Return LoRAs that enhance ``prompt`` while recording metrics."""
+
+        start = time.perf_counter()
+        try:
+            embedder = self._embedder_provider()
+            return await prompt_strategy(
+                prompt=prompt,
+                active_loras=list(active_loras) if active_loras else None,
+                limit=limit,
+                style_preference=style_preference,
+                repository=self._repository,
+                embedder=embedder,
+                device=self._device,
+            )
+        finally:
+            elapsed_ms = (time.perf_counter() - start) * 1000
+            self._metrics.record_query(elapsed_ms)

--- a/tests/test_recommendations.py
+++ b/tests/test_recommendations.py
@@ -28,6 +28,8 @@ from backend.services.recommendations import (
     RecommendationPersistenceManager,
     RecommendationPersistenceService,
     RecommendationRepository,
+    PromptRecommendationUseCase,
+    SimilarLoraUseCase,
     RecommendationService,
 )
 
@@ -209,6 +211,73 @@ class TestRecommendationRepository:
         assert stored.learned_from == "feedback"
 
 
+class TestRecommendationUseCases:
+    """Ensure focused use cases delegate correctly."""
+
+    @pytest.mark.anyio("asyncio")
+    async def test_similar_use_case_records_metrics(self):
+        repository = MagicMock()
+        workflow = MagicMock()
+        engine_provider = MagicMock(return_value=MagicMock())
+        metrics = MagicMock()
+        use_case = SimilarLoraUseCase(
+            repository=repository,
+            embedding_workflow=workflow,
+            engine_provider=engine_provider,
+            metrics=metrics,
+        )
+
+        payload = [MagicMock()]
+        strategy = AsyncMock(return_value=payload)
+
+        with patch(
+            "backend.services.recommendations.use_cases.similar_loras_strategy",
+            strategy,
+        ):
+            result = await use_case.execute(
+                target_lora_id="adapter-id",
+                limit=5,
+                similarity_threshold=0.3,
+                weights=None,
+            )
+
+        assert result == payload
+        strategy.assert_awaited_once()
+        engine_provider.assert_called_once()
+        metrics.record_query.assert_called_once()
+
+    @pytest.mark.anyio("asyncio")
+    async def test_prompt_use_case_records_metrics(self):
+        repository = MagicMock()
+        embedder_provider = MagicMock(return_value=MagicMock())
+        metrics = MagicMock()
+        use_case = PromptRecommendationUseCase(
+            repository=repository,
+            embedder_provider=embedder_provider,
+            metrics=metrics,
+            device="cpu",
+        )
+
+        payload = [MagicMock()]
+        strategy = AsyncMock(return_value=payload)
+
+        with patch(
+            "backend.services.recommendations.use_cases.prompt_strategy",
+            strategy,
+        ):
+            result = await use_case.execute(
+                prompt="test",
+                active_loras=["a"],
+                limit=3,
+                style_preference=None,
+            )
+
+        assert result == payload
+        strategy.assert_awaited_once()
+        embedder_provider.assert_called_once()
+        metrics.record_query.assert_called_once()
+
+
 class TestRecommendationMetricsTracker:
     """Ensure stats aggregation relies on the tracker."""
 
@@ -270,10 +339,13 @@ class TestRecommendationService:
             metrics_tracker=metrics_tracker,
         )
 
-        service.index_cache_path
-        service.embedding_cache_dir
-        persistence_service.index_cache_path = "cache/index.pkl"
-        persistence_service.embedding_cache_dir = "cache/embeddings"
+        service.config.index_cache_path
+        service.config.embedding_cache_dir
+        service.config.index_cache_path = "cache/index.pkl"
+        service.config.embedding_cache_dir = "cache/embeddings"
+
+        assert persistence_service.index_cache_path == "cache/index.pkl"
+        assert persistence_service.embedding_cache_dir == "cache/embeddings"
 
         service.record_feedback(MagicMock())
         repository.record_feedback.assert_called()


### PR DESCRIPTION
## Summary
- extract new SimilarLoraUseCase and PromptRecommendationUseCase for strategy orchestration and metrics capture
- add a RecommendationConfig helper so cache path settings no longer leak through the RecommendationService
- rewire RecommendationService, the service container, and tests to compose the new collaborators and simplify strategy functions

## Testing
- pytest tests/test_recommendations.py

------
https://chatgpt.com/codex/tasks/task_e_68d1fdd2828483299b43c429453f3d46