### PR TITLE
Refactor import/export workflows into modular components

### DIFF
--- a/app/frontend/src/components/ImportExport.vue
+++ b/app/frontend/src/components/ImportExport.vue
@@ -1,6 +1,5 @@
 <template>
   <div class="import-export-container" v-if="isInitialized">
-    <!-- Page Header -->
     <div class="page-header">
       <div class="flex justify-between items-center">
         <div>
@@ -9,14 +8,13 @@
         </div>
         <div class="header-actions">
           <div class="flex items-center space-x-3">
-            <!-- Quick Actions -->
-            <button @click="quickExportAll" class="btn btn-primary btn-sm">
+            <button @click="onQuickExportAll" class="btn btn-primary btn-sm">
               <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 10v6m0 0l-4-4m4 4l4-4m6-2a9 9 0 11-18 0 9 9 0 0118 0z"></path>
               </svg>
               Quick Export All
             </button>
-            
+
             <button @click="viewHistory" class="btn btn-secondary btn-sm">
               <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"></path>
@@ -28,37 +26,44 @@
       </div>
     </div>
 
-    <!-- Main Content Tabs -->
     <div class="card">
       <div class="card-header">
         <div class="border-b border-gray-200">
           <nav class="-mb-px flex space-x-8">
-            <button @click="activeTab = 'export'" 
-                    :class="activeTab === 'export' ? 'tab-button active' : 'tab-button'">
+            <button
+              @click="activeTab = 'export'"
+              :class="activeTab === 'export' ? 'tab-button active' : 'tab-button'"
+            >
               <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 10v6m0 0l-4-4m4 4l4-4m6-2a9 9 0 11-18 0 9 9 0 0118 0z"></path>
               </svg>
               Export Data
             </button>
-            
-            <button @click="activeTab = 'import'" 
-                    :class="activeTab === 'import' ? 'tab-button active' : 'tab-button'">
+
+            <button
+              @click="activeTab = 'import'"
+              :class="activeTab === 'import' ? 'tab-button active' : 'tab-button'"
+            >
               <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M9 19l3 3m0 0l3-3m-3 3V10"></path>
               </svg>
               Import Data
             </button>
-            
-            <button @click="activeTab = 'backup'" 
-                    :class="activeTab === 'backup' ? 'tab-button active' : 'tab-button'">
+
+            <button
+              @click="activeTab = 'backup'"
+              :class="activeTab === 'backup' ? 'tab-button active' : 'tab-button'"
+            >
               <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7H5a2 2 0 00-2 2v9a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-3m-1 4l-3-3m0 0l-3 3m3-3v12"></path>
               </svg>
               Backup/Restore
             </button>
-            
-            <button @click="activeTab = 'migration'" 
-                    :class="activeTab === 'migration' ? 'tab-button active' : 'tab-button'">
+
+            <button
+              @click="activeTab = 'migration'"
+              :class="activeTab === 'migration' ? 'tab-button active' : 'tab-button'"
+            >
               <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 9l4-4 4 4m0 6l-4 4-4-4"></path>
               </svg>
@@ -67,613 +72,77 @@
           </nav>
         </div>
       </div>
-      
+
       <div class="card-body">
-        
-        <!-- Export Tab -->
-        <div v-show="activeTab === 'export'" class="space-y-6">
-          
-          <!-- Export Selection -->
-          <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
-            
-            <!-- Data Types to Export -->
-            <div class="card">
-              <div class="card-header">
-                <h3 class="text-lg font-semibold">Select Data to Export</h3>
-              </div>
-              <div class="card-body space-y-4">
-                
-                <!-- LoRA Data -->
-                <div>
-                  <label class="flex items-center">
-                    <input type="checkbox" 
-                           v-model="exportConfig.loras" 
-                           class="form-checkbox mr-3">
-                    <div>
-                      <div class="font-medium">LoRA Models</div>
-                      <div class="text-sm text-gray-600">All LoRA files, metadata, and configurations</div>
-                    </div>
-                  </label>
-                  
-                  <div v-show="exportConfig.loras" 
-                       class="ml-6 mt-3 space-y-2 transition-all duration-200">
-                    <label class="flex items-center">
-                      <input type="checkbox" 
-                             v-model="exportConfig.lora_files" 
-                             class="form-checkbox mr-2">
-                      <span class="text-sm">Include model files</span>
-                    </label>
-                    <label class="flex items-center">
-                      <input type="checkbox" 
-                             v-model="exportConfig.lora_metadata" 
-                             class="form-checkbox mr-2">
-                      <span class="text-sm">Include metadata only</span>
-                    </label>
-                    <label class="flex items-center">
-                      <input type="checkbox" 
-                             v-model="exportConfig.lora_embeddings" 
-                             class="form-checkbox mr-2">
-                      <span class="text-sm">Include embeddings</span>
-                    </label>
-                  </div>
-                </div>
-                
-                <!-- Generation Results -->
-                <div>
-                  <label class="flex items-center">
-                    <input type="checkbox" 
-                           v-model="exportConfig.generations" 
-                           class="form-checkbox mr-3">
-                    <div>
-                      <div class="font-medium">Generation Results</div>
-                      <div class="text-sm text-gray-600">Generated images and their parameters</div>
-                    </div>
-                  </label>
-                  
-                  <div v-show="exportConfig.generations" 
-                       class="ml-6 mt-3 space-y-2 transition-all duration-200">
-                    <div class="flex items-center space-x-4">
-                      <label class="flex items-center">
-                        <input type="radio" 
-                               name="generation_range" 
-                               value="all" 
-                               v-model="exportConfig.generation_range" 
-                               class="form-radio mr-2">
-                        <span class="text-sm">All generations</span>
-                      </label>
-                      <label class="flex items-center">
-                        <input type="radio" 
-                               name="generation_range" 
-                               value="date_range" 
-                               v-model="exportConfig.generation_range" 
-                               class="form-radio mr-2">
-                        <span class="text-sm">Date range</span>
-                      </label>
-                    </div>
-                    
-                    <div v-show="exportConfig.generation_range === 'date_range'" 
-                         class="grid grid-cols-2 gap-3 transition-all duration-200">
-                      <div>
-                        <label class="form-label text-xs">From Date</label>
-                        <input type="date" 
-                               v-model="exportConfig.date_from" 
-                               class="form-input text-sm">
-                      </div>
-                      <div>
-                        <label class="form-label text-xs">To Date</label>
-                        <input type="date" 
-                               v-model="exportConfig.date_to" 
-                               class="form-input text-sm">
-                      </div>
-                    </div>
-                  </div>
-                </div>
-                
-                <!-- Other data types -->
-                <div>
-                  <label class="flex items-center">
-                    <input type="checkbox" 
-                           v-model="exportConfig.user_data" 
-                           class="form-checkbox mr-3">
-                    <div>
-                      <div class="font-medium">User Data</div>
-                      <div class="text-sm text-gray-600">User preferences and settings</div>
-                    </div>
-                  </label>
-                </div>
-                
-                <div>
-                  <label class="flex items-center">
-                    <input type="checkbox" 
-                           v-model="exportConfig.system_config" 
-                           class="form-checkbox mr-3">
-                    <div>
-                      <div class="font-medium">System Configuration</div>
-                      <div class="text-sm text-gray-600">System settings and configurations</div>
-                    </div>
-                  </label>
-                </div>
-                
-                <div>
-                  <label class="flex items-center">
-                    <input type="checkbox" 
-                           v-model="exportConfig.analytics" 
-                           class="form-checkbox mr-3">
-                    <div>
-                      <div class="font-medium">Analytics Data</div>
-                      <div class="text-sm text-gray-600">Performance metrics and usage statistics</div>
-                    </div>
-                  </label>
-                </div>
-              </div>
-            </div>
-            
-            <!-- Export Options -->
-            <div class="card">
-              <div class="card-header">
-                <h3 class="text-lg font-semibold">Export Options</h3>
-              </div>
-              <div class="card-body space-y-4">
-                
-                <!-- Format Selection -->
-                <div>
-                  <label class="form-label">Export Format</label>
-                  <select v-model="exportConfig.format" class="form-input">
-                    <option value="zip">ZIP Archive</option>
-                    <option value="tar.gz">TAR.GZ Archive</option>
-                    <option value="folder">Folder Structure</option>
-                  </select>
-                </div>
-                
-                <!-- Compression Level -->
-                <div>
-                  <label class="form-label">Compression Level</label>
-                  <select v-model="exportConfig.compression" class="form-input">
-                    <option value="none">No Compression</option>
-                    <option value="fast">Fast Compression</option>
-                    <option value="balanced">Balanced</option>
-                    <option value="maximum">Maximum Compression</option>
-                  </select>
-                </div>
-                
-                <!-- Split Archives -->
-                <div>
-                  <label class="flex items-center">
-                    <input type="checkbox" 
-                           v-model="exportConfig.split_archives" 
-                           class="form-checkbox mr-2">
-                    <span>Split large archives</span>
-                  </label>
-                  <div v-show="exportConfig.split_archives" 
-                       class="mt-2 transition-all duration-200">
-                    <label class="form-label text-sm">Max size per archive (MB)</label>
-                    <input type="number" 
-                           v-model="exportConfig.max_size_mb" 
-                           min="100" 
-                           max="4096" 
-                           class="form-input text-sm">
-                  </div>
-                </div>
-                
-                <!-- Encryption -->
-                <div>
-                  <label class="flex items-center">
-                    <input type="checkbox" 
-                           v-model="exportConfig.encrypt" 
-                           class="form-checkbox mr-2">
-                    <span>Encrypt export</span>
-                  </label>
-                  <div v-show="exportConfig.encrypt" 
-                       class="mt-2 transition-all duration-200">
-                    <label class="form-label text-sm">Password</label>
-                    <input type="password" 
-                           v-model="exportConfig.password" 
-                           class="form-input text-sm">
-                  </div>
-                </div>
-                
-                <!-- Estimated Size -->
-                <div class="p-3 bg-gray-50 rounded">
-                  <div class="text-sm font-medium">Estimated Export Size</div>
-                  <div class="text-lg font-bold text-blue-600">{{ estimatedSize }}</div>
-                  <div class="text-xs text-gray-600">
-                    Processing time: ~{{ estimatedTime }}
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-          
-          <!-- Export Actions -->
-          <div class="flex justify-between items-center pt-6 border-t">
-            <div class="flex items-center space-x-4">
-              <button @click="validateExport" class="btn btn-secondary">
-                Validate Selection
-              </button>
-              <button @click="previewExport" class="btn btn-secondary">
-                Preview Contents
-              </button>
-            </div>
-            <button @click="startExport" 
-                    class="btn btn-primary"
-                    :disabled="!canExport || isExporting">
-              <template v-if="!isExporting">
-                <span>Start Export</span>
-              </template>
-              <template v-else>
-                <div class="flex items-center">
-                  <svg class="animate-spin w-4 h-4 mr-2" fill="none" viewBox="0 0 24 24">
-                    <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
-                    <path class="opacity-75" fill="currentColor" d="m 12 2 a 10,10 0 0,1 10,10 h -4 a 6,6 0 0,0 -6,-6 z"></path>
-                  </svg>
-                  Exporting...
-                </div>
-              </template>
-            </button>
-          </div>
-        </div>
-        
-        <!-- Import Tab -->
-        <div v-show="activeTab === 'import'" class="space-y-6">
-          
-          <!-- Import Options -->
-          <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
-            
-            <!-- File Upload -->
-            <div class="card">
-              <div class="card-header">
-                <h3 class="text-lg font-semibold">Select Import Source</h3>
-              </div>
-              <div class="card-body">
-                
-                <!-- File Upload Area -->
-                <div class="border-2 border-dashed border-gray-300 rounded-lg p-6 text-center hover:border-gray-400 transition-colors"
-                     @drop.prevent="handleFileDrop"
-                     @dragover.prevent="handleDragOver"
-                     @dragleave="handleDragLeave">
-                  <svg class="mx-auto h-12 w-12 text-gray-400" stroke="currentColor" fill="none" viewBox="0 0 48 48">
-                    <path d="M28 8H12a4 4 0 00-4 4v20m32-12v8m0 0v8a4 4 0 01-4 4H12a4 4 0 01-4-4v-4m32-4l-3.172-3.172a4 4 0 00-5.656 0L28 28M8 32l9.172-9.172a4 4 0 015.656 0L28 28m0 0l4 4m4-24h8m-4-4v8m-12 4h.02" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></path>
-                  </svg>
-                  <div class="mt-4">
-                    <label class="cursor-pointer">
-                      <span class="mt-2 block text-sm font-medium text-gray-900">
-                        Drop files here or click to upload
-                      </span>
-                      <input type="file" 
-                             @change="handleFileSelect" 
-                             multiple 
-                             accept=".zip,.tar.gz,.json,.lora,.safetensors"
-                             class="hidden">
-                    </label>
-                    <p class="mt-2 text-xs text-gray-500">
-                      Supports ZIP, TAR.GZ, JSON, LoRA, SafeTensors files
-                    </p>
-                  </div>
-                </div>
-                
-                <!-- Selected Files -->
-                <div v-show="importFiles.length > 0" class="mt-4 transition-all duration-200">
-                  <h4 class="text-sm font-medium mb-2">Selected Files</h4>
-                  <div class="space-y-2">
-                    <div v-for="file in importFiles" :key="file.name" class="flex items-center justify-between p-2 bg-gray-50 rounded">
-                      <div class="flex items-center space-x-2">
-                        <svg class="w-4 h-4 text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"></path>
-                        </svg>
-                        <span class="text-sm">{{ file.name }}</span>
-                      </div>
-                      <div class="flex items-center space-x-2">
-                        <span class="text-xs text-gray-500">{{ formatFileSize(file.size) }}</span>
-                        <button @click="removeFile(file)" class="text-red-500 hover:text-red-700">
-                          <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
-                          </svg>
-                        </button>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
-            
-            <!-- Import Settings -->
-            <div class="card">
-              <div class="card-header">
-                <h3 class="text-lg font-semibold">Import Settings</h3>
-              </div>
-              <div class="card-body space-y-4">
-                
-                <!-- Import Mode -->
-                <div>
-                  <label class="form-label">Import Mode</label>
-                  <select v-model="importConfig.mode" class="form-input">
-                    <option value="merge">Merge with existing data</option>
-                    <option value="replace">Replace existing data</option>
-                    <option value="skip">Skip conflicting items</option>
-                  </select>
-                </div>
-                
-                <!-- Conflict Resolution -->
-                <div>
-                  <label class="form-label">Conflict Resolution</label>
-                  <select v-model="importConfig.conflict_resolution" class="form-input">
-                    <option value="ask">Ask for each conflict</option>
-                    <option value="keep_existing">Keep existing</option>
-                    <option value="overwrite">Overwrite with imported</option>
-                    <option value="rename">Rename imported items</option>
-                  </select>
-                </div>
-                
-                <!-- Validation -->
-                <div>
-                  <label class="flex items-center">
-                    <input type="checkbox" 
-                           v-model="importConfig.validate" 
-                           class="form-checkbox mr-2">
-                    <span>Validate data before import</span>
-                  </label>
-                </div>
-                
-                <!-- Backup Before Import -->
-                <div>
-                  <label class="flex items-center">
-                    <input type="checkbox" 
-                           v-model="importConfig.backup_before" 
-                           class="form-checkbox mr-2">
-                    <span>Create backup before import</span>
-                  </label>
-                </div>
-                
-                <!-- Encryption -->
-                <div v-show="hasEncryptedFiles" class="transition-all duration-200">
-                  <label class="form-label">Archive Password</label>
-                  <input type="password" 
-                         v-model="importConfig.password" 
-                         placeholder="Enter password for encrypted archives"
-                         class="form-input">
-                </div>
-              </div>
-            </div>
-          </div>
-          
-          <!-- Import Preview -->
-          <div v-show="importPreview.length > 0" class="card transition-all duration-200">
-            <div class="card-header">
-              <h3 class="text-lg font-semibold">Import Preview</h3>
-              <p class="text-sm text-gray-600">Review what will be imported</p>
-            </div>
-            <div class="card-body">
-              <div class="overflow-x-auto">
-                <table class="min-w-full divide-y divide-gray-200">
-                  <thead class="bg-gray-50">
-                    <tr>
-                      <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Type</th>
-                      <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Name</th>
-                      <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Status</th>
-                      <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Action</th>
-                    </tr>
-                  </thead>
-                  <tbody class="bg-white divide-y divide-gray-200">
-                    <tr v-for="item in importPreview" :key="item.id">
-                      <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">{{ item.type }}</td>
-                      <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900">{{ item.name }}</td>
-                      <td class="px-6 py-4 whitespace-nowrap">
-                        <span class="inline-flex px-2 py-1 text-xs font-semibold rounded-full"
-                              :class="getStatusClasses(item.status)">
-                          {{ item.status }}
-                        </span>
-                      </td>
-                      <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900">{{ item.action }}</td>
-                    </tr>
-                  </tbody>
-                </table>
-              </div>
-            </div>
-          </div>
-          
-          <!-- Import Actions -->
-          <div class="flex justify-between items-center pt-6 border-t">
-            <div class="flex items-center space-x-4">
-              <button @click="analyzeFiles" 
-                      class="btn btn-secondary"
-                      :disabled="importFiles.length === 0">
-                Analyze Files
-              </button>
-              <button @click="validateImport" 
-                      class="btn btn-secondary"
-                      :disabled="importFiles.length === 0">
-                Validate Import
-              </button>
-            </div>
-            <button @click="startImport" 
-                    class="btn btn-primary"
-                    :disabled="importFiles.length === 0 || isImporting">
-              <template v-if="!isImporting">
-                <span>Start Import</span>
-              </template>
-              <template v-else>
-                <div class="flex items-center">
-                  <svg class="animate-spin w-4 h-4 mr-2" fill="none" viewBox="0 0 24 24">
-                    <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
-                    <path class="opacity-75" fill="currentColor" d="m 12 2 a 10,10 0 0,1 10,10 h -4 a 6,6 0 0,0 -6,-6 z"></path>
-                  </svg>
-                  Importing...
-                </div>
-              </template>
-            </button>
-          </div>
-        </div>
-        
-        <!-- Backup/Restore Tab -->
-        <div v-show="activeTab === 'backup'" class="space-y-6">
-          <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
-            <button @click="createFullBackup" class="card card-interactive text-center p-6">
-              <svg class="w-12 h-12 mx-auto mb-4 text-blue-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7H5a2 2 0 00-2 2v9a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-3m-1 4l-3-3m0 0l-3 3m3-3v12"></path>
-              </svg>
-              <h3 class="text-lg font-semibold mb-2">Full System Backup</h3>
-              <p class="text-sm text-gray-600">Complete backup of all data and settings</p>
-            </button>
-            
-            <button @click="createQuickBackup" class="card card-interactive text-center p-6">
-              <svg class="w-12 h-12 mx-auto mb-4 text-green-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 10V3L4 14h7v7l9-11h-7z"></path>
-              </svg>
-              <h3 class="text-lg font-semibold mb-2">Quick Backup</h3>
-              <p class="text-sm text-gray-600">Essential data only for fast backup</p>
-            </button>
-            
-            <button @click="scheduleBackup" class="card card-interactive text-center p-6">
-              <svg class="w-12 h-12 mx-auto mb-4 text-purple-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"></path>
-              </svg>
-              <h3 class="text-lg font-semibold mb-2">Schedule Backup</h3>
-              <p class="text-sm text-gray-600">Automatic recurring backups</p>
-            </button>
-          </div>
-          
-          <!-- Backup History -->
-          <div class="card">
-            <div class="card-header">
-              <h3 class="text-lg font-semibold">Backup History</h3>
-              <p class="text-sm text-gray-600">Manage existing backups</p>
-            </div>
-            <div class="card-body">
-              <div class="overflow-x-auto">
-                <table class="min-w-full divide-y divide-gray-200">
-                  <thead class="bg-gray-50">
-                    <tr>
-                      <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Date</th>
-                      <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Type</th>
-                      <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Size</th>
-                      <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Status</th>
-                      <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Actions</th>
-                    </tr>
-                  </thead>
-                  <tbody class="bg-white divide-y divide-gray-200">
-                    <tr v-for="backup in backupHistory" :key="backup.id">
-                      <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
-                        {{ formatDate(backup.created_at) }}
-                      </td>
-                      <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900">{{ backup.type }}</td>
-                      <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
-                        {{ formatFileSize(backup.size) }}
-                      </td>
-                      <td class="px-6 py-4 whitespace-nowrap">
-                        <span class="inline-flex px-2 py-1 text-xs font-semibold rounded-full"
-                              :class="backup.status === 'completed' ? 'bg-green-100 text-green-800' : 
-                                      backup.status === 'failed' ? 'bg-red-100 text-red-800' : 
-                                      'bg-yellow-100 text-yellow-800'">
-                          {{ backup.status }}
-                        </span>
-                      </td>
-                      <td class="px-6 py-4 whitespace-nowrap text-sm font-medium">
-                        <div class="flex space-x-2">
-                          <button @click="downloadBackup(backup.id)" class="text-blue-600 hover:text-blue-900">
-                            Download
-                          </button>
-                          <button @click="restoreBackup(backup.id)" class="text-green-600 hover:text-green-900">
-                            Restore
-                          </button>
-                          <button @click="deleteBackup(backup.id)" class="text-red-600 hover:text-red-900">
-                            Delete
-                          </button>
-                        </div>
-                      </td>
-                    </tr>
-                    <tr v-if="backupHistory.length === 0">
-                      <td colspan="5" class="px-6 py-4 text-center text-sm text-gray-500">
-                        No backups found. Create your first backup above.
-                      </td>
-                    </tr>
-                  </tbody>
-                </table>
-              </div>
-            </div>
-          </div>
-        </div>
-        
-        <!-- Migration Tab -->
-        <div v-show="activeTab === 'migration'" class="space-y-6">
-          <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
-            
-            <!-- Version Migration -->
-            <div class="card">
-              <div class="card-header">
-                <h3 class="text-lg font-semibold">Version Migration</h3>
-                <p class="text-sm text-gray-600">Migrate data between software versions</p>
-              </div>
-              <div class="card-body space-y-4">
-                <div>
-                  <label class="form-label">From Version</label>
-                  <select v-model="migrationConfig.from_version" class="form-input">
-                    <option value="1.0">Version 1.0</option>
-                    <option value="1.1">Version 1.1</option>
-                    <option value="2.0">Version 2.0</option>
-                  </select>
-                </div>
-                <div>
-                  <label class="form-label">To Version</label>
-                  <select v-model="migrationConfig.to_version" class="form-input">
-                    <option value="2.1">Version 2.1 (Current)</option>
-                    <option value="3.0">Version 3.0 (Beta)</option>
-                  </select>
-                </div>
-                <button @click="startVersionMigration" class="btn btn-primary w-full">
-                  Start Version Migration
-                </button>
-              </div>
-            </div>
-            
-            <!-- Platform Migration -->
-            <div class="card">
-              <div class="card-header">
-                <h3 class="text-lg font-semibold">Platform Migration</h3>
-                <p class="text-sm text-gray-600">Migrate from other LoRA management systems</p>
-              </div>
-              <div class="card-body space-y-4">
-                <div>
-                  <label class="form-label">Source Platform</label>
-                  <select v-model="migrationConfig.source_platform" class="form-input">
-                    <option value="automatic1111">Automatic1111</option>
-                    <option value="invokeai">InvokeAI</option>
-                    <option value="comfyui">ComfyUI</option>
-                    <option value="fooocus">Fooocus</option>
-                    <option value="other">Other</option>
-                  </select>
-                </div>
-                <div>
-                  <label class="form-label">Data Location</label>
-                  <input type="text" 
-                         v-model="migrationConfig.source_path" 
-                         placeholder="/path/to/source/data"
-                         class="form-input">
-                </div>
-                <button @click="startPlatformMigration" class="btn btn-primary w-full">
-                  Start Platform Migration
-                </button>
-              </div>
-            </div>
-          </div>
-        </div>
+        <ExportConfigurationPanel
+          v-show="activeTab === 'export'"
+          :config="exportConfig"
+          :can-export="canExport"
+          :estimated-size="estimatedSize"
+          :estimated-time="estimatedTime"
+          :is-exporting="isExporting"
+          @update-config="onExportConfigUpdate"
+          @validate="validateExport"
+          @preview="previewExport"
+          @start="() => startExport()"
+        />
+
+        <ImportProcessingPanel
+          v-show="activeTab === 'import'"
+          :config="importConfig"
+          :files="importFiles"
+          :preview="importPreview"
+          :has-encrypted-files="hasEncryptedFiles"
+          :is-importing="isImporting"
+          :format-file-size="formatFileSize"
+          :get-status-classes="getStatusClasses"
+          @update-config="onImportConfigUpdate"
+          @add-files="onImportFilesAdded"
+          @remove-file="onImportFileRemoved"
+          @analyze="() => analyzeFiles()"
+          @validate="validateImport"
+          @start="() => startImport()"
+        />
+
+        <BackupManagementPanel
+          v-show="activeTab === 'backup'"
+          :history="backupHistory"
+          :format-file-size="formatFileSize"
+          :format-date="formatDate"
+          @create-full-backup="() => createFullBackup()"
+          @create-quick-backup="() => createQuickBackup()"
+          @schedule-backup="scheduleBackup"
+          @download-backup="downloadBackup"
+          @restore-backup="restoreBackup"
+          @delete-backup="deleteBackup"
+        />
+
+        <MigrationWorkflowPanel
+          v-show="activeTab === 'migration'"
+          :config="migrationConfig"
+          @update-config="onMigrationConfigUpdate"
+          @start-version-migration="startVersionMigration"
+          @start-platform-migration="startPlatformMigration"
+        />
       </div>
     </div>
 
-    <!-- Progress Modal -->
-    <div v-show="showProgress" 
-         class="fixed inset-0 z-50 overflow-y-auto transition-opacity duration-300"
-         :class="showProgress ? 'opacity-100' : 'opacity-0'"
-         role="dialog"
-         aria-modal="true"
-         :aria-busy="showProgress"
-         aria-labelledby="progress-title">
+    <div
+      v-show="showProgress"
+      class="fixed inset-0 z-50 overflow-y-auto transition-opacity duration-300"
+      :class="showProgress ? 'opacity-100' : 'opacity-0'"
+      role="dialog"
+      aria-modal="true"
+      :aria-busy="showProgress"
+      aria-labelledby="progress-title"
+    >
       <div class="flex items-center justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:block sm:p-0">
         <div class="fixed inset-0 bg-gray-500 bg-opacity-75"></div>
-        
+
         <div class="inline-block align-bottom bg-white rounded-lg text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-lg sm:w-full">
           <div class="bg-white px-4 pt-5 pb-4 sm:p-6 sm:pb-4">
             <h3 id="progress-title" class="text-lg leading-6 font-medium text-gray-900 mb-4">{{ progressTitle }}</h3>
-            
+
             <div class="space-y-4">
               <div>
                 <div class="flex justify-between text-sm mb-1">
@@ -681,11 +150,13 @@
                   <span>{{ progressValue }}%</span>
                 </div>
                 <div class="w-full bg-gray-200 rounded-full h-2">
-                  <div class="bg-blue-600 h-2 rounded-full transition-all duration-500"
-                       :style="`width: ${progressValue}%`"></div>
+                  <div
+                    class="bg-blue-600 h-2 rounded-full transition-all duration-500"
+                    :style="`width: ${progressValue}%`"
+                  ></div>
                 </div>
               </div>
-              
+
               <div class="max-h-40 overflow-y-auto text-xs font-mono bg-gray-100 p-3 rounded">
                 <div v-for="message in progressMessages" :key="message.id">
                   {{ message.text }}
@@ -694,9 +165,11 @@
             </div>
           </div>
           <div class="bg-gray-50 px-4 py-3 sm:px-6 sm:flex sm:flex-row-reverse">
-            <button @click="cancelOperation" 
-                    type="button" 
-                    class="w-full inline-flex justify-center rounded-md border border-gray-300 shadow-sm px-4 py-2 bg-white text-base font-medium text-gray-700 hover:bg-gray-50 sm:ml-3 sm:w-auto sm:text-sm">
+            <button
+              @click="cancelOperation"
+              type="button"
+              class="w-full inline-flex justify-center rounded-md border border-gray-300 shadow-sm px-4 py-2 bg-white text-base font-medium text-gray-700 hover:bg-gray-50 sm:ml-3 sm:w-auto sm:text-sm"
+            >
               Cancel
             </button>
           </div>
@@ -704,721 +177,262 @@
       </div>
     </div>
 
-    <!-- Toast Notifications -->
-    <div v-show="showToast" 
-         class="fixed top-4 right-4 z-50 px-4 py-2 rounded-lg shadow-lg transition-all duration-300"
-         :class="toastClasses">
+    <div
+      v-show="showToast"
+      class="fixed top-4 right-4 z-50 px-4 py-2 rounded-lg shadow-lg transition-all duration-300"
+      :class="toastClasses"
+    >
       {{ toastMessage }}
     </div>
   </div>
-  
-  <!-- Loading state -->
+
   <div v-else class="py-12 text-center text-gray-500">
     <svg class="animate-spin w-8 h-8 mx-auto mb-4" viewBox="0 0 24 24" fill="none" stroke="currentColor">
       <circle cx="12" cy="12" r="10" stroke-width="4" class="opacity-25"></circle>
       <path d="M4 12a8 8 0 018-8" stroke-width="4" class="opacity-75"></path>
     </svg>
-    <div>Preparing import/export...</div>
+    Loading import/export workflows...
   </div>
 </template>
 
-<script>
-import { ref, reactive, computed, watch, onMounted } from 'vue';
+<script setup lang="ts">
+import { computed, onMounted, ref } from 'vue';
 
-import { getJson, postJson, requestBlob, requestJson, ensureData, getFilenameFromContentDisposition } from '@/utils/api';
-import { downloadFile } from '@/utils/browser';
+import BackupManagementPanel from './import-export/BackupManagementPanel.vue';
+import ExportConfigurationPanel from './import-export/ExportConfigurationPanel.vue';
+import ImportProcessingPanel from './import-export/ImportProcessingPanel.vue';
+import MigrationWorkflowPanel from './import-export/MigrationWorkflowPanel.vue';
+
+import { useBackupWorkflow } from '@/composables/useBackupWorkflow';
+import { useExportWorkflow, type ExportConfig, type ProgressUpdate } from '@/composables/useExportWorkflow';
+import { useImportWorkflow, type ImportConfig } from '@/composables/useImportWorkflow';
+import { useMigrationWorkflow, type MigrationConfig } from '@/composables/useMigrationWorkflow';
 import { formatDateTime, formatFileSize as formatBytes } from '@/utils/format';
 
-export default {
-  name: 'ImportExport',
-  setup() {
-    // Component state
-    const isInitialized = ref(false);
-    const activeTab = ref('export');
-    
-    // Operation states
-    const isExporting = ref(false);
-    const isImporting = ref(false);
-    const isMigrating = ref(false);
-    
-    // Progress tracking
-    const showProgress = ref(false);
-    const progressValue = ref(0);
-    const currentStep = ref('');
-    const progressMessages = ref([]);
-    const progressTitle = computed(() => {
-      if (isExporting.value) return 'Export Progress';
-      if (isImporting.value) return 'Import Progress';
-      if (isMigrating.value) return 'Migration Progress';
+type OperationType = 'export' | 'import' | 'migration';
+
+type ExportConfigUpdate = {
+  [K in keyof ExportConfig]: { key: K; value: ExportConfig[K] }
+}[keyof ExportConfig];
+
+type ImportConfigUpdate = {
+  [K in keyof ImportConfig]: { key: K; value: ImportConfig[K] }
+}[keyof ImportConfig];
+
+type MigrationConfigUpdate = {
+  [K in keyof MigrationConfig]: { key: K; value: MigrationConfig[K] }
+}[keyof MigrationConfig];
+
+const isInitialized = ref(false);
+const activeTab = ref<'export' | 'import' | 'backup' | 'migration'>('export');
+
+const showProgress = ref(false);
+const progressValue = ref(0);
+const currentStep = ref('');
+const progressMessages = ref<Array<{ id: number; text: string }>>([]);
+const currentOperation = ref<OperationType | null>(null);
+
+const showToast = ref(false);
+const toastMessage = ref('');
+const toastType = ref<'success' | 'error' | 'warning' | 'info'>('info');
+let toastTimeout: ReturnType<typeof setTimeout> | undefined;
+
+const progressTitle = computed(() => {
+  switch (currentOperation.value) {
+    case 'export':
+      return 'Export Progress';
+    case 'import':
+      return 'Import Progress';
+    case 'migration':
+      return 'Migration Progress';
+    default:
       return 'Progress';
-    });
-    
-    // Toast notifications
-    const showToast = ref(false);
-    const toastMessage = ref('');
-    const toastType = ref('info');
-    const toastClasses = computed(() => {
-      const baseClasses = 'px-4 py-2 rounded-lg shadow-lg';
-      switch (toastType.value) {
-        case 'success': return `${baseClasses} bg-green-500 text-white`;
-        case 'error': return `${baseClasses} bg-red-500 text-white`;
-        case 'warning': return `${baseClasses} bg-yellow-500 text-white`;
-        default: return `${baseClasses} bg-blue-500 text-white`;
-      }
-    });
-    
-    // Export configuration
-    const exportConfig = reactive({
-      loras: true,
-      lora_files: true,
-      lora_metadata: true,
-      lora_embeddings: false,
-      generations: false,
-      generation_range: 'all',
-      date_from: '',
-      date_to: '',
-      user_data: false,
-      system_config: false,
-      analytics: false,
-      format: 'zip',
-      compression: 'balanced',
-      split_archives: false,
-      max_size_mb: 1024,
-      encrypt: false,
-      password: ''
-    });
-    
-    // Import configuration
-    const importConfig = reactive({
-      mode: 'merge',
-      conflict_resolution: 'ask',
-      validate: true,
-      backup_before: true,
-      password: ''
-    });
-    
-    // Migration configuration
-    const migrationConfig = reactive({
-      from_version: '2.0',
-      to_version: '2.1',
-      source_platform: 'automatic1111',
-      source_path: ''
-    });
-    
-    // Import state
-    const importFiles = ref([]);
-    const importPreview = ref([]);
-    const hasEncryptedFiles = computed(() => 
-      importFiles.value.some(file => 
-        file.name.includes('encrypted') || 
-        file.name.includes('password') || 
-        file.name.includes('.enc')
-      )
-    );
-    
-    // Backup state
-    const backupHistory = ref([]);
-    
-    // Export estimates
-    const estimatedSize = ref('0 MB');
-    const estimatedTime = ref('0 minutes');
-    
-    // Computed properties
-    const canExport = computed(() => 
-      exportConfig.loras || 
-      exportConfig.generations || 
-      exportConfig.user_data || 
-      exportConfig.system_config || 
-      exportConfig.analytics
-    );
-    
-    // Watch for config changes to update estimates
-    watch(exportConfig, async () => {
-      await updateEstimates();
-    }, { deep: true });
-    
-    // Utility functions
-    const formatFileSize = (bytes) => formatBytes(typeof bytes === 'number' ? bytes : 0);
+  }
+});
 
-    const formatDate = (dateString) => formatDateTime(dateString, {
-      year: 'numeric',
-      month: 'short',
-      day: 'numeric',
-      hour: '2-digit',
-      minute: '2-digit'
-    });
-    
-    const showToastMessage = (message, type = 'info') => {
-      toastMessage.value = message;
-      toastType.value = type;
-      showToast.value = true;
-      
-      setTimeout(() => {
-        showToast.value = false;
-      }, 3000);
-    };
-    
-    const getStatusClasses = (status) => {
-      const statusClasses = {
-        'new': 'bg-green-100 text-green-800',
-        'conflict': 'bg-yellow-100 text-yellow-800',
-        'existing': 'bg-gray-100 text-gray-800',
-        'error': 'bg-red-100 text-red-800'
-      };
-      return statusClasses[status] || 'bg-gray-100 text-gray-800';
-    };
-    
-    const updateProgressDisplay = (progress) => {
-      if (progress.value !== undefined) progressValue.value = progress.value;
-      if (progress.step !== undefined) currentStep.value = progress.step;
-      if (progress.message !== undefined) {
-        progressMessages.value.push({
-          id: Date.now(),
-          text: `[${new Date().toLocaleTimeString()}] ${progress.message}`
-        });
-      }
-    };
-    
-    // Export functions
-    const updateEstimates = async () => {
-      try {
-        const estimates = ensureData(
-          await postJson('/api/v1/export/estimate', { ...exportConfig })
-        );
+const toastClasses = computed(() => {
+  const baseClasses = 'px-4 py-2 rounded-lg shadow-lg';
+  switch (toastType.value) {
+    case 'success':
+      return `${baseClasses} bg-green-500 text-white`;
+    case 'error':
+      return `${baseClasses} bg-red-500 text-white`;
+    case 'warning':
+      return `${baseClasses} bg-yellow-500 text-white`;
+    default:
+      return `${baseClasses} bg-blue-500 text-white`;
+  }
+});
 
-        if (estimates && typeof estimates === 'object') {
-          const { size, time } = estimates;
-          if (typeof size === 'string') {
-            estimatedSize.value = size;
-          }
-          if (typeof time === 'string') {
-            estimatedTime.value = time;
-          }
-        } else {
-          updateEstimatesLocal();
-        }
-      } catch (error) {
-        if (import.meta.env.DEV) {
-          console.warn('Failed to fetch export estimates:', error)
-        }
-        updateEstimatesLocal();
-      }
-    };
-    
-    const updateEstimatesLocal = () => {
-      let sizeBytes = 0;
-      let timeMinutes = 0;
-      
-      if (exportConfig.loras) {
-        sizeBytes += 10 * 1024 * 1024; // 10MB for metadata
-        timeMinutes += 2;
-        
-        if (exportConfig.lora_files) {
-          sizeBytes += 500 * 1024 * 1024; // 500MB for model files
-          timeMinutes += 10;
-        }
-        
-        if (exportConfig.lora_embeddings) {
-          sizeBytes += 100 * 1024 * 1024; // 100MB for embeddings
-          timeMinutes += 3;
-        }
-      }
-      
-      if (exportConfig.generations) {
-        if (exportConfig.generation_range === 'all') {
-          sizeBytes += 200 * 1024 * 1024; // 200MB
-          timeMinutes += 5;
-        } else {
-          sizeBytes += 50 * 1024 * 1024; // 50MB for date range
-          timeMinutes += 2;
-        }
-      }
-      
-      if (exportConfig.user_data) {
-        sizeBytes += 5 * 1024 * 1024; // 5MB
-        timeMinutes += 1;
-      }
-      
-      if (exportConfig.system_config) {
-        sizeBytes += 1 * 1024 * 1024; // 1MB
-        timeMinutes += 1;
-      }
-      
-      if (exportConfig.analytics) {
-        sizeBytes += 20 * 1024 * 1024; // 20MB
-        timeMinutes += 2;
-      }
-      
-      // Apply compression
-      const compressionRatio = {
-        'none': 1.0,
-        'fast': 0.7,
-        'balanced': 0.5,
-        'maximum': 0.3
-      }[exportConfig.compression];
-      
-      sizeBytes *= compressionRatio;
-      
-      estimatedSize.value = formatFileSize(sizeBytes);
-      estimatedTime.value = Math.max(1, Math.ceil(timeMinutes)) + ' minutes';
-    };
-    
-    const validateExport = () => {
-      const issues = [];
-      
-      if (!canExport.value) {
-        issues.push('No data types selected for export');
-      }
-      
-      if (exportConfig.generations && 
-          exportConfig.generation_range === 'date_range' &&
-          (!exportConfig.date_from || !exportConfig.date_to)) {
-        issues.push('Date range required for generation export');
-      }
-      
-      if (exportConfig.split_archives && exportConfig.max_size_mb < 10) {
-        issues.push('Maximum archive size too small for split archives');
-      }
-      
-      if (exportConfig.encrypt && !exportConfig.password) {
-        issues.push('Password required for encrypted export');
-      }
-      
-      if (issues.length > 0) {
-        showToastMessage(`Validation failed: ${issues.join(', ')}`, 'error');
-      } else {
-        showToastMessage('Export configuration is valid', 'success');
-      }
-    };
-    
-    const previewExport = () => {
-      showToastMessage('Preview functionality coming soon', 'info');
-    };
-    
-    const startExport = async () => {
-      try {
-        isExporting.value = true;
-        showProgress.value = true;
-        progressValue.value = 0;
-        progressMessages.value = [];
+const notify: Parameters<typeof useExportWorkflow>[0]['notify'] = (message, type = 'info') => {
+  toastMessage.value = message;
+  toastType.value = type;
+  showToast.value = true;
+  if (toastTimeout) {
+    clearTimeout(toastTimeout);
+  }
+  toastTimeout = setTimeout(() => {
+    showToast.value = false;
+  }, 3000);
+};
 
-        updateProgressDisplay({
-          value: 10,
-          step: 'Preparing export...',
-          message: 'Validating configuration'
-        });
+const resetProgress = () => {
+  progressValue.value = 0;
+  currentStep.value = '';
+  progressMessages.value = [];
+};
 
-        updateProgressDisplay({
-          value: 50,
-          step: 'Generating export...',
-          message: 'Creating archive'
-        });
+const beginProgress = (operation: OperationType) => {
+  currentOperation.value = operation;
+  resetProgress();
+  showProgress.value = true;
+};
 
-        const { blob, response } = await requestBlob('/api/v1/export', {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json'
-          },
-          body: JSON.stringify({ ...exportConfig })
-        });
-
-        updateProgressDisplay({
-          value: 90,
-          step: 'Finalizing export...',
-          message: 'Preparing download'
-        });
-
-        const contentDisposition = response.headers.get('Content-Disposition');
-        const fallbackName = `lora_export_${new Date().toISOString().slice(0, 10)}.${exportConfig.format}`;
-        const filename = getFilenameFromContentDisposition(contentDisposition) ?? fallbackName;
-
-        downloadFile(blob, filename);
-
-        updateProgressDisplay({
-          value: 100,
-          step: 'Export completed',
-          message: 'Download started'
-        });
-
-        showToastMessage('Export completed successfully', 'success');
-
-      } catch (error) {
-        showToastMessage(`Export failed: ${error.message}`, 'error');
-      } finally {
-        isExporting.value = false;
-        showProgress.value = false;
+const updateProgress = (update: ProgressUpdate) => {
+  if (typeof update.value === 'number') {
+    progressValue.value = update.value;
+  }
+  if (typeof update.step === 'string') {
+    currentStep.value = update.step;
+  }
+  if (update.message) {
+    progressMessages.value = [
+      ...progressMessages.value,
+      {
+        id: Date.now() + Math.random(),
+        text: `[${new Date().toLocaleTimeString()}] ${update.message}`
       }
-    };
-    
-    const quickExportAll = () => {
-      exportConfig.loras = true;
-      exportConfig.lora_files = true;
-      exportConfig.generations = true;
-      exportConfig.user_data = true;
-      exportConfig.system_config = true;
-      startExport();
-    };
-    
-    // Import functions
-    const handleFileDrop = (event) => {
-      const droppedFiles = Array.from(event.dataTransfer.files);
-      const validFiles = validateImportFiles(droppedFiles);
-      importFiles.value = [...importFiles.value, ...validFiles];
-      
-      if (validFiles.length < droppedFiles.length) {
-        showToastMessage('Some files were skipped (unsupported format)', 'warning');
-      }
-    };
-    
-    const handleFileSelect = (event) => {
-      const selectedFiles = Array.from(event.target.files);
-      const validFiles = validateImportFiles(selectedFiles);
-      importFiles.value = [...importFiles.value, ...validFiles];
-      
-      if (validFiles.length < selectedFiles.length) {
-        showToastMessage('Some files were skipped (unsupported format)', 'warning');
-      }
-    };
-    
-    const validateImportFiles = (files) => {
-      const validExtensions = ['.zip', '.tar.gz', '.json', '.lora', '.safetensors'];
-      return files.filter(file => {
-        const extension = getFileExtension(file.name);
-        return validExtensions.includes(extension);
-      });
-    };
-    
-    const getFileExtension = (filename) => {
-      if (filename.endsWith('.tar.gz')) return '.tar.gz';
-      const lastDot = filename.lastIndexOf('.');
-      return lastDot !== -1 ? filename.substring(lastDot) : '';
-    };
-    
-    const removeFile = (fileToRemove) => {
-      importFiles.value = importFiles.value.filter(file => file !== fileToRemove);
-      if (importFiles.value.length === 0) {
-        importPreview.value = [];
-      }
-    };
-    
-    const handleDragOver = (event) => {
-      event.preventDefault();
-      event.dataTransfer.dropEffect = 'copy';
-      event.currentTarget.classList.add('border-blue-500', 'bg-blue-50');
-    };
-    
-    const handleDragLeave = (event) => {
-      event.currentTarget.classList.remove('border-blue-500', 'bg-blue-50');
-    };
-    
-    const analyzeFiles = async () => {
-      if (importFiles.value.length === 0) return;
-      
-      try {
-        showToastMessage('Analyzing import files...', 'info');
-        
-        // Simulate file analysis
-        await new Promise(resolve => setTimeout(resolve, 1500));
-        
-        // Generate preview data
-        const preview = [];
-        const types = ['LoRA', 'Generation', 'Config', 'User Data'];
-        const statuses = ['new', 'conflict', 'existing'];
-        const actions = ['Import', 'Skip', 'Overwrite', 'Rename'];
-        
-        importFiles.value.forEach((file, fileIndex) => {
-          const itemsPerFile = Math.floor(Math.random() * 5) + 1;
-          
-          for (let i = 0; i < itemsPerFile; i++) {
-            const type = types[Math.floor(Math.random() * types.length)];
-            const status = statuses[Math.floor(Math.random() * statuses.length)];
-            
-            preview.push({
-              id: `${fileIndex}_${i}`,
-              type: type,
-              name: `${type.toLowerCase()}_${file.name}_${i + 1}`,
-              status: status,
-              action: status === 'conflict' ? 'Ask' : actions[Math.floor(Math.random() * actions.length)]
-            });
-          }
-        });
-        
-        importPreview.value = preview;
-        showToastMessage('File analysis completed', 'success');
-        
-      } catch (error) {
-        showToastMessage(`Analysis failed: ${error.message}`, 'error');
-      }
-    };
-    
-    const validateImport = () => {
-      const issues = [];
-      
-      if (importFiles.value.length === 0) {
-        issues.push('No files selected for import');
-      }
-      
-      if (importConfig.mode === 'replace' && !importConfig.backup_before) {
-        issues.push('Backup recommended when using replace mode');
-      }
-      
-      if (issues.length > 0) {
-        showToastMessage(`Validation failed: ${issues.join(', ')}`, 'error');
-      } else {
-        showToastMessage('Import configuration is valid', 'success');
-      }
-    };
-    
-    const startImport = async () => {
-      if (importFiles.value.length === 0) {
-        showToastMessage('No files selected for import', 'error');
-        return;
-      }
-      
-      try {
-        isImporting.value = true;
-        showProgress.value = true;
-        progressValue.value = 0;
-        progressMessages.value = [];
-        
-        updateProgressDisplay({
-          value: 10,
-          step: 'Preparing import...',
-          message: 'Validating files'
-        });
-        
-        // Create FormData for multipart upload
-        const formData = new FormData();
-        
-        // Add files
-        importFiles.value.forEach(file => {
-          formData.append('files', file);
-        });
-        
-        // Add configuration as JSON string
-        formData.append('config', JSON.stringify(importConfig));
-        
-        updateProgressDisplay({
-          value: 30,
-          step: 'Uploading files...',
-          message: 'Sending files to server'
-        });
-        
-        const result = ensureData(
-          await requestJson('/api/v1/import', {
-            method: 'POST',
-            body: formData
-          })
-        );
-
-        updateProgressDisplay({
-          value: 70,
-          step: 'Processing import...',
-          message: 'Server is processing files'
-        });
-
-        const processedFiles = result && typeof result === 'object' ? result.processed_files : undefined;
-        const totalFiles = result && typeof result === 'object' ? result.total_files : undefined;
-
-        updateProgressDisplay({
-          value: 100,
-          step: 'Import completed',
-          message: `Processed ${processedFiles ?? importFiles.value.length} of ${totalFiles ?? importFiles.value.length} files`
-        });
-        
-        showToastMessage(`Import completed: ${result.processed_files} files processed`, 'success');
-        importFiles.value = [];
-        importPreview.value = [];
-        
-      } catch (error) {
-        showToastMessage(`Import failed: ${error.message}`, 'error');
-      } finally {
-        isImporting.value = false;
-        showProgress.value = false;
-      }
-    };
-    
-    // Backup functions
-    const loadBackupHistory = async () => {
-      try {
-        const result = await getJson('/api/v1/backups/history');
-        const data = result.data;
-        if (Array.isArray(data)) {
-          backupHistory.value = data;
-        } else if (data && typeof data === 'object') {
-          const history = Array.isArray(data.history) ? data.history : [];
-          backupHistory.value = history;
-        } else {
-          backupHistory.value = [];
-        }
-      } catch (error) {
-        console.error('Failed to load backup history:', error);
-      }
-    };
-
-    const createFullBackup = async () => {
-      try {
-        const result = ensureData(
-          await postJson('/api/v1/backup/create', { backup_type: 'full' })
-        );
-        const backupId = result && typeof result === 'object' ? result.backup_id : null;
-        showToastMessage(
-          backupId ? `Full backup initiated: ${backupId}` : 'Full backup initiated',
-          'success'
-        );
-        await loadBackupHistory();
-      } catch (error) {
-        showToastMessage(`Backup failed: ${error.message}`, 'error');
-      }
-    };
-
-    const createQuickBackup = async () => {
-      try {
-        const result = ensureData(
-          await postJson('/api/v1/backup/create', { backup_type: 'quick' })
-        );
-        const backupId = result && typeof result === 'object' ? result.backup_id : null;
-        showToastMessage(
-          backupId ? `Quick backup initiated: ${backupId}` : 'Quick backup initiated',
-          'success'
-        );
-        await loadBackupHistory();
-      } catch (error) {
-        showToastMessage(`Backup failed: ${error.message}`, 'error');
-      }
-    };
-    
-    const scheduleBackup = () => {
-      showToastMessage('Schedule backup functionality coming soon', 'info');
-    };
-    
-    const downloadBackup = (backupId) => {
-      showToastMessage(`Download backup ${backupId} functionality coming soon`, 'info');
-    };
-    
-    const restoreBackup = (backupId) => {
-      showToastMessage(`Restore backup ${backupId} functionality coming soon`, 'info');
-    };
-    
-    const deleteBackup = (backupId) => {
-      showToastMessage(`Delete backup ${backupId} functionality coming soon`, 'info');
-    };
-    
-    // Migration functions
-    const startVersionMigration = () => {
-      showToastMessage('Version migration functionality coming soon', 'info');
-    };
-    
-    const startPlatformMigration = () => {
-      showToastMessage('Platform migration functionality coming soon', 'info');
-    };
-    
-    // General functions
-    const viewHistory = () => {
-      activeTab.value = 'backup';
-    };
-    
-    const cancelOperation = () => {
-      isExporting.value = false;
-      isImporting.value = false;
-      isMigrating.value = false;
-      showProgress.value = false;
-      showToastMessage('Operation cancelled', 'warning');
-    };
-    
-    // Initialize component
-    onMounted(async () => {
-      await updateEstimates();
-      await loadBackupHistory();
-      
-      // Set up auto-hide for toast messages
-      watch(showToast, (value) => {
-        if (value) {
-          setTimeout(() => {
-            showToast.value = false;
-          }, 3000);
-        }
-      });
-      
-      isInitialized.value = true;
-    });
-    
-    return {
-      // State
-      isInitialized,
-      activeTab,
-      isExporting,
-      isImporting,
-      isMigrating,
-      
-      // Progress
-      showProgress,
-      progressValue,
-      currentStep,
-      progressMessages,
-      progressTitle,
-      
-      // Toast
-      showToast,
-      toastMessage,
-      toastType,
-      toastClasses,
-      
-      // Configuration
-      exportConfig,
-      importConfig,
-      migrationConfig,
-      
-      // Import state
-      importFiles,
-      importPreview,
-      hasEncryptedFiles,
-      
-      // Backup state
-      backupHistory,
-      
-      // Computed
-      canExport,
-      estimatedSize,
-      estimatedTime,
-      
-      // Utility functions
-      formatFileSize,
-      formatDate,
-      getStatusClasses,
-      
-      // Export functions
-      validateExport,
-      previewExport,
-      startExport,
-      quickExportAll,
-      
-      // Import functions
-      handleFileDrop,
-      handleFileSelect,
-      removeFile,
-      handleDragOver,
-      handleDragLeave,
-      analyzeFiles,
-      validateImport,
-      startImport,
-      
-      // Backup functions
-      createFullBackup,
-      createQuickBackup,
-      scheduleBackup,
-      downloadBackup,
-      restoreBackup,
-      deleteBackup,
-      
-      // Migration functions
-      startVersionMigration,
-      startPlatformMigration,
-      
-      // General functions
-      viewHistory,
-      cancelOperation
-    };
+    ];
   }
 };
+
+const endProgress = () => {
+  showProgress.value = false;
+  currentOperation.value = null;
+};
+
+const exportWorkflow = useExportWorkflow({
+  notify,
+  progress: {
+    begin: () => beginProgress('export'),
+    update: updateProgress,
+    end: endProgress
+  }
+});
+
+const importWorkflow = useImportWorkflow({
+  notify,
+  progress: {
+    begin: () => beginProgress('import'),
+    update: updateProgress,
+    end: endProgress
+  }
+});
+
+const backupWorkflow = useBackupWorkflow({ notify });
+const migrationWorkflow = useMigrationWorkflow({ notify });
+
+const exportConfig = exportWorkflow.exportConfig;
+const canExport = exportWorkflow.canExport;
+const estimatedSize = exportWorkflow.estimatedSize;
+const estimatedTime = exportWorkflow.estimatedTime;
+const isExporting = exportWorkflow.isExporting;
+
+const importConfig = importWorkflow.importConfig;
+const importFiles = importWorkflow.importFiles;
+const importPreview = importWorkflow.importPreview;
+const hasEncryptedFiles = importWorkflow.hasEncryptedFiles;
+const isImporting = importWorkflow.isImporting;
+
+const backupHistory = backupWorkflow.backupHistory;
+const migrationConfig = migrationWorkflow.migrationConfig;
+
+const formatFileSize = (bytes: number) => formatBytes(typeof bytes === 'number' ? bytes : 0);
+const formatDate = (dateString: string) => formatDateTime(dateString, {
+  year: 'numeric',
+  month: 'short',
+  day: 'numeric',
+  hour: '2-digit',
+  minute: '2-digit'
+});
+
+const getStatusClasses = (status: string) => {
+  const statusClasses: Record<string, string> = {
+    new: 'bg-green-100 text-green-800',
+    conflict: 'bg-yellow-100 text-yellow-800',
+    existing: 'bg-gray-100 text-gray-800',
+    error: 'bg-red-100 text-red-800'
+  };
+  return statusClasses[status] ?? 'bg-gray-100 text-gray-800';
+};
+
+const onExportConfigUpdate = (payload: ExportConfigUpdate) => {
+  exportWorkflow.updateConfig(payload.key, payload.value);
+};
+
+const onImportConfigUpdate = (payload: ImportConfigUpdate) => {
+  importWorkflow.updateConfig(payload.key, payload.value);
+};
+
+const onMigrationConfigUpdate = (payload: MigrationConfigUpdate) => {
+  migrationWorkflow.updateConfig(payload.key, payload.value);
+};
+
+const onImportFilesAdded = (files: File[]) => {
+  importWorkflow.addFiles(files);
+};
+
+const onImportFileRemoved = (file: File) => {
+  importWorkflow.removeFile(file);
+};
+
+const startExport = () => {
+  void exportWorkflow.startExport();
+};
+
+const startImport = () => {
+  void importWorkflow.startImport();
+};
+
+const analyzeFiles = () => {
+  void importWorkflow.analyzeFiles();
+};
+
+const validateExport = () => exportWorkflow.validateExport();
+const previewExport = () => exportWorkflow.previewExport();
+const validateImport = () => importWorkflow.validateImport();
+const createFullBackup = () => backupWorkflow.createFullBackup();
+const createQuickBackup = () => backupWorkflow.createQuickBackup();
+const scheduleBackup = () => backupWorkflow.scheduleBackup();
+const downloadBackup = (backupId: string) => backupWorkflow.downloadBackup(backupId);
+const restoreBackup = (backupId: string) => backupWorkflow.restoreBackup(backupId);
+const deleteBackup = (backupId: string) => backupWorkflow.deleteBackup(backupId);
+const startVersionMigration = () => migrationWorkflow.startVersionMigration();
+const startPlatformMigration = () => migrationWorkflow.startPlatformMigration();
+
+const onQuickExportAll = () => {
+  void exportWorkflow.quickExportAll();
+};
+
+const viewHistory = () => {
+  activeTab.value = 'backup';
+};
+
+const cancelOperation = () => {
+  if (currentOperation.value === 'export') {
+    exportWorkflow.cancelExport();
+  } else if (currentOperation.value === 'import') {
+    importWorkflow.cancelImport();
+  }
+  endProgress();
+  notify('Operation cancelled', 'warning');
+};
+
+onMounted(async () => {
+  await Promise.all([
+    exportWorkflow.initialize(),
+    backupWorkflow.initialize()
+  ]);
+  isInitialized.value = true;
+});
 </script>

--- a/app/frontend/src/components/import-export/BackupManagementPanel.vue
+++ b/app/frontend/src/components/import-export/BackupManagementPanel.vue
@@ -1,0 +1,102 @@
+<template>
+  <div class="space-y-6">
+    <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+      <button class="card card-interactive text-center p-6" @click="$emit('create-full-backup')">
+        <svg class="w-12 h-12 mx-auto mb-4 text-blue-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7H5a2 2 0 00-2 2v9a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-3m-1 4l-3-3m0 0l-3 3m3-3v12"></path>
+        </svg>
+        <h3 class="text-lg font-semibold mb-2">Full System Backup</h3>
+        <p class="text-sm text-gray-600">Complete backup of all data and settings</p>
+      </button>
+
+      <button class="card card-interactive text-center p-6" @click="$emit('create-quick-backup')">
+        <svg class="w-12 h-12 mx-auto mb-4 text-green-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 10V3L4 14h7v7l9-11h-7z"></path>
+        </svg>
+        <h3 class="text-lg font-semibold mb-2">Quick Backup</h3>
+        <p class="text-sm text-gray-600">Essential data only for fast backup</p>
+      </button>
+
+      <button class="card card-interactive text-center p-6" @click="$emit('schedule-backup')">
+        <svg class="w-12 h-12 mx-auto mb-4 text-purple-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"></path>
+        </svg>
+        <h3 class="text-lg font-semibold mb-2">Schedule Backup</h3>
+        <p class="text-sm text-gray-600">Automatic recurring backups</p>
+      </button>
+    </div>
+
+    <div class="card">
+      <div class="card-header">
+        <h3 class="text-lg font-semibold">Backup History</h3>
+        <p class="text-sm text-gray-600">Manage existing backups</p>
+      </div>
+      <div class="card-body">
+        <div class="overflow-x-auto">
+          <table class="min-w-full divide-y divide-gray-200">
+            <thead class="bg-gray-50">
+              <tr>
+                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Date</th>
+                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Type</th>
+                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Size</th>
+                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Status</th>
+                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Actions</th>
+              </tr>
+            </thead>
+            <tbody class="bg-white divide-y divide-gray-200">
+              <tr v-for="backup in history" :key="backup.id">
+                <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
+                  {{ formatDate(backup.created_at) }}
+                </td>
+                <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900">{{ backup.type }}</td>
+                <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
+                  {{ formatFileSize(backup.size ?? 0) }}
+                </td>
+                <td class="px-6 py-4 whitespace-nowrap">
+                  <span
+                    class="inline-flex px-2 py-1 text-xs font-semibold rounded-full"
+                    :class="backup.status === 'completed'
+                      ? 'bg-green-100 text-green-800'
+                      : backup.status === 'failed'
+                        ? 'bg-red-100 text-red-800'
+                        : 'bg-yellow-100 text-yellow-800'"
+                  >
+                    {{ backup.status }}
+                  </span>
+                </td>
+                <td class="px-6 py-4 whitespace-nowrap text-sm font-medium">
+                  <div class="flex space-x-2">
+                    <button class="text-blue-600 hover:text-blue-900" @click="$emit('download-backup', backup.id)">
+                      Download
+                    </button>
+                    <button class="text-green-600 hover:text-green-900" @click="$emit('restore-backup', backup.id)">
+                      Restore
+                    </button>
+                    <button class="text-red-600 hover:text-red-900" @click="$emit('delete-backup', backup.id)">
+                      Delete
+                    </button>
+                  </div>
+                </td>
+              </tr>
+              <tr v-if="history.length === 0">
+                <td colspan="5" class="px-6 py-4 text-center text-sm text-gray-500">
+                  No backups found. Create your first backup above.
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import type { BackupEntry } from '@/composables/useBackupWorkflow';
+
+const props = defineProps<{
+  history: BackupEntry[];
+  formatFileSize: (bytes: number) => string;
+  formatDate: (input: string) => string;
+}>();
+</script>

--- a/app/frontend/src/components/import-export/ExportConfigurationPanel.vue
+++ b/app/frontend/src/components/import-export/ExportConfigurationPanel.vue
@@ -1,0 +1,356 @@
+<template>
+  <div class="space-y-6">
+    <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
+      <div class="card">
+        <div class="card-header">
+          <h3 class="text-lg font-semibold">Select Data to Export</h3>
+        </div>
+        <div class="card-body space-y-4">
+          <div>
+            <label class="flex items-center">
+              <input
+                type="checkbox"
+                class="form-checkbox mr-3"
+                :checked="config.loras"
+                @change="onCheckboxChange('loras', $event)"
+              >
+              <div>
+                <div class="font-medium">LoRA Models</div>
+                <div class="text-sm text-gray-600">All LoRA files, metadata, and configurations</div>
+              </div>
+            </label>
+
+            <div
+              v-show="config.loras"
+              class="ml-6 mt-3 space-y-2 transition-all duration-200"
+            >
+              <label class="flex items-center">
+                <input
+                  type="checkbox"
+                  class="form-checkbox mr-2"
+                  :checked="config.lora_files"
+                  @change="onCheckboxChange('lora_files', $event)"
+                >
+                <span class="text-sm">Include model files</span>
+              </label>
+              <label class="flex items-center">
+                <input
+                  type="checkbox"
+                  class="form-checkbox mr-2"
+                  :checked="config.lora_metadata"
+                  @change="onCheckboxChange('lora_metadata', $event)"
+                >
+                <span class="text-sm">Include metadata only</span>
+              </label>
+              <label class="flex items-center">
+                <input
+                  type="checkbox"
+                  class="form-checkbox mr-2"
+                  :checked="config.lora_embeddings"
+                  @change="onCheckboxChange('lora_embeddings', $event)"
+                >
+                <span class="text-sm">Include embeddings</span>
+              </label>
+            </div>
+          </div>
+
+          <div>
+            <label class="flex items-center">
+              <input
+                type="checkbox"
+                class="form-checkbox mr-3"
+                :checked="config.generations"
+                @change="onCheckboxChange('generations', $event)"
+              >
+              <div>
+                <div class="font-medium">Generation Results</div>
+                <div class="text-sm text-gray-600">Generated images and their parameters</div>
+              </div>
+            </label>
+
+            <div
+              v-show="config.generations"
+              class="ml-6 mt-3 space-y-2 transition-all duration-200"
+            >
+              <div class="flex items-center space-x-4">
+                <label class="flex items-center">
+                  <input
+                    type="radio"
+                    class="form-radio mr-2"
+                    name="generation_range"
+                    value="all"
+                    :checked="config.generation_range === 'all'"
+                    @change="onRadioChange('generation_range', $event)"
+                  >
+                  <span class="text-sm">All generations</span>
+                </label>
+                <label class="flex items-center">
+                  <input
+                    type="radio"
+                    class="form-radio mr-2"
+                    name="generation_range"
+                    value="date_range"
+                    :checked="config.generation_range === 'date_range'"
+                    @change="onRadioChange('generation_range', $event)"
+                  >
+                  <span class="text-sm">Date range</span>
+                </label>
+              </div>
+
+              <div
+                v-show="config.generation_range === 'date_range'"
+                class="grid grid-cols-2 gap-3 transition-all duration-200"
+              >
+                <div>
+                  <label class="form-label text-xs">From Date</label>
+                  <input
+                    type="date"
+                    class="form-input text-sm"
+                    :value="config.date_from"
+                    @input="onInputChange('date_from', $event)"
+                  >
+                </div>
+                <div>
+                  <label class="form-label text-xs">To Date</label>
+                  <input
+                    type="date"
+                    class="form-input text-sm"
+                    :value="config.date_to"
+                    @input="onInputChange('date_to', $event)"
+                  >
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div>
+            <label class="flex items-center">
+              <input
+                type="checkbox"
+                class="form-checkbox mr-3"
+                :checked="config.user_data"
+                @change="onCheckboxChange('user_data', $event)"
+              >
+              <div>
+                <div class="font-medium">User Data</div>
+                <div class="text-sm text-gray-600">User preferences and settings</div>
+              </div>
+            </label>
+          </div>
+
+          <div>
+            <label class="flex items-center">
+              <input
+                type="checkbox"
+                class="form-checkbox mr-3"
+                :checked="config.system_config"
+                @change="onCheckboxChange('system_config', $event)"
+              >
+              <div>
+                <div class="font-medium">System Configuration</div>
+                <div class="text-sm text-gray-600">System settings and configurations</div>
+              </div>
+            </label>
+          </div>
+
+          <div>
+            <label class="flex items-center">
+              <input
+                type="checkbox"
+                class="form-checkbox mr-3"
+                :checked="config.analytics"
+                @change="onCheckboxChange('analytics', $event)"
+              >
+              <div>
+                <div class="font-medium">Analytics</div>
+                <div class="text-sm text-gray-600">Usage metrics and performance data</div>
+              </div>
+            </label>
+          </div>
+        </div>
+      </div>
+
+      <div class="card">
+        <div class="card-header">
+          <h3 class="text-lg font-semibold">Export Settings</h3>
+        </div>
+        <div class="card-body space-y-4">
+          <div>
+            <label class="form-label">Export Format</label>
+            <select
+              class="form-input"
+              :value="config.format"
+              @change="onSelectChange('format', $event)"
+            >
+              <option value="zip">ZIP Archive</option>
+              <option value="tar.gz">TAR.GZ Archive</option>
+              <option value="json">JSON Files</option>
+            </select>
+          </div>
+
+          <div>
+            <label class="form-label">Compression Level</label>
+            <select
+              class="form-input"
+              :value="config.compression"
+              @change="onSelectChange('compression', $event)"
+            >
+              <option value="none">No Compression</option>
+              <option value="fast">Fast</option>
+              <option value="balanced">Balanced</option>
+              <option value="maximum">Maximum</option>
+            </select>
+          </div>
+
+          <div>
+            <label class="flex items-center">
+              <input
+                type="checkbox"
+                class="form-checkbox mr-2"
+                :checked="config.split_archives"
+                @change="onCheckboxChange('split_archives', $event)"
+              >
+              <span>Split large archives</span>
+            </label>
+            <div
+              v-show="config.split_archives"
+              class="mt-2 transition-all duration-200"
+            >
+              <label class="form-label text-sm">Max size per archive (MB)</label>
+              <input
+                type="number"
+                min="100"
+                max="4096"
+                class="form-input text-sm"
+                :value="config.max_size_mb"
+                @input="onNumberInput('max_size_mb', $event)"
+              >
+            </div>
+          </div>
+
+          <div>
+            <label class="flex items-center">
+              <input
+                type="checkbox"
+                class="form-checkbox mr-2"
+                :checked="config.encrypt"
+                @change="onCheckboxChange('encrypt', $event)"
+              >
+              <span>Encrypt export</span>
+            </label>
+            <div
+              v-show="config.encrypt"
+              class="mt-2 transition-all duration-200"
+            >
+              <label class="form-label text-sm">Password</label>
+              <input
+                type="password"
+                class="form-input text-sm"
+                :value="config.password"
+                @input="onInputChange('password', $event)"
+              >
+            </div>
+          </div>
+
+          <div class="p-3 bg-gray-50 rounded">
+            <div class="text-sm font-medium">Estimated Export Size</div>
+            <div class="text-lg font-bold text-blue-600">{{ estimatedSize }}</div>
+            <div class="text-xs text-gray-600">
+              Processing time: ~{{ estimatedTime }}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="flex justify-between items-center pt-6 border-t">
+      <div class="flex items-center space-x-4">
+        <button class="btn btn-secondary" @click="$emit('validate')">
+          Validate Selection
+        </button>
+        <button class="btn btn-secondary" @click="$emit('preview')">
+          Preview Contents
+        </button>
+      </div>
+      <button
+        class="btn btn-primary"
+        :disabled="!canExport || isExporting"
+        @click="$emit('start')"
+      >
+        <template v-if="!isExporting">
+          <span>Start Export</span>
+        </template>
+        <template v-else>
+          <div class="flex items-center">
+            <svg class="animate-spin w-4 h-4 mr-2" fill="none" viewBox="0 0 24 24">
+              <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+              <path class="opacity-75" fill="currentColor" d="m 12 2 a 10,10 0 0,1 10,10 h -4 a 6,6 0 0,0 -6,-6 z"></path>
+            </svg>
+            Exporting...
+          </div>
+        </template>
+      </button>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import type { ExportConfig } from '@/composables/useExportWorkflow';
+
+type ExportConfigKey = keyof ExportConfig;
+
+const props = defineProps<{
+  config: ExportConfig;
+  canExport: boolean;
+  estimatedSize: string;
+  estimatedTime: string;
+  isExporting: boolean;
+}>();
+
+const emit = defineEmits<{
+  (e: 'update-config', payload: { key: ExportConfigKey; value: ExportConfig[ExportConfigKey] }): void;
+  (e: 'validate'): void;
+  (e: 'preview'): void;
+  (e: 'start'): void;
+}>();
+
+const updateConfig = (key: ExportConfigKey, value: ExportConfig[ExportConfigKey]) => {
+  emit('update-config', { key, value });
+};
+
+const onCheckboxChange = (key: ExportConfigKey, event: Event) => {
+  const target = event.target as HTMLInputElement | null;
+  if (target) {
+    updateConfig(key, target.checked as ExportConfig[ExportConfigKey]);
+  }
+};
+
+const onRadioChange = (key: ExportConfigKey, event: Event) => {
+  const target = event.target as HTMLInputElement | null;
+  if (target) {
+    updateConfig(key, target.value as ExportConfig[ExportConfigKey]);
+  }
+};
+
+const onSelectChange = (key: ExportConfigKey, event: Event) => {
+  const target = event.target as HTMLSelectElement | null;
+  if (target) {
+    updateConfig(key, target.value as ExportConfig[ExportConfigKey]);
+  }
+};
+
+const onInputChange = (key: ExportConfigKey, event: Event) => {
+  const target = event.target as HTMLInputElement | null;
+  if (target) {
+    updateConfig(key, target.value as ExportConfig[ExportConfigKey]);
+  }
+};
+
+const onNumberInput = (key: ExportConfigKey, event: Event) => {
+  const target = event.target as HTMLInputElement | null;
+  if (target) {
+    const parsed = Number(target.value);
+    updateConfig(key, (Number.isNaN(parsed) ? 0 : parsed) as ExportConfig[ExportConfigKey]);
+  }
+};
+</script>

--- a/app/frontend/src/components/import-export/ImportProcessingPanel.vue
+++ b/app/frontend/src/components/import-export/ImportProcessingPanel.vue
@@ -1,0 +1,282 @@
+<template>
+  <div class="space-y-6">
+    <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
+      <div class="card">
+        <div class="card-header">
+          <h3 class="text-lg font-semibold">Select Import Source</h3>
+        </div>
+        <div class="card-body">
+          <div
+            class="border-2 border-dashed border-gray-300 rounded-lg p-6 text-center hover:border-gray-400 transition-colors"
+            @drop.prevent="onDrop"
+            @dragover.prevent="onDragOver"
+            @dragleave="onDragLeave"
+          >
+            <svg class="mx-auto h-12 w-12 text-gray-400" stroke="currentColor" fill="none" viewBox="0 0 48 48">
+              <path
+                d="M28 8H12a4 4 0 00-4 4v20m32-12v8m0 0v8a4 4 0 01-4 4H12a4 4 0 01-4-4v-4m32-4l-3.172-3.172a4 4 0 00-5.656 0L28 28M8 32l9.172-9.172a4 4 0 015.656 0L28 28m0 0l4 4m4-24h8m-4-4v8m-12 4h.02"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              ></path>
+            </svg>
+            <div class="mt-4">
+              <label class="cursor-pointer">
+                <span class="mt-2 block text-sm font-medium text-gray-900">
+                  Drop files here or click to upload
+                </span>
+                <input
+                  type="file"
+                  class="hidden"
+                  multiple
+                  accept=".zip,.tar.gz,.json,.lora,.safetensors"
+                  @change="onFileSelect"
+                >
+              </label>
+              <p class="mt-2 text-xs text-gray-500">
+                Supports ZIP, TAR.GZ, JSON, LoRA, SafeTensors files
+              </p>
+            </div>
+          </div>
+
+          <div v-show="files.length > 0" class="mt-4 transition-all duration-200">
+            <h4 class="text-sm font-medium mb-2">Selected Files</h4>
+            <div class="space-y-2">
+              <div
+                v-for="file in files"
+                :key="file.name"
+                class="flex items-center justify-between p-2 bg-gray-50 rounded"
+              >
+                <div class="flex items-center space-x-2">
+                  <svg class="w-4 h-4 text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                      stroke-width="2"
+                      d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
+                    ></path>
+                  </svg>
+                  <span class="text-sm">{{ file.name }}</span>
+                </div>
+                <div class="flex items-center space-x-2">
+                  <span class="text-xs text-gray-500">{{ formatFileSize(file.size ?? 0) }}</span>
+                  <button class="text-red-500 hover:text-red-700" @click="$emit('remove-file', file)">
+                    <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
+                    </svg>
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="card">
+        <div class="card-header">
+          <h3 class="text-lg font-semibold">Import Settings</h3>
+        </div>
+        <div class="card-body space-y-4">
+          <div>
+            <label class="form-label">Import Mode</label>
+            <select class="form-input" :value="config.mode" @change="onSelectChange('mode', $event)">
+              <option value="merge">Merge with existing data</option>
+              <option value="replace">Replace existing data</option>
+              <option value="skip">Skip conflicting items</option>
+            </select>
+          </div>
+
+          <div>
+            <label class="form-label">Conflict Resolution</label>
+            <select
+              class="form-input"
+              :value="config.conflict_resolution"
+              @change="onSelectChange('conflict_resolution', $event)"
+            >
+              <option value="ask">Ask for each conflict</option>
+              <option value="keep_existing">Keep existing</option>
+              <option value="overwrite">Overwrite with imported</option>
+              <option value="rename">Rename imported items</option>
+            </select>
+          </div>
+
+          <div>
+            <label class="flex items-center">
+              <input
+                type="checkbox"
+                class="form-checkbox mr-2"
+                :checked="config.validate"
+                @change="onCheckboxChange('validate', $event)"
+              >
+              <span>Validate data before import</span>
+            </label>
+          </div>
+
+          <div>
+            <label class="flex items-center">
+              <input
+                type="checkbox"
+                class="form-checkbox mr-2"
+                :checked="config.backup_before"
+                @change="onCheckboxChange('backup_before', $event)"
+              >
+              <span>Create backup before import</span>
+            </label>
+          </div>
+
+          <div v-show="hasEncryptedFiles" class="transition-all duration-200">
+            <label class="form-label">Archive Password</label>
+            <input
+              type="password"
+              class="form-input"
+              placeholder="Enter password for encrypted archives"
+              :value="config.password"
+              @input="onInputChange('password', $event)"
+            >
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div v-show="preview.length > 0" class="card transition-all duration-200">
+      <div class="card-header">
+        <h3 class="text-lg font-semibold">Import Preview</h3>
+        <p class="text-sm text-gray-600">Review what will be imported</p>
+      </div>
+      <div class="card-body">
+        <div class="overflow-x-auto">
+          <table class="min-w-full divide-y divide-gray-200">
+            <thead class="bg-gray-50">
+              <tr>
+                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Type</th>
+                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Name</th>
+                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Status</th>
+                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Action</th>
+              </tr>
+            </thead>
+            <tbody class="bg-white divide-y divide-gray-200">
+              <tr v-for="item in preview" :key="item.id">
+                <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">{{ item.type }}</td>
+                <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900">{{ item.name }}</td>
+                <td class="px-6 py-4 whitespace-nowrap">
+                  <span
+                    class="inline-flex px-2 py-1 text-xs font-semibold rounded-full"
+                    :class="getStatusClasses(item.status)"
+                  >
+                    {{ item.status }}
+                  </span>
+                </td>
+                <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900">{{ item.action }}</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+
+    <div class="flex justify-between items-center pt-6 border-t">
+      <div class="flex items-center space-x-4">
+        <button class="btn btn-secondary" :disabled="files.length === 0" @click="$emit('analyze')">
+          Analyze Files
+        </button>
+        <button class="btn btn-secondary" :disabled="files.length === 0" @click="$emit('validate')">
+          Validate Import
+        </button>
+      </div>
+      <button
+        class="btn btn-primary"
+        :disabled="files.length === 0 || isImporting"
+        @click="$emit('start')"
+      >
+        <template v-if="!isImporting">
+          <span>Start Import</span>
+        </template>
+        <template v-else>
+          <div class="flex items-center">
+            <svg class="animate-spin w-4 h-4 mr-2" fill="none" viewBox="0 0 24 24">
+              <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+              <path class="opacity-75" fill="currentColor" d="m 12 2 a 10,10 0 0,1 10,10 h -4 a 6,6 0 0,0 -6,-6 z"></path>
+            </svg>
+            Importing...
+          </div>
+        </template>
+      </button>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import type { ImportConfig, ImportPreviewItem } from '@/composables/useImportWorkflow';
+
+type ImportConfigKey = keyof ImportConfig;
+
+const props = defineProps<{
+  config: ImportConfig;
+  files: File[];
+  preview: ImportPreviewItem[];
+  hasEncryptedFiles: boolean;
+  isImporting: boolean;
+  formatFileSize: (bytes: number) => string;
+  getStatusClasses: (status: string) => string;
+}>();
+
+const emit = defineEmits<{
+  (e: 'update-config', payload: { key: ImportConfigKey; value: ImportConfig[ImportConfigKey] }): void;
+  (e: 'add-files', payload: File[]): void;
+  (e: 'remove-file', payload: File): void;
+  (e: 'analyze'): void;
+  (e: 'validate'): void;
+  (e: 'start'): void;
+}>();
+
+const updateConfig = (key: ImportConfigKey, value: ImportConfig[ImportConfigKey]) => {
+  emit('update-config', { key, value });
+};
+
+const onCheckboxChange = (key: ImportConfigKey, event: Event) => {
+  const target = event.target as HTMLInputElement | null;
+  if (target) {
+    updateConfig(key, target.checked as ImportConfig[ImportConfigKey]);
+  }
+};
+
+const onSelectChange = (key: ImportConfigKey, event: Event) => {
+  const target = event.target as HTMLSelectElement | null;
+  if (target) {
+    updateConfig(key, target.value as ImportConfig[ImportConfigKey]);
+  }
+};
+
+const onInputChange = (key: ImportConfigKey, event: Event) => {
+  const target = event.target as HTMLInputElement | null;
+  if (target) {
+    updateConfig(key, target.value as ImportConfig[ImportConfigKey]);
+  }
+};
+
+const onFileSelect = (event: Event) => {
+  const target = event.target as HTMLInputElement | null;
+  if (target && target.files) {
+    emit('add-files', Array.from(target.files));
+    target.value = '';
+  }
+};
+
+const onDrop = (event: DragEvent) => {
+  const files = event.dataTransfer?.files ? Array.from(event.dataTransfer.files) : [];
+  if (files.length > 0) {
+    emit('add-files', files);
+  }
+  onDragLeave(event);
+};
+
+const onDragOver = (event: DragEvent) => {
+  const element = event.currentTarget as HTMLElement | null;
+  element?.classList.add('border-blue-500', 'bg-blue-50');
+};
+
+const onDragLeave = (event: Event) => {
+  const element = event.currentTarget as HTMLElement | null;
+  element?.classList.remove('border-blue-500', 'bg-blue-50');
+};
+</script>

--- a/app/frontend/src/components/import-export/MigrationWorkflowPanel.vue
+++ b/app/frontend/src/components/import-export/MigrationWorkflowPanel.vue
@@ -1,0 +1,102 @@
+<template>
+  <div class="space-y-6">
+    <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+      <div class="card">
+        <div class="card-header">
+          <h3 class="text-lg font-semibold">Version Migration</h3>
+          <p class="text-sm text-gray-600">Migrate data between software versions</p>
+        </div>
+        <div class="card-body space-y-4">
+          <div>
+            <label class="form-label">From Version</label>
+            <select class="form-input" :value="config.from_version" @change="onSelectChange('from_version', $event)">
+              <option value="1.0">Version 1.0</option>
+              <option value="1.1">Version 1.1</option>
+              <option value="2.0">Version 2.0</option>
+            </select>
+          </div>
+          <div>
+            <label class="form-label">To Version</label>
+            <select class="form-input" :value="config.to_version" @change="onSelectChange('to_version', $event)">
+              <option value="2.1">Version 2.1 (Current)</option>
+              <option value="3.0">Version 3.0 (Beta)</option>
+            </select>
+          </div>
+          <button class="btn btn-primary w-full" @click="$emit('start-version-migration')">
+            Start Version Migration
+          </button>
+        </div>
+      </div>
+
+      <div class="card">
+        <div class="card-header">
+          <h3 class="text-lg font-semibold">Platform Migration</h3>
+          <p class="text-sm text-gray-600">Migrate from other LoRA management systems</p>
+        </div>
+        <div class="card-body space-y-4">
+          <div>
+            <label class="form-label">Source Platform</label>
+            <select
+              class="form-input"
+              :value="config.source_platform"
+              @change="onSelectChange('source_platform', $event)"
+            >
+              <option value="automatic1111">Automatic1111</option>
+              <option value="invokeai">InvokeAI</option>
+              <option value="comfyui">ComfyUI</option>
+              <option value="fooocus">Fooocus</option>
+              <option value="other">Other</option>
+            </select>
+          </div>
+          <div>
+            <label class="form-label">Data Location</label>
+            <input
+              type="text"
+              class="form-input"
+              placeholder="/path/to/source/data"
+              :value="config.source_path"
+              @input="onInputChange('source_path', $event)"
+            >
+          </div>
+          <button class="btn btn-primary w-full" @click="$emit('start-platform-migration')">
+            Start Platform Migration
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import type { MigrationConfig } from '@/composables/useMigrationWorkflow';
+
+type MigrationConfigKey = keyof MigrationConfig;
+
+const props = defineProps<{
+  config: MigrationConfig;
+}>();
+
+const emit = defineEmits<{
+  (e: 'update-config', payload: { key: MigrationConfigKey; value: MigrationConfig[MigrationConfigKey] }): void;
+  (e: 'start-version-migration'): void;
+  (e: 'start-platform-migration'): void;
+}>();
+
+const updateConfig = (key: MigrationConfigKey, value: MigrationConfig[MigrationConfigKey]) => {
+  emit('update-config', { key, value });
+};
+
+const onSelectChange = (key: MigrationConfigKey, event: Event) => {
+  const target = event.target as HTMLSelectElement | null;
+  if (target) {
+    updateConfig(key, target.value as MigrationConfig[MigrationConfigKey]);
+  }
+};
+
+const onInputChange = (key: MigrationConfigKey, event: Event) => {
+  const target = event.target as HTMLInputElement | null;
+  if (target) {
+    updateConfig(key, target.value as MigrationConfig[MigrationConfigKey]);
+  }
+};
+</script>

--- a/app/frontend/src/composables/useBackupWorkflow.ts
+++ b/app/frontend/src/composables/useBackupWorkflow.ts
@@ -1,0 +1,89 @@
+import { ref, type Ref } from 'vue';
+
+import { ensureData, getJson, postJson } from '@/utils/api';
+import type { NotifyFn } from './useExportWorkflow';
+
+export interface BackupEntry {
+  id: string;
+  type: string;
+  size?: number;
+  status: string;
+  created_at: string;
+}
+
+interface UseBackupWorkflowOptions {
+  notify: NotifyFn;
+}
+
+export interface UseBackupWorkflow {
+  backupHistory: Ref<BackupEntry[]>;
+  initialize: () => Promise<void>;
+  createFullBackup: () => Promise<void>;
+  createQuickBackup: () => Promise<void>;
+  scheduleBackup: () => void;
+  downloadBackup: (backupId: string) => void;
+  restoreBackup: (backupId: string) => void;
+  deleteBackup: (backupId: string) => void;
+}
+
+export function useBackupWorkflow(options: UseBackupWorkflowOptions): UseBackupWorkflow {
+  const { notify } = options;
+  const history = ref<BackupEntry[]>([]);
+
+  const loadHistory = async () => {
+    try {
+      const response = await getJson('/api/v1/backups/history');
+      const data = response?.data;
+
+      if (Array.isArray(data)) {
+        history.value = data as BackupEntry[];
+      } else if (data && typeof data === 'object' && Array.isArray((data as Record<string, unknown>).history)) {
+        history.value = (data as { history: BackupEntry[] }).history;
+      } else {
+        history.value = [];
+      }
+    } catch (error) {
+      if (import.meta.env.DEV) {
+        console.error('Failed to load backup history:', error);
+      }
+      history.value = [];
+    }
+  };
+
+  const createBackup = async (backupType: 'full' | 'quick', successMessage: string) => {
+    try {
+      const result = ensureData(
+        await postJson('/api/v1/backup/create', { backup_type: backupType })
+      ) as Record<string, unknown> | null;
+      const backupId = typeof result?.backup_id === 'string' ? result.backup_id : null;
+      notify(backupId ? `${successMessage}: ${backupId}` : successMessage, 'success');
+      await loadHistory();
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      notify(`Backup failed: ${message}`, 'error');
+    }
+  };
+
+  const initialize = async () => {
+    await loadHistory();
+  };
+
+  return {
+    backupHistory: history,
+    initialize,
+    createFullBackup: () => createBackup('full', 'Full backup initiated'),
+    createQuickBackup: () => createBackup('quick', 'Quick backup initiated'),
+    scheduleBackup: () => {
+      notify('Schedule backup functionality coming soon', 'info');
+    },
+    downloadBackup: (backupId: string) => {
+      notify(`Download backup ${backupId} functionality coming soon`, 'info');
+    },
+    restoreBackup: (backupId: string) => {
+      notify(`Restore backup ${backupId} functionality coming soon`, 'info');
+    },
+    deleteBackup: (backupId: string) => {
+      notify(`Delete backup ${backupId} functionality coming soon`, 'info');
+    }
+  };
+}

--- a/app/frontend/src/composables/useExportWorkflow.ts
+++ b/app/frontend/src/composables/useExportWorkflow.ts
@@ -1,0 +1,284 @@
+import { computed, reactive, ref, watch } from 'vue';
+
+import { ensureData, getFilenameFromContentDisposition, postJson, requestBlob } from '@/utils/api';
+import { downloadFile } from '@/utils/browser';
+import { formatFileSize as formatBytes } from '@/utils/format';
+
+export type NotifyType = 'success' | 'error' | 'warning' | 'info';
+export type NotifyFn = (message: string, type?: NotifyType) => void;
+
+export interface ProgressUpdate {
+  value?: number;
+  step?: string;
+  message?: string;
+}
+
+export interface ProgressCallbacks {
+  begin: () => void;
+  update: (update: ProgressUpdate) => void;
+  end: () => void;
+}
+
+export interface ExportConfig {
+  loras: boolean;
+  lora_files: boolean;
+  lora_metadata: boolean;
+  lora_embeddings: boolean;
+  generations: boolean;
+  generation_range: 'all' | 'date_range';
+  date_from: string;
+  date_to: string;
+  user_data: boolean;
+  system_config: boolean;
+  analytics: boolean;
+  format: 'zip' | 'tar.gz' | 'json';
+  compression: 'none' | 'fast' | 'balanced' | 'maximum';
+  split_archives: boolean;
+  max_size_mb: number;
+  encrypt: boolean;
+  password: string;
+}
+
+interface UseExportWorkflowOptions {
+  notify: NotifyFn;
+  progress: ProgressCallbacks;
+}
+
+export interface UseExportWorkflow {
+  exportConfig: ExportConfig;
+  canExport: Readonly<boolean>;
+  estimatedSize: Readonly<string>;
+  estimatedTime: Readonly<string>;
+  isExporting: Readonly<boolean>;
+  initialize: () => Promise<void>;
+  updateConfig: <K extends keyof ExportConfig>(key: K, value: ExportConfig[K]) => void;
+  validateExport: () => void;
+  previewExport: () => void;
+  startExport: () => Promise<void>;
+  quickExportAll: () => Promise<void>;
+  cancelExport: () => void;
+}
+
+export function useExportWorkflow(options: UseExportWorkflowOptions): UseExportWorkflow {
+  const { notify, progress } = options;
+
+  const exportConfig = reactive<ExportConfig>({
+    loras: true,
+    lora_files: true,
+    lora_metadata: true,
+    lora_embeddings: false,
+    generations: false,
+    generation_range: 'all',
+    date_from: '',
+    date_to: '',
+    user_data: false,
+    system_config: false,
+    analytics: false,
+    format: 'zip',
+    compression: 'balanced',
+    split_archives: false,
+    max_size_mb: 1024,
+    encrypt: false,
+    password: ''
+  });
+
+  const estimatedSize = ref('0 MB');
+  const estimatedTime = ref('0 minutes');
+  const isExporting = ref(false);
+
+  const canExport = computed(() =>
+    exportConfig.loras ||
+    exportConfig.generations ||
+    exportConfig.user_data ||
+    exportConfig.system_config ||
+    exportConfig.analytics
+  );
+
+  const updateConfig = <K extends keyof ExportConfig>(key: K, value: ExportConfig[K]) => {
+    exportConfig[key] = value;
+  };
+
+  const updateEstimatesLocal = () => {
+    let sizeBytes = 0;
+    let timeMinutes = 0;
+
+    if (exportConfig.loras) {
+      sizeBytes += 10 * 1024 * 1024;
+      timeMinutes += 2;
+
+      if (exportConfig.lora_files) {
+        sizeBytes += 500 * 1024 * 1024;
+        timeMinutes += 10;
+      }
+
+      if (exportConfig.lora_embeddings) {
+        sizeBytes += 100 * 1024 * 1024;
+        timeMinutes += 3;
+      }
+    }
+
+    if (exportConfig.generations) {
+      if (exportConfig.generation_range === 'all') {
+        sizeBytes += 200 * 1024 * 1024;
+        timeMinutes += 5;
+      } else {
+        sizeBytes += 50 * 1024 * 1024;
+        timeMinutes += 2;
+      }
+    }
+
+    if (exportConfig.user_data) {
+      sizeBytes += 5 * 1024 * 1024;
+      timeMinutes += 1;
+    }
+
+    if (exportConfig.system_config) {
+      sizeBytes += 1 * 1024 * 1024;
+      timeMinutes += 1;
+    }
+
+    if (exportConfig.analytics) {
+      sizeBytes += 20 * 1024 * 1024;
+      timeMinutes += 2;
+    }
+
+    const compressionRatio: Record<ExportConfig['compression'], number> = {
+      none: 1,
+      fast: 0.7,
+      balanced: 0.5,
+      maximum: 0.3
+    };
+
+    sizeBytes *= compressionRatio[exportConfig.compression];
+
+    estimatedSize.value = formatBytes(typeof sizeBytes === 'number' ? sizeBytes : 0);
+    estimatedTime.value = `${Math.max(1, Math.ceil(timeMinutes))} minutes`;
+  };
+
+  const updateEstimates = async () => {
+    try {
+      const estimates = ensureData(
+        await postJson('/api/v1/export/estimate', { ...exportConfig })
+      );
+
+      if (estimates && typeof estimates === 'object') {
+        const { size, time } = estimates as Record<string, unknown>;
+        if (typeof size === 'string') {
+          estimatedSize.value = size;
+        }
+        if (typeof time === 'string') {
+          estimatedTime.value = time;
+        }
+        return;
+      }
+    } catch (error) {
+      if (import.meta.env.DEV) {
+        console.warn('Failed to fetch export estimates:', error);
+      }
+    }
+
+    updateEstimatesLocal();
+  };
+
+  const validateExport = () => {
+    const issues: string[] = [];
+
+    if (!canExport.value) {
+      issues.push('No data types selected for export');
+    }
+
+    if (exportConfig.generations && exportConfig.generation_range === 'date_range' && (!exportConfig.date_from || !exportConfig.date_to)) {
+      issues.push('Date range required for generation export');
+    }
+
+    if (exportConfig.split_archives && exportConfig.max_size_mb < 10) {
+      issues.push('Maximum archive size too small for split archives');
+    }
+
+    if (exportConfig.encrypt && !exportConfig.password) {
+      issues.push('Password required for encrypted export');
+    }
+
+    if (issues.length > 0) {
+      notify(`Validation failed: ${issues.join(', ')}`, 'error');
+    } else {
+      notify('Export configuration is valid', 'success');
+    }
+  };
+
+  const previewExport = () => {
+    notify('Preview functionality coming soon', 'info');
+  };
+
+  const startExport = async () => {
+    if (isExporting.value) return;
+
+    try {
+      isExporting.value = true;
+      progress.begin();
+      progress.update({ value: 10, step: 'Preparing export...', message: 'Validating configuration' });
+      progress.update({ value: 50, step: 'Generating export...', message: 'Creating archive' });
+
+      const { blob, response } = await requestBlob('/api/v1/export', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({ ...exportConfig })
+      });
+
+      progress.update({ value: 90, step: 'Finalizing export...', message: 'Preparing download' });
+
+      const contentDisposition = response.headers.get('Content-Disposition');
+      const fallbackName = `lora_export_${new Date().toISOString().slice(0, 10)}.${exportConfig.format}`;
+      const filename = getFilenameFromContentDisposition(contentDisposition) ?? fallbackName;
+
+      downloadFile(blob, filename);
+
+      progress.update({ value: 100, step: 'Export completed', message: 'Download started' });
+      notify('Export completed successfully', 'success');
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      notify(`Export failed: ${message}`, 'error');
+    } finally {
+      isExporting.value = false;
+      progress.end();
+    }
+  };
+
+  const quickExportAll = async () => {
+    updateConfig('loras', true);
+    updateConfig('lora_files', true);
+    updateConfig('generations', true);
+    updateConfig('user_data', true);
+    updateConfig('system_config', true);
+    await startExport();
+  };
+
+  const initialize = async () => {
+    await updateEstimates();
+  };
+
+  const cancelExport = () => {
+    isExporting.value = false;
+  };
+
+  watch(exportConfig, () => {
+    void updateEstimates();
+  }, { deep: true });
+
+  return {
+    exportConfig,
+    canExport: computed(() => canExport.value),
+    estimatedSize: computed(() => estimatedSize.value),
+    estimatedTime: computed(() => estimatedTime.value),
+    isExporting: computed(() => isExporting.value),
+    initialize,
+    updateConfig,
+    validateExport,
+    previewExport,
+    startExport,
+    quickExportAll,
+    cancelExport
+  };
+}

--- a/app/frontend/src/composables/useImportWorkflow.ts
+++ b/app/frontend/src/composables/useImportWorkflow.ts
@@ -1,0 +1,234 @@
+import { computed, reactive, ref } from 'vue';
+
+import { ensureData, requestJson } from '@/utils/api';
+import type { NotifyFn, ProgressCallbacks } from './useExportWorkflow';
+
+export type ImportMode = 'merge' | 'replace' | 'skip';
+export type ConflictResolution = 'ask' | 'keep_existing' | 'overwrite' | 'rename';
+
+export interface ImportConfig {
+  mode: ImportMode;
+  conflict_resolution: ConflictResolution;
+  validate: boolean;
+  backup_before: boolean;
+  password: string;
+}
+
+export interface ImportPreviewItem {
+  id: string;
+  type: string;
+  name: string;
+  status: string;
+  action: string;
+}
+
+interface UseImportWorkflowOptions {
+  notify: NotifyFn;
+  progress: ProgressCallbacks;
+}
+
+export interface UseImportWorkflow {
+  importConfig: ImportConfig;
+  importFiles: Readonly<File[]>;
+  importPreview: Readonly<ImportPreviewItem[]>;
+  hasEncryptedFiles: Readonly<boolean>;
+  isImporting: Readonly<boolean>;
+  updateConfig: <K extends keyof ImportConfig>(key: K, value: ImportConfig[K]) => void;
+  addFiles: (files: File[]) => void;
+  removeFile: (file: File) => void;
+  clearFiles: () => void;
+  analyzeFiles: () => Promise<void>;
+  validateImport: () => void;
+  startImport: () => Promise<void>;
+  cancelImport: () => void;
+}
+
+export function useImportWorkflow(options: UseImportWorkflowOptions): UseImportWorkflow {
+  const { notify, progress } = options;
+
+  const importConfig = reactive<ImportConfig>({
+    mode: 'merge',
+    conflict_resolution: 'ask',
+    validate: true,
+    backup_before: true,
+    password: ''
+  });
+
+  const files = ref<File[]>([]);
+  const preview = ref<ImportPreviewItem[]>([]);
+  const isImporting = ref(false);
+
+  const hasEncryptedFiles = computed(() =>
+    files.value.some(file =>
+      file.name.includes('encrypted') ||
+      file.name.includes('password') ||
+      file.name.includes('.enc')
+    )
+  );
+
+  const updateConfig = <K extends keyof ImportConfig>(key: K, value: ImportConfig[K]) => {
+    importConfig[key] = value;
+  };
+
+  const addFiles = (newFiles: File[]) => {
+    if (!newFiles.length) return;
+
+    const validFiles = validateImportFiles(newFiles);
+
+    if (validFiles.length < newFiles.length) {
+      notify('Some files were skipped (unsupported format)', 'warning');
+    }
+
+    files.value = [...files.value, ...validFiles];
+  };
+
+  const removeFile = (fileToRemove: File) => {
+    files.value = files.value.filter(file => file !== fileToRemove);
+    if (files.value.length === 0) {
+      preview.value = [];
+    }
+  };
+
+  const clearFiles = () => {
+    files.value = [];
+    preview.value = [];
+  };
+
+  const analyzeFiles = async () => {
+    if (files.value.length === 0) return;
+
+    try {
+      notify('Analyzing import files...', 'info');
+
+      await new Promise(resolve => setTimeout(resolve, 1500));
+
+      const generatedPreview: ImportPreviewItem[] = [];
+      const types = ['LoRA', 'Generation', 'Config', 'User Data'];
+      const statuses = ['new', 'conflict', 'existing'];
+      const actions = ['Import', 'Skip', 'Overwrite', 'Rename'];
+
+      files.value.forEach((file, fileIndex) => {
+        const itemsPerFile = Math.floor(Math.random() * 5) + 1;
+
+        for (let i = 0; i < itemsPerFile; i++) {
+          const type = types[Math.floor(Math.random() * types.length)];
+          const status = statuses[Math.floor(Math.random() * statuses.length)];
+
+          generatedPreview.push({
+            id: `${fileIndex}_${i}`,
+            type,
+            name: `${type.toLowerCase()}_${file.name}_${i + 1}`,
+            status,
+            action: status === 'conflict' ? 'Ask' : actions[Math.floor(Math.random() * actions.length)]
+          });
+        }
+      });
+
+      preview.value = generatedPreview;
+      notify('File analysis completed', 'success');
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      notify(`Analysis failed: ${message}`, 'error');
+    }
+  };
+
+  const validateImport = () => {
+    const issues: string[] = [];
+
+    if (files.value.length === 0) {
+      issues.push('No files selected for import');
+    }
+
+    if (importConfig.mode === 'replace' && !importConfig.backup_before) {
+      issues.push('Backup recommended when using replace mode');
+    }
+
+    if (issues.length > 0) {
+      notify(`Validation failed: ${issues.join(', ')}`, 'error');
+    } else {
+      notify('Import configuration is valid', 'success');
+    }
+  };
+
+  const startImport = async () => {
+    if (files.value.length === 0) {
+      notify('No files selected for import', 'error');
+      return;
+    }
+
+    try {
+      isImporting.value = true;
+      progress.begin();
+      progress.update({ value: 10, step: 'Preparing import...', message: 'Validating files' });
+
+      const formData = new FormData();
+      files.value.forEach(file => {
+        formData.append('files', file);
+      });
+      formData.append('config', JSON.stringify(importConfig));
+
+      progress.update({ value: 30, step: 'Uploading files...', message: 'Sending files to server' });
+
+      const result = ensureData(
+        await requestJson('/api/v1/import', {
+          method: 'POST',
+          body: formData
+        })
+      ) as Record<string, unknown> | null;
+
+      progress.update({ value: 70, step: 'Processing import...', message: 'Server is processing files' });
+
+      const processedFiles = typeof result?.processed_files === 'number' ? result.processed_files : files.value.length;
+      const totalFiles = typeof result?.total_files === 'number' ? result.total_files : files.value.length;
+
+      progress.update({
+        value: 100,
+        step: 'Import completed',
+        message: `Processed ${processedFiles} of ${totalFiles} files`
+      });
+
+      notify(`Import completed: ${processedFiles} files processed`, 'success');
+      clearFiles();
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      notify(`Import failed: ${message}`, 'error');
+    } finally {
+      isImporting.value = false;
+      progress.end();
+    }
+  };
+
+  const cancelImport = () => {
+    isImporting.value = false;
+  };
+
+  return {
+    importConfig,
+    importFiles: computed(() => files.value),
+    importPreview: computed(() => preview.value),
+    hasEncryptedFiles: computed(() => hasEncryptedFiles.value),
+    isImporting: computed(() => isImporting.value),
+    updateConfig,
+    addFiles,
+    removeFile,
+    clearFiles,
+    analyzeFiles,
+    validateImport,
+    startImport,
+    cancelImport
+  };
+}
+
+const validateImportFiles = (files: File[]): File[] => {
+  const validExtensions = ['.zip', '.tar.gz', '.json', '.lora', '.safetensors'];
+  return files.filter(file => {
+    const extension = getFileExtension(file.name);
+    return validExtensions.includes(extension);
+  });
+};
+
+const getFileExtension = (filename: string): string => {
+  if (filename.endsWith('.tar.gz')) return '.tar.gz';
+  const lastDot = filename.lastIndexOf('.');
+  return lastDot !== -1 ? filename.substring(lastDot) : '';
+};

--- a/app/frontend/src/composables/useMigrationWorkflow.ts
+++ b/app/frontend/src/composables/useMigrationWorkflow.ts
@@ -1,0 +1,51 @@
+import { reactive } from 'vue';
+
+import type { NotifyFn } from './useExportWorkflow';
+
+export interface MigrationConfig {
+  from_version: string;
+  to_version: string;
+  source_platform: string;
+  source_path: string;
+}
+
+interface UseMigrationWorkflowOptions {
+  notify: NotifyFn;
+}
+
+export interface UseMigrationWorkflow {
+  migrationConfig: MigrationConfig;
+  updateConfig: <K extends keyof MigrationConfig>(key: K, value: MigrationConfig[K]) => void;
+  startVersionMigration: () => void;
+  startPlatformMigration: () => void;
+}
+
+export function useMigrationWorkflow(options: UseMigrationWorkflowOptions): UseMigrationWorkflow {
+  const { notify } = options;
+
+  const migrationConfig = reactive<MigrationConfig>({
+    from_version: '2.0',
+    to_version: '2.1',
+    source_platform: 'automatic1111',
+    source_path: ''
+  });
+
+  const updateConfig = <K extends keyof MigrationConfig>(key: K, value: MigrationConfig[K]) => {
+    migrationConfig[key] = value;
+  };
+
+  const startVersionMigration = () => {
+    notify('Version migration functionality coming soon', 'info');
+  };
+
+  const startPlatformMigration = () => {
+    notify('Platform migration functionality coming soon', 'info');
+  };
+
+  return {
+    migrationConfig,
+    updateConfig,
+    startVersionMigration,
+    startPlatformMigration
+  };
+}

--- a/tests/vue/LoraCard.spec.js
+++ b/tests/vue/LoraCard.spec.js
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { mount } from '@vue/test-utils';
+import { flushPromises, mount } from '@vue/test-utils';
 import LoraCard from '../../app/frontend/src/components/LoraCard.vue';
+import LoraCardGrid from '../../app/frontend/src/components/LoraCardGrid.vue';
 
 const mocks = vi.hoisted(() => ({
   updateLoraWeightMock: vi.fn(),
@@ -178,16 +179,22 @@ describe('LoraCard', () => {
     const wrapper = mount(LoraCard, {
       props: {
         lora: mockLora,
+        viewMode: 'grid',
       },
     });
 
-    await wrapper.vm.updateWeight();
-    expect(mocks.updateLoraWeightMock).toHaveBeenCalledWith('/api/v1', 1, expect.any(Number));
+    const grid = wrapper.findComponent(LoraCardGrid);
 
-    await wrapper.vm.toggleActive();
+    grid.vm.$emit('change-weight', 1.25);
+    await flushPromises();
+    expect(mocks.updateLoraWeightMock).toHaveBeenCalledWith('/api/v1', 1, 1.25);
+
+    grid.vm.$emit('toggle-active');
+    await flushPromises();
     expect(mocks.toggleLoraActiveStateMock).toHaveBeenCalledWith('/api/v1', 1, false);
 
-    await wrapper.vm.generatePreview();
+    grid.vm.$emit('generate-preview');
+    await flushPromises();
     expect(mocks.triggerPreviewGenerationMock).toHaveBeenCalledWith('/api/v1', 1);
   });
 });

--- a/tests/vue/useBackupWorkflow.spec.ts
+++ b/tests/vue/useBackupWorkflow.spec.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+import { useBackupWorkflow } from '../../app/frontend/src/composables/useBackupWorkflow';
+
+const getJson = vi.fn();
+const postJson = vi.fn();
+
+vi.mock('@/utils/api', async () => {
+  const actual = await vi.importActual<typeof import('@/utils/api')>('@/utils/api');
+  return {
+    ...actual,
+    getJson: (...args: unknown[]) => getJson(...args),
+    postJson: (...args: unknown[]) => postJson(...args),
+    ensureData: (value: unknown) => value
+  };
+});
+
+describe('useBackupWorkflow', () => {
+  const notify = vi.fn();
+
+  beforeEach(() => {
+    getJson.mockReset();
+    postJson.mockReset();
+    notify.mockReset();
+
+    getJson.mockResolvedValue({ data: { history: [{ id: 'b1', type: 'full', size: 1024, status: 'completed', created_at: '2024-01-01' }] } });
+    postJson.mockResolvedValue({ backup_id: 'b2' });
+  });
+
+  it('loads backup history on initialize', async () => {
+    const workflow = useBackupWorkflow({ notify });
+    await workflow.initialize();
+
+    expect(getJson).toHaveBeenCalledWith('/api/v1/backups/history');
+    expect(workflow.backupHistory.value).toHaveLength(1);
+    expect(workflow.backupHistory.value[0].id).toBe('b1');
+  });
+
+  it('creates backups and refreshes history', async () => {
+    const workflow = useBackupWorkflow({ notify });
+    await workflow.initialize();
+
+    await workflow.createFullBackup();
+    expect(postJson).toHaveBeenCalledWith('/api/v1/backup/create', { backup_type: 'full' });
+    expect(notify).toHaveBeenCalledWith('Full backup initiated: b2', 'success');
+
+    await workflow.createQuickBackup();
+    expect(postJson).toHaveBeenCalledWith('/api/v1/backup/create', { backup_type: 'quick' });
+    expect(notify).toHaveBeenCalledWith('Quick backup initiated: b2', 'success');
+  });
+
+  it('emits informational notifications for other actions', () => {
+    const workflow = useBackupWorkflow({ notify });
+
+    workflow.scheduleBackup();
+    workflow.downloadBackup('b1');
+    workflow.restoreBackup('b1');
+    workflow.deleteBackup('b1');
+
+    expect(notify).toHaveBeenCalledWith('Schedule backup functionality coming soon', 'info');
+    expect(notify).toHaveBeenCalledWith('Download backup b1 functionality coming soon', 'info');
+    expect(notify).toHaveBeenCalledWith('Restore backup b1 functionality coming soon', 'info');
+    expect(notify).toHaveBeenCalledWith('Delete backup b1 functionality coming soon', 'info');
+  });
+});

--- a/tests/vue/useExportWorkflow.spec.ts
+++ b/tests/vue/useExportWorkflow.spec.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { nextTick } from 'vue';
+
+import { useExportWorkflow, type ProgressCallbacks } from '../../app/frontend/src/composables/useExportWorkflow';
+
+const postJson = vi.fn();
+const requestBlob = vi.fn();
+const getFilenameFromContentDisposition = vi.fn();
+const downloadFile = vi.fn();
+
+vi.mock('@/utils/api', async () => {
+  const actual = await vi.importActual<typeof import('@/utils/api')>('@/utils/api');
+  return {
+    ...actual,
+    postJson: (...args: unknown[]) => postJson(...args),
+    requestBlob: (...args: unknown[]) => requestBlob(...args),
+    ensureData: (value: unknown) => value,
+    getFilenameFromContentDisposition: (...args: unknown[]) => getFilenameFromContentDisposition(...args)
+  };
+});
+
+vi.mock('@/utils/browser', async () => {
+  const actual = await vi.importActual<typeof import('@/utils/browser')>('@/utils/browser');
+  return {
+    ...actual,
+    downloadFile: (...args: unknown[]) => downloadFile(...args)
+  };
+});
+
+describe('useExportWorkflow', () => {
+  const notify = vi.fn();
+  let progress: ProgressCallbacks;
+
+  beforeEach(() => {
+    postJson.mockReset();
+    requestBlob.mockReset();
+    getFilenameFromContentDisposition.mockReset();
+    downloadFile.mockReset();
+    notify.mockReset();
+
+    postJson.mockResolvedValue({ size: '10 MB', time: '5 minutes' });
+    requestBlob.mockResolvedValue({
+      blob: new Blob(['content'], { type: 'application/zip' }),
+      response: new Response(null, { headers: { 'Content-Disposition': 'attachment; filename="export.zip"' } })
+    });
+    getFilenameFromContentDisposition.mockReturnValue('export.zip');
+
+    progress = {
+      begin: vi.fn(),
+      update: vi.fn(),
+      end: vi.fn()
+    };
+  });
+
+  it('initializes and updates estimates', async () => {
+    const workflow = useExportWorkflow({ notify, progress });
+
+    await workflow.initialize();
+    await nextTick();
+
+    expect(postJson).toHaveBeenCalledWith('/api/v1/export/estimate', expect.any(Object));
+    expect(workflow.estimatedSize.value).toBe('10 MB');
+    expect(workflow.estimatedTime.value).toBe('5 minutes');
+  });
+
+  it('validates configuration and triggers notifications', () => {
+    const workflow = useExportWorkflow({ notify, progress });
+
+    workflow.updateConfig('loras', false);
+    workflow.updateConfig('generations', false);
+    workflow.updateConfig('user_data', false);
+    workflow.updateConfig('system_config', false);
+    workflow.updateConfig('analytics', false);
+    workflow.validateExport();
+
+    expect(notify).toHaveBeenCalledWith(expect.stringContaining('No data types selected for export'), 'error');
+
+    workflow.updateConfig('loras', true);
+    workflow.validateExport();
+    expect(notify).toHaveBeenCalledWith('Export configuration is valid', 'success');
+  });
+
+  it('starts export and downloads file', async () => {
+    const workflow = useExportWorkflow({ notify, progress });
+
+    await workflow.startExport();
+
+    expect(progress.begin).toHaveBeenCalled();
+    expect(requestBlob).toHaveBeenCalledWith('/api/v1/export', expect.objectContaining({ method: 'POST' }));
+    expect(downloadFile).toHaveBeenCalledWith(expect.any(Blob), 'export.zip');
+    expect(progress.end).toHaveBeenCalled();
+    expect(notify).toHaveBeenCalledWith('Export completed successfully', 'success');
+  });
+
+  it('quick export enables primary datasets and triggers export', async () => {
+    const workflow = useExportWorkflow({ notify, progress });
+
+    requestBlob.mockClear();
+    await workflow.quickExportAll();
+
+    expect(workflow.exportConfig.loras).toBe(true);
+    expect(workflow.exportConfig.lora_files).toBe(true);
+    expect(workflow.exportConfig.generations).toBe(true);
+    expect(workflow.exportConfig.user_data).toBe(true);
+    expect(workflow.exportConfig.system_config).toBe(true);
+    expect(requestBlob).toHaveBeenCalled();
+  });
+
+  it('cancels export by resetting state', () => {
+    const workflow = useExportWorkflow({ notify, progress });
+    workflow.cancelExport();
+    expect(workflow.isExporting.value).toBe(false);
+  });
+});

--- a/tests/vue/useImportWorkflow.spec.ts
+++ b/tests/vue/useImportWorkflow.spec.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+import { useImportWorkflow, type ProgressCallbacks } from '../../app/frontend/src/composables/useImportWorkflow';
+
+const requestJson = vi.fn();
+
+vi.mock('@/utils/api', async () => {
+  const actual = await vi.importActual<typeof import('@/utils/api')>('@/utils/api');
+  return {
+    ...actual,
+    requestJson: (...args: unknown[]) => requestJson(...args),
+    ensureData: (value: unknown) => value
+  };
+});
+
+describe('useImportWorkflow', () => {
+  const notify = vi.fn();
+  let progress: ProgressCallbacks;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    requestJson.mockReset();
+    notify.mockReset();
+
+    requestJson.mockResolvedValue({ processed_files: 1, total_files: 1 });
+    progress = {
+      begin: vi.fn(),
+      update: vi.fn(),
+      end: vi.fn()
+    };
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('adds valid files and filters unsupported ones', () => {
+    const workflow = useImportWorkflow({ notify, progress });
+    const validFile = new File(['data'], 'test.zip');
+    const invalidFile = new File(['data'], 'invalid.txt');
+
+    workflow.addFiles([validFile, invalidFile]);
+
+    expect(workflow.importFiles.value).toHaveLength(1);
+    expect(workflow.importFiles.value[0].name).toBe('test.zip');
+    expect(notify).toHaveBeenCalledWith('Some files were skipped (unsupported format)', 'warning');
+  });
+
+  it('analyzes files and populates preview', async () => {
+    const workflow = useImportWorkflow({ notify, progress });
+    workflow.addFiles([new File(['data'], 'test.zip')]);
+
+    const analyzePromise = workflow.analyzeFiles();
+    await vi.runAllTimersAsync();
+    await analyzePromise;
+
+    expect(notify).toHaveBeenCalledWith('File analysis completed', 'success');
+    expect(workflow.importPreview.value.length).toBeGreaterThan(0);
+  });
+
+  it('validates import configuration', () => {
+    const workflow = useImportWorkflow({ notify, progress });
+
+    workflow.validateImport();
+    expect(notify).toHaveBeenCalledWith(expect.stringContaining('No files selected for import'), 'error');
+
+    workflow.addFiles([new File(['data'], 'test.zip')]);
+    workflow.validateImport();
+    expect(notify).toHaveBeenCalledWith('Import configuration is valid', 'success');
+  });
+
+  it('starts import workflow and clears files on success', async () => {
+    const workflow = useImportWorkflow({ notify, progress });
+    workflow.addFiles([new File(['data'], 'test.zip')]);
+
+    await workflow.startImport();
+
+    expect(progress.begin).toHaveBeenCalled();
+    expect(requestJson).toHaveBeenCalledWith('/api/v1/import', expect.objectContaining({ method: 'POST' }));
+    expect(notify).toHaveBeenCalledWith('Import completed: 1 files processed', 'success');
+    expect(workflow.importFiles.value).toHaveLength(0);
+    expect(progress.end).toHaveBeenCalled();
+  });
+
+  it('cancels import by resetting state', () => {
+    const workflow = useImportWorkflow({ notify, progress });
+    workflow.cancelImport();
+    expect(workflow.isImporting.value).toBe(false);
+  });
+});

--- a/tests/vue/useMigrationWorkflow.spec.ts
+++ b/tests/vue/useMigrationWorkflow.spec.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect, vi } from 'vitest';
+
+import { useMigrationWorkflow } from '../../app/frontend/src/composables/useMigrationWorkflow';
+
+describe('useMigrationWorkflow', () => {
+  const notify = vi.fn();
+
+  it('updates configuration values', () => {
+    const workflow = useMigrationWorkflow({ notify });
+
+    workflow.updateConfig('from_version', '1.0');
+    workflow.updateConfig('source_path', '/data');
+
+    expect(workflow.migrationConfig.from_version).toBe('1.0');
+    expect(workflow.migrationConfig.source_path).toBe('/data');
+  });
+
+  it('announces migration actions', () => {
+    const workflow = useMigrationWorkflow({ notify });
+
+    workflow.startVersionMigration();
+    workflow.startPlatformMigration();
+
+    expect(notify).toHaveBeenCalledWith('Version migration functionality coming soon', 'info');
+    expect(notify).toHaveBeenCalledWith('Platform migration functionality coming soon', 'info');
+  });
+});


### PR DESCRIPTION
## Summary
- split the ImportExport UI into dedicated subcomponents for export, import, backups, and migration panels
- extract export, import, backup, and migration orchestration into new composables with a simplified parent component
- refresh the ImportExport test suite and add workflow-specific composable tests for better coverage

## Testing
- npm run test:unit

------
https://chatgpt.com/codex/tasks/task_e_68d20f08875c8329a00daa0fc0d1f1e4