### PR TITLE
Refactor prompt composer state management and persistence

### DIFF
--- a/app/frontend/src/components/LoraCard.vue
+++ b/app/frontend/src/components/LoraCard.vue
@@ -82,6 +82,16 @@ const {
   emitDelete: (id) => emit('delete', id),
 });
 
+const toggleActive = handleToggleActive;
+const updateWeight = (value?: number) => handleWeightChange(value ?? weight.value);
+const generatePreview = handleGeneratePreview;
+
+defineExpose({
+  toggleActive,
+  updateWeight,
+  generatePreview,
+});
+
 const cardViewModel = computed<LoraCardViewModel>(() => ({
   id: loraRef.value.id,
   name: loraRef.value.name,

--- a/app/frontend/src/components/PromptComposer.vue
+++ b/app/frontend/src/components/PromptComposer.vue
@@ -70,11 +70,7 @@ import PromptComposerComposition from './PromptComposerComposition.vue';
 import { usePromptComposition } from '@/composables/usePromptComposition';
 
 const {
-  searchTerm,
-  activeOnly,
-  filteredLoras,
-  isLoading,
-  error,
+  catalog,
   activeLoras,
   basePrompt,
   negativePrompt,
@@ -83,8 +79,6 @@ const {
   isGenerating,
   canGenerate,
   canSave,
-  setSearchTerm,
-  setActiveOnly,
   addToComposition,
   removeFromComposition,
   moveUp,
@@ -101,6 +95,16 @@ const {
   generateImage,
   isInComposition,
 } = usePromptComposition();
+
+const {
+  filteredAdapters: filteredLoras,
+  searchTerm,
+  activeOnly,
+  isLoading,
+  error,
+  setSearchTerm,
+  setActiveOnly,
+} = catalog;
 
 const onUpdateWeight = (payload: { index: number; weight: number }) => {
   updateWeight(payload.index, payload.weight);

--- a/app/frontend/src/composables/useAdapterCatalog.ts
+++ b/app/frontend/src/composables/useAdapterCatalog.ts
@@ -1,0 +1,99 @@
+import { computed, onMounted, ref, watch, type ComputedRef, type Ref } from 'vue';
+
+import { useAdapterListApi } from '@/services/loraService';
+
+import type { AdapterSummary, LoraListItem } from '@/types';
+
+type AdapterCatalogQuery = {
+  page?: number;
+  perPage?: number;
+};
+
+export interface AdapterCatalogState {
+  searchTerm: Ref<string>;
+  activeOnly: Ref<boolean>;
+  adapters: ComputedRef<AdapterSummary[]>;
+  filteredAdapters: ComputedRef<AdapterSummary[]>;
+  isLoading: Ref<boolean>;
+  error: Ref<unknown>;
+}
+
+export interface AdapterCatalogActions {
+  setSearchTerm: (value: string) => void;
+  setActiveOnly: (value: boolean) => void;
+  refresh: () => Promise<void>;
+}
+
+export type AdapterCatalogApi = AdapterCatalogState & AdapterCatalogActions;
+
+const toSummary = (item: LoraListItem): AdapterSummary => ({
+  id: item.id,
+  name: item.name,
+  description: item.description,
+  active: item.active ?? true,
+});
+
+export const useAdapterCatalog = (query: AdapterCatalogQuery = {}): AdapterCatalogApi => {
+  const searchTerm = ref('');
+  const activeOnly = ref(false);
+  const summaries = ref<AdapterSummary[]>([]);
+
+  const { adapters, error, isLoading, fetchData } = useAdapterListApi({
+    page: query.page ?? 1,
+    perPage: query.perPage ?? 200,
+  });
+
+  const refresh = async () => {
+    await fetchData();
+  };
+
+  const items = computed<AdapterSummary[]>(() => summaries.value);
+
+  const filteredAdapters = computed<AdapterSummary[]>(() => {
+    const term = searchTerm.value.trim().toLowerCase();
+    let result = items.value;
+
+    if (activeOnly.value) {
+      result = result.filter((item) => item.active);
+    }
+
+    if (term) {
+      result = result.filter((item) => item.name.toLowerCase().includes(term));
+    }
+
+    return result;
+  });
+
+  watch(
+    adapters,
+    (next) => {
+      const payload = Array.isArray(next) ? next : [];
+      summaries.value = payload.map(toSummary);
+    },
+    { immediate: true },
+  );
+
+  onMounted(async () => {
+    await refresh();
+  });
+
+  const setSearchTerm = (value: string) => {
+    searchTerm.value = value;
+  };
+
+  const setActiveOnly = (value: boolean) => {
+    activeOnly.value = value;
+  };
+
+  return {
+    searchTerm,
+    activeOnly,
+    adapters: items,
+    filteredAdapters,
+    isLoading,
+    error,
+    setSearchTerm,
+    setActiveOnly,
+    refresh,
+  };
+};

--- a/app/frontend/src/constants/promptComposer.ts
+++ b/app/frontend/src/constants/promptComposer.ts
@@ -1,0 +1,3 @@
+export const PROMPT_COMPOSITION_STORAGE_KEY = 'prompt-composer-composition';
+export const PROMPT_COMPOSITION_DEFAULT_WEIGHT = 1;
+export const PROMPT_COMPOSITION_PERSIST_DEBOUNCE_MS = 250;

--- a/app/frontend/src/utils/promptClipboard.ts
+++ b/app/frontend/src/utils/promptClipboard.ts
@@ -1,0 +1,18 @@
+import { copyToClipboard } from '@/utils/browser';
+
+export const copyPromptToClipboard = async (prompt: string): Promise<boolean> => {
+  try {
+    const success = await copyToClipboard(prompt);
+
+    if (!success && import.meta.env.DEV) {
+      console.warn('Failed to copy prompt to clipboard');
+    }
+
+    return success;
+  } catch (err) {
+    if (import.meta.env.DEV) {
+      console.warn('Copy prompt failed', err);
+    }
+    return false;
+  }
+};

--- a/app/frontend/src/utils/promptCompositionPersistence.ts
+++ b/app/frontend/src/utils/promptCompositionPersistence.ts
@@ -1,0 +1,151 @@
+import { PROMPT_COMPOSITION_DEFAULT_WEIGHT, PROMPT_COMPOSITION_PERSIST_DEBOUNCE_MS, PROMPT_COMPOSITION_STORAGE_KEY } from '@/constants/promptComposer';
+
+import type { CompositionEntry, SavedComposition } from '@/types';
+
+export interface StorageLike {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+}
+
+export interface PromptCompositionPersistenceOptions {
+  storage?: StorageLike | null;
+  storageKey?: string;
+  debounceMs?: number;
+}
+
+export interface PromptCompositionPersistence {
+  load: () => SavedComposition | null;
+  save: (payload: SavedComposition) => void;
+  scheduleSave: (payload: SavedComposition) => void;
+  cancel: () => void;
+}
+
+type PersistTimeout = ReturnType<typeof setTimeout> | null;
+
+const resolveStorage = (value?: StorageLike | null): StorageLike | null => {
+  if (value) {
+    return value;
+  }
+
+  if (typeof window !== 'undefined' && window.localStorage) {
+    return window.localStorage;
+  }
+
+  return null;
+};
+
+const normaliseWeight = (value: number | string | null | undefined): number => {
+  const parsed = typeof value === 'number' ? value : Number(value);
+  const numeric = Number.isFinite(parsed) ? parsed : PROMPT_COMPOSITION_DEFAULT_WEIGHT;
+
+  if (numeric < 0) {
+    return 0;
+  }
+
+  if (numeric > 2) {
+    return 2;
+  }
+
+  return numeric;
+};
+
+const toCompositionEntry = (value: unknown): CompositionEntry | null => {
+  if (!value || typeof value !== 'object') {
+    return null;
+  }
+
+  const input = value as Partial<CompositionEntry>;
+
+  if (typeof input.id !== 'string' || typeof input.name !== 'string') {
+    return null;
+  }
+
+  return {
+    id: input.id,
+    name: input.name,
+    weight: normaliseWeight(input.weight ?? null),
+  } satisfies CompositionEntry;
+};
+
+export const parseSavedComposition = (value: unknown): SavedComposition | null => {
+  if (!value || typeof value !== 'object') {
+    return null;
+  }
+
+  const input = value as Partial<SavedComposition> & { items?: unknown };
+  const rawItems = Array.isArray(input.items) ? input.items : [];
+  const items = rawItems
+    .map(toCompositionEntry)
+    .filter((entry): entry is CompositionEntry => entry !== null);
+
+  return {
+    items,
+    base: typeof input.base === 'string' ? input.base : '',
+    neg: typeof input.neg === 'string' ? input.neg : '',
+  } satisfies SavedComposition;
+};
+
+export const createPromptCompositionPersistence = (
+  options: PromptCompositionPersistenceOptions = {},
+): PromptCompositionPersistence => {
+  const storage = resolveStorage(options.storage);
+  const storageKey = options.storageKey ?? PROMPT_COMPOSITION_STORAGE_KEY;
+  const debounceMs = options.debounceMs ?? PROMPT_COMPOSITION_PERSIST_DEBOUNCE_MS;
+  let timeout: PersistTimeout = null;
+
+  const cancel = () => {
+    if (timeout) {
+      clearTimeout(timeout);
+      timeout = null;
+    }
+  };
+
+  const save = (payload: SavedComposition) => {
+    if (!storage) {
+      return;
+    }
+
+    try {
+      storage.setItem(storageKey, JSON.stringify(payload));
+    } catch (err) {
+      if (import.meta.env.DEV) {
+        console.warn('Failed to persist composition', err);
+      }
+    }
+  };
+
+  const scheduleSave = (payload: SavedComposition) => {
+    cancel();
+    timeout = setTimeout(() => {
+      timeout = null;
+      save(payload);
+    }, debounceMs);
+  };
+
+  const load = (): SavedComposition | null => {
+    if (!storage) {
+      return null;
+    }
+
+    try {
+      const raw = storage.getItem(storageKey);
+      if (!raw) {
+        return null;
+      }
+
+      return parseSavedComposition(JSON.parse(raw) as unknown);
+    } catch (err) {
+      if (import.meta.env.DEV) {
+        console.warn('Failed to load composition', err);
+      }
+      return null;
+    }
+  };
+
+  return {
+    load,
+    save,
+    scheduleSave,
+    cancel,
+  };
+};

--- a/app/frontend/src/utils/promptGeneration.ts
+++ b/app/frontend/src/utils/promptGeneration.ts
@@ -1,0 +1,37 @@
+import { createGenerationParams, requestGeneration } from '@/services/generationService';
+
+import type { CompositionEntry } from '@/types';
+
+export interface PromptGenerationPayload {
+  prompt: string;
+  negativePrompt: string;
+  loras: CompositionEntry[];
+}
+
+const cloneEntries = (entries: CompositionEntry[]): CompositionEntry[] => entries.map((entry) => ({ ...entry }));
+
+export const triggerPromptGeneration = async ({
+  prompt,
+  negativePrompt,
+  loras,
+}: PromptGenerationPayload): Promise<boolean> => {
+  try {
+    const trimmedNegative = negativePrompt.trim();
+    const params = createGenerationParams({
+      prompt,
+      negative_prompt: trimmedNegative ? trimmedNegative : null,
+    });
+
+    await requestGeneration({
+      ...params,
+      loras: cloneEntries(loras),
+    });
+
+    return true;
+  } catch (err) {
+    if (import.meta.env.DEV) {
+      console.warn('Failed to trigger generation', err);
+    }
+    return false;
+  }
+};

--- a/tests/unit/promptCompositionPersistence.spec.ts
+++ b/tests/unit/promptCompositionPersistence.spec.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it, vi, afterEach } from 'vitest';
+
+import { createPromptCompositionPersistence, parseSavedComposition } from '@/utils/promptCompositionPersistence';
+
+const createStorage = () => {
+  const store = new Map<string, string>();
+
+  return {
+    getItem: vi.fn((key: string) => store.get(key) ?? null),
+    setItem: vi.fn((key: string, value: string) => {
+      store.set(key, value);
+    }),
+    store,
+  };
+};
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('promptCompositionPersistence', () => {
+  it('saves and loads compositions using provided storage', () => {
+    const storage = createStorage();
+    const persistence = createPromptCompositionPersistence({ storage, storageKey: 'test-key' });
+    const payload = {
+      items: [
+        { id: 'one', name: 'One', weight: 1.25 },
+        { id: 'two', name: 'Two', weight: 0.5 },
+      ],
+      base: 'base prompt',
+      neg: 'negative',
+    };
+
+    persistence.save(payload);
+    expect(storage.setItem).toHaveBeenCalledWith('test-key', JSON.stringify(payload));
+
+    const loaded = persistence.load();
+    expect(loaded).not.toBeNull();
+    expect(loaded?.items).toHaveLength(2);
+    expect(loaded?.items[0].weight).toBeCloseTo(1.25);
+  });
+
+  it('debounces scheduled saves and can be cancelled', () => {
+    vi.useFakeTimers();
+    const storage = createStorage();
+    const persistence = createPromptCompositionPersistence({ storage, debounceMs: 100, storageKey: 'debounce' });
+    const payload = { items: [], base: 'base', neg: '' };
+
+    persistence.scheduleSave(payload);
+    expect(storage.setItem).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(99);
+    expect(storage.setItem).not.toHaveBeenCalled();
+
+    persistence.cancel();
+    vi.advanceTimersByTime(10);
+    expect(storage.setItem).not.toHaveBeenCalled();
+
+    persistence.scheduleSave(payload);
+    vi.advanceTimersByTime(100);
+    expect(storage.setItem).toHaveBeenCalledTimes(1);
+  });
+
+  it('parses and normalises stored compositions', () => {
+    const parsed = parseSavedComposition({
+      items: [
+        { id: 'one', name: 'One', weight: 10 },
+        { id: 'two', name: 'Two', weight: -5 },
+        { id: 'skip' },
+      ],
+      base: 123,
+      neg: null,
+    });
+
+    expect(parsed).not.toBeNull();
+    expect(parsed?.items).toHaveLength(2);
+    expect(parsed?.items[0].weight).toBe(2);
+    expect(parsed?.items[1].weight).toBe(0);
+    expect(parsed?.base).toBe('');
+    expect(parsed?.neg).toBe('');
+  });
+
+  it('handles storage errors gracefully', () => {
+    const storage = {
+      getItem: vi.fn(() => {
+        throw new Error('boom');
+      }),
+      setItem: vi.fn(() => {
+        throw new Error('boom');
+      }),
+    };
+
+    const persistence = createPromptCompositionPersistence({ storage, storageKey: 'error' });
+    expect(() => persistence.save({ items: [], base: '', neg: '' })).not.toThrow();
+    expect(() => persistence.load()).not.toThrow();
+  });
+});

--- a/tests/vue/useAdapterCatalog.spec.ts
+++ b/tests/vue/useAdapterCatalog.spec.ts
@@ -1,0 +1,89 @@
+import { describe, expect, beforeEach, it, vi } from 'vitest';
+import { computed, nextTick, ref } from 'vue';
+import { mount } from '@vue/test-utils';
+
+const adaptersRef = ref([] as any[]);
+const errorRef = ref<unknown>(null);
+const loadingRef = ref(false);
+
+const fetchData = vi.fn(async () => {
+  adaptersRef.value = [
+    { id: 'alpha', name: 'Alpha', description: 'First adapter', active: true },
+    { id: 'beta', name: 'Beta', description: 'Second adapter', active: false },
+  ];
+  return adaptersRef.value;
+});
+
+vi.mock('../../app/frontend/src/services/loraService', () => ({
+  useAdapterListApi: vi.fn(() => ({
+    adapters: computed(() => adaptersRef.value),
+    error: errorRef,
+    isLoading: loadingRef,
+    fetchData,
+  })),
+}));
+
+import { useAdapterCatalog } from '../../app/frontend/src/composables/useAdapterCatalog';
+
+type CatalogReturn = ReturnType<typeof useAdapterCatalog>;
+
+const flush = async () => {
+  await Promise.resolve();
+  await nextTick();
+  await Promise.resolve();
+  await nextTick();
+};
+
+const withSetup = () => {
+  let result: CatalogReturn;
+  mount({
+    template: '<div />',
+    setup() {
+      result = useAdapterCatalog();
+      return result;
+    },
+  });
+  return result!;
+};
+
+describe('useAdapterCatalog', () => {
+  beforeEach(() => {
+    adaptersRef.value = [];
+    errorRef.value = null;
+    loadingRef.value = false;
+    fetchData.mockClear();
+  });
+
+  it('fetches adapters and filters them', async () => {
+    const state = withSetup();
+    await flush();
+
+    expect(fetchData).toHaveBeenCalled();
+    expect(state.adapters.value).toHaveLength(2);
+    expect(state.adapters.value[1].active).toBe(false);
+
+    state.setActiveOnly(true);
+    await nextTick();
+    expect(state.filteredAdapters.value).toHaveLength(1);
+    expect(state.filteredAdapters.value[0].name).toBe('Alpha');
+
+    state.setActiveOnly(false);
+    await nextTick();
+
+    state.setSearchTerm('beta');
+    await nextTick();
+    expect(state.filteredAdapters.value).toHaveLength(1);
+
+    state.setActiveOnly(true);
+    await nextTick();
+    expect(state.filteredAdapters.value).toHaveLength(0);
+  });
+
+  it('refreshes adapters on demand', async () => {
+    const state = withSetup();
+    await flush();
+
+    await state.refresh();
+    expect(fetchData).toHaveBeenCalledTimes(2);
+  });
+});

--- a/tests/vue/usePromptComposition.spec.ts
+++ b/tests/vue/usePromptComposition.spec.ts
@@ -2,43 +2,86 @@ import { describe, expect, beforeEach, it, vi } from 'vitest';
 import { computed, nextTick, ref } from 'vue';
 import { mount } from '@vue/test-utils';
 
-const adaptersRef = ref([] as any[]);
+import type { AdapterSummary, SavedComposition } from '@/types';
+
+const adapterSource = ref<AdapterSummary[]>([]);
+const searchTermRef = ref('');
+const activeOnlyRef = ref(false);
+const isLoadingRef = ref(false);
 const errorRef = ref<unknown>(null);
-const loadingRef = ref(false);
-const fetchData = vi.fn(async () => {
-  adaptersRef.value = [
-    { id: 'alpha', name: 'Alpha', description: 'First adapter', active: true },
-    { id: 'beta', name: 'Beta', description: 'Second adapter', active: false },
-  ];
-  return adaptersRef.value;
+
+const filteredAdapters = computed(() => {
+  const term = searchTermRef.value.trim().toLowerCase();
+  return adapterSource.value.filter((item) => {
+    if (activeOnlyRef.value && !item.active) {
+      return false;
+    }
+
+    if (term) {
+      return item.name.toLowerCase().includes(term);
+    }
+
+    return true;
+  });
 });
 
-const generationServiceMock = vi.hoisted(() => ({
-  createGenerationParams: vi.fn((payload: any) => payload),
-  requestGeneration: vi.fn(async () => {}),
+const setSearchTerm = vi.fn((value: string) => {
+  searchTermRef.value = value;
+});
+
+const setActiveOnly = vi.fn((value: boolean) => {
+  activeOnlyRef.value = value;
+});
+
+const refresh = vi.fn(async () => {
+  return adapterSource.value;
+});
+
+const catalogModuleMock = vi.hoisted(() => ({
+  useAdapterCatalog: vi.fn(),
 }));
 
-const browserMock = vi.hoisted(() => ({
-  copyToClipboard: vi.fn(async () => true),
+vi.mock('../../app/frontend/src/composables/useAdapterCatalog', () => catalogModuleMock);
+
+const clipboardMock = vi.hoisted(() => ({
+  copyPromptToClipboard: vi.fn(async () => true),
 }));
 
-vi.mock('../../app/frontend/src/services/loraService', () => ({
-  useAdapterListApi: vi.fn(() => ({
-    adapters: computed(() => adaptersRef.value),
-    error: errorRef,
-    isLoading: loadingRef,
-    fetchData,
-  })),
+vi.mock('../../app/frontend/src/utils/promptClipboard', () => clipboardMock);
+
+const generationMock = vi.hoisted(() => ({
+  triggerPromptGeneration: vi.fn(async () => true),
 }));
 
-vi.mock('../../app/frontend/src/services/generationService', () => generationServiceMock);
+vi.mock('../../app/frontend/src/utils/promptGeneration', () => generationMock);
 
-vi.mock('../../app/frontend/src/utils/browser', () => browserMock);
+const persistenceState = {
+  saved: ref<SavedComposition | null>(null),
+  load: vi.fn<[], SavedComposition | null>(),
+  save: vi.fn<(payload: SavedComposition) => void>(),
+  scheduleSave: vi.fn<(payload: SavedComposition) => void>(),
+  cancel: vi.fn<[], void>(),
+};
 
-const { createGenerationParams, requestGeneration } = generationServiceMock;
-const { copyToClipboard } = browserMock;
+vi.mock('../../app/frontend/src/utils/promptCompositionPersistence', async () => {
+  const actual = await vi.importActual<typeof import('../../app/frontend/src/utils/promptCompositionPersistence')>(
+    '../../app/frontend/src/utils/promptCompositionPersistence',
+  );
+
+  return {
+    ...actual,
+    createPromptCompositionPersistence: vi.fn(() => ({
+      load: persistenceState.load,
+      save: persistenceState.save,
+      scheduleSave: persistenceState.scheduleSave,
+      cancel: persistenceState.cancel,
+    })),
+  };
+});
 
 import { usePromptComposition } from '../../app/frontend/src/composables/usePromptComposition';
+
+type UsePromptCompositionReturn = ReturnType<typeof usePromptComposition>;
 
 const flush = async () => {
   await Promise.resolve();
@@ -48,7 +91,7 @@ const flush = async () => {
 };
 
 const withSetup = () => {
-  let result: ReturnType<typeof usePromptComposition>;
+  let result: UsePromptCompositionReturn;
   mount({
     template: '<div />',
     setup() {
@@ -61,38 +104,73 @@ const withSetup = () => {
 
 describe('usePromptComposition', () => {
   beforeEach(() => {
-    adaptersRef.value = [];
+    adapterSource.value = [
+      { id: 'alpha', name: 'Alpha', description: 'First adapter', active: true },
+      { id: 'beta', name: 'Beta', description: 'Second adapter', active: false },
+    ];
+    searchTermRef.value = '';
+    activeOnlyRef.value = false;
+    isLoadingRef.value = false;
     errorRef.value = null;
-    loadingRef.value = false;
-    fetchData.mockClear();
-    createGenerationParams.mockClear();
-    requestGeneration.mockClear();
-    copyToClipboard.mockClear();
-    localStorage.clear();
+    setSearchTerm.mockClear();
+    setActiveOnly.mockClear();
+    refresh.mockClear();
+    clipboardMock.copyPromptToClipboard.mockClear();
+    generationMock.triggerPromptGeneration.mockClear();
+    persistenceState.saved.value = null;
+    persistenceState.load.mockImplementation(() => persistenceState.saved.value);
+    persistenceState.save.mockImplementation((payload: SavedComposition) => {
+      persistenceState.saved.value = payload;
+    });
+    persistenceState.scheduleSave.mockImplementation((payload: SavedComposition) => {
+      persistenceState.saved.value = payload;
+    });
+    persistenceState.cancel.mockClear();
+    persistenceState.load.mockClear();
+    persistenceState.save.mockClear();
+    persistenceState.scheduleSave.mockClear();
+    persistenceState.cancel.mockClear();
+    catalogModuleMock.useAdapterCatalog.mockReset();
+    catalogModuleMock.useAdapterCatalog.mockImplementation(() => ({
+      searchTerm: searchTermRef,
+      activeOnly: activeOnlyRef,
+      adapters: computed(() => adapterSource.value),
+      filteredAdapters,
+      isLoading: isLoadingRef,
+      error: errorRef,
+      setSearchTerm,
+      setActiveOnly,
+      refresh,
+    }));
   });
 
-  it('loads adapters and filters them', async () => {
+  it('exposes catalog filters and updates composition weights', async () => {
     const state = withSetup();
     await flush();
 
-    expect(fetchData).toHaveBeenCalled();
-    expect(state.filteredLoras.value).toHaveLength(2);
+    expect(catalogModuleMock.useAdapterCatalog).toHaveBeenCalled();
+    expect(state.catalog.filteredAdapters.value).toHaveLength(2);
 
-    state.setSearchTerm('beta');
+    state.catalog.setSearchTerm('beta');
     await nextTick();
-    expect(state.filteredLoras.value).toHaveLength(1);
-    expect(state.filteredLoras.value[0].name).toBe('Beta');
+    expect(state.catalog.filteredAdapters.value).toHaveLength(1);
+    expect(state.catalog.filteredAdapters.value[0].name).toBe('Beta');
 
-    state.setActiveOnly(true);
+    state.catalog.setActiveOnly(true);
     await nextTick();
-    expect(state.filteredLoras.value).toHaveLength(0);
+    expect(state.catalog.filteredAdapters.value).toHaveLength(0);
+
+    const first = adapterSource.value[0];
+    state.addToComposition(first);
+    state.updateWeight(0, 5);
+    expect(state.activeLoras.value[0].weight).toBe(2);
   });
 
-  it('builds final prompt, copies and generates', async () => {
+  it('builds final prompt, copies and triggers generation through helpers', async () => {
     const state = withSetup();
     await flush();
 
-    const first = state.filteredLoras.value[0];
+    const first = adapterSource.value[0];
     state.addToComposition(first);
     state.setBasePrompt('Shining stars');
     state.setNegativePrompt('blurry');
@@ -102,35 +180,36 @@ describe('usePromptComposition', () => {
     expect(state.finalPrompt.value).toContain('<lora:Alpha:1.0>');
 
     await state.copyPrompt();
-    expect(copyToClipboard).toHaveBeenCalledWith(state.finalPrompt.value);
+    expect(clipboardMock.copyPromptToClipboard).toHaveBeenCalledWith(state.finalPrompt.value);
 
     await state.generateImage();
-    expect(createGenerationParams).toHaveBeenCalledWith({
-      prompt: state.finalPrompt.value,
-      negative_prompt: 'blurry',
-    });
-    expect(requestGeneration).toHaveBeenCalledWith(
+    expect(generationMock.triggerPromptGeneration).toHaveBeenCalledWith(
       expect.objectContaining({
-        loras: [expect.objectContaining({ id: 'alpha', weight: 1 })],
+        prompt: state.finalPrompt.value,
+        negativePrompt: 'blurry',
+        loras: expect.any(Array),
       }),
     );
   });
 
-  it('persists and reloads compositions', async () => {
+  it('persists and reloads compositions using persistence helper', async () => {
     const state = withSetup();
     await flush();
 
-    const first = state.filteredLoras.value[0];
+    const first = adapterSource.value[0];
     state.addToComposition(first);
     state.setBasePrompt('Persist base');
     state.saveComposition();
 
+    expect(persistenceState.save).toHaveBeenCalled();
+
     state.clearComposition();
     expect(state.activeLoras.value).toHaveLength(0);
+
+    persistenceState.load.mockReturnValueOnce(persistenceState.saved.value);
 
     state.loadComposition();
     expect(state.activeLoras.value).toHaveLength(1);
     expect(state.basePrompt.value).toBe('Persist base');
   });
 });
-


### PR DESCRIPTION
## Summary
- extract a reusable adapter catalog composable that centralizes adapter fetching and filtering
- move prompt composition persistence, clipboard, and generation utilities into dedicated helpers and update the main composable to consume them
- adjust PromptComposer and LoraCard components along with new unit coverage for catalog and persistence helpers

## Testing
- npm run test:unit

------
https://chatgpt.com/codex/tasks/task_e_68d20f105d448329891e7adbe998ee61