### PR TITLE
Refactor service providers for explicit dependency injection

### DIFF
--- a/backend/services/generation/statuses.py
+++ b/backend/services/generation/statuses.py
@@ -12,44 +12,51 @@ from typing import Dict, Optional
 class GenerationStatus(Enum):
     """Canonical generation statuses exposed by the API."""
 
-
     QUEUED = "queued"
     PROCESSING = "processing"
     COMPLETED = "completed"
     FAILED = "failed"
 
 
-_VALUE_TO_STATUS: Dict[str, GenerationStatus] = {
-    status.value: status for status in GenerationStatus
-}
+NormalizedGenerationStatus = GenerationStatus
 
-_DELIVERY_TO_STATUS: Dict[str, GenerationStatus] = {
+
+DEFAULT_NORMALIZED_STATUS: NormalizedGenerationStatus = GenerationStatus.PROCESSING
+
+
+STATUS_NORMALIZATION_MAP: Dict[str, NormalizedGenerationStatus] = {
+    GenerationStatus.QUEUED.value: GenerationStatus.QUEUED,
+    GenerationStatus.PROCESSING.value: GenerationStatus.PROCESSING,
+    GenerationStatus.COMPLETED.value: GenerationStatus.COMPLETED,
+    GenerationStatus.FAILED.value: GenerationStatus.FAILED,
     "pending": GenerationStatus.QUEUED,
     "running": GenerationStatus.PROCESSING,
     "retrying": GenerationStatus.PROCESSING,
+    "starting": GenerationStatus.PROCESSING,
     "succeeded": GenerationStatus.COMPLETED,
     "failed": GenerationStatus.FAILED,
     "cancelled": GenerationStatus.FAILED,
 }
 
 
-def normalize_status(status: Optional[str]) -> GenerationStatus:
+def normalize_status(status: Optional[str]) -> NormalizedGenerationStatus:
     """Normalize a delivery status into a canonical API value."""
 
     if not status:
-        return GenerationStatus.PROCESSING
+        return DEFAULT_NORMALIZED_STATUS
 
     normalized = status.lower()
-
-    mapped = _DELIVERY_TO_STATUS.get(normalized)
+    mapped = STATUS_NORMALIZATION_MAP.get(normalized)
     if mapped is not None:
         return mapped
 
-    existing = _VALUE_TO_STATUS.get(normalized)
-    if existing is not None:
-        return existing
-
-    return GenerationStatus.PROCESSING
+    return DEFAULT_NORMALIZED_STATUS
 
 
-__all__ = ["GenerationStatus", "normalize_status"]
+__all__ = [
+    "DEFAULT_NORMALIZED_STATUS",
+    "GenerationStatus",
+    "NormalizedGenerationStatus",
+    "STATUS_NORMALIZATION_MAP",
+    "normalize_status",
+]

--- a/backend/services/providers/__init__.py
+++ b/backend/services/providers/__init__.py
@@ -1,0 +1,236 @@
+"""Factory helpers for constructing service instances with explicit dependencies."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from sqlmodel import Session
+
+from backend.services.adapters import AdapterService
+from backend.services.analytics import AnalyticsService, InsightGenerator, TimeSeriesBuilder
+from backend.services.analytics_repository import AnalyticsRepository
+from backend.services.archive import ArchiveExportPlanner, ArchiveImportExecutor, ArchiveService
+from backend.services.composition import ComposeService
+from backend.services.deliveries import DeliveryService
+from backend.services.delivery_repository import DeliveryJobRepository
+from backend.services.generation import GenerationCoordinator, GenerationService
+from backend.services.queue import QueueOrchestrator
+from backend.services.recommendations import (
+    EmbeddingCoordinator,
+    EmbeddingManager,
+    FeedbackManager,
+    LoRAEmbeddingRepository,
+    RecommendationConfig,
+    RecommendationMetricsTracker,
+    RecommendationModelBootstrap,
+    RecommendationPersistenceManager,
+    RecommendationPersistenceService,
+    RecommendationRepository,
+    RecommendationService,
+    RecommendationServiceBuilder,
+    SimilarLoraUseCase,
+    StatsReporter,
+    PromptRecommendationUseCase,
+)
+from backend.services.storage import StorageBackend, StorageService, get_storage_backend
+from backend.services.system import SystemService
+from backend.services.websocket import WebSocketService
+
+
+def make_storage_service(*, backend: Optional[StorageBackend] = None) -> StorageService:
+    """Create a :class:`StorageService` using the provided backend."""
+
+    backend = backend or get_storage_backend()
+    return StorageService(backend)
+
+
+def make_adapter_service(
+    *,
+    db_session: Session,
+    storage_service: StorageService,
+    storage_backend: Optional[StorageBackend] = None,
+) -> AdapterService:
+    """Create an :class:`AdapterService` with explicit collaborators."""
+
+    backend = storage_backend or storage_service.backend
+    return AdapterService(db_session, storage_backend=backend)
+
+
+def make_archive_service(
+    adapter_service: AdapterService,
+    storage_service: StorageService,
+    *,
+    planner: Optional[ArchiveExportPlanner] = None,
+    executor: Optional[ArchiveImportExecutor] = None,
+    chunk_size: int = 64 * 1024,
+    spooled_file_max_size: int = 32 * 1024 * 1024,
+) -> ArchiveService:
+    """Create an :class:`ArchiveService` wired with planner and executor collaborators."""
+
+    return ArchiveService(
+        adapter_service,
+        storage_service,
+        planner=planner,
+        executor=executor,
+        chunk_size=chunk_size,
+        spooled_file_max_size=spooled_file_max_size,
+    )
+
+
+def make_delivery_service(
+    repository: DeliveryJobRepository,
+    *,
+    queue_orchestrator: QueueOrchestrator,
+) -> DeliveryService:
+    """Create a :class:`DeliveryService` with explicit repository and queue orchestrator."""
+
+    return DeliveryService(repository, queue_orchestrator=queue_orchestrator)
+
+
+def make_compose_service() -> ComposeService:
+    """Create a :class:`ComposeService`."""
+
+    return ComposeService()
+
+
+def make_generation_service() -> GenerationService:
+    """Create a :class:`GenerationService`."""
+
+    return GenerationService()
+
+
+def make_generation_coordinator(
+    delivery_service: DeliveryService,
+    websocket_service: WebSocketService,
+    generation_service: GenerationService,
+) -> GenerationCoordinator:
+    """Create a :class:`GenerationCoordinator` with its collaborators."""
+
+    return GenerationCoordinator(delivery_service, websocket_service, generation_service)
+
+
+def make_websocket_service(
+    *,
+    service: Optional[WebSocketService] = None,
+    connection_manager=None,
+    job_monitor=None,
+) -> WebSocketService:
+    """Create or return a :class:`WebSocketService` configured with explicit collaborators."""
+
+    if service is not None:
+        return service
+    return WebSocketService(connection_manager=connection_manager, job_monitor=job_monitor)
+
+
+def make_system_service(delivery_service: DeliveryService) -> SystemService:
+    """Create a :class:`SystemService` bound to the delivery service."""
+
+    return SystemService(delivery_service)
+
+
+def make_analytics_service(
+    db_session: Session,
+    *,
+    repository: AnalyticsRepository,
+    time_series_builder: Optional[TimeSeriesBuilder] = None,
+    insight_generator: Optional[InsightGenerator] = None,
+) -> AnalyticsService:
+    """Create an :class:`AnalyticsService` with explicit collaborators."""
+
+    return AnalyticsService(
+        db_session,
+        repository=repository,
+        time_series_builder=time_series_builder or TimeSeriesBuilder(),
+        insight_generator=insight_generator or InsightGenerator(),
+    )
+
+
+def make_recommendation_service(
+    db_session: Session,
+    *,
+    gpu_available: bool,
+    model_bootstrap: Optional[RecommendationModelBootstrap] = None,
+    embedding_repository: Optional[LoRAEmbeddingRepository] = None,
+    embedding_manager: Optional[EmbeddingManager] = None,
+    repository: Optional[RecommendationRepository] = None,
+    persistence_manager: Optional[RecommendationPersistenceManager] = None,
+    persistence_service: Optional[RecommendationPersistenceService] = None,
+    metrics_tracker: Optional[RecommendationMetricsTracker] = None,
+    config: Optional[RecommendationConfig] = None,
+    similar_use_case: Optional[SimilarLoraUseCase] = None,
+    prompt_use_case: Optional[PromptRecommendationUseCase] = None,
+    embedding_coordinator: Optional[EmbeddingCoordinator] = None,
+    feedback_manager: Optional[FeedbackManager] = None,
+    stats_reporter: Optional[StatsReporter] = None,
+    builder: Optional[RecommendationServiceBuilder] = None,
+) -> RecommendationService:
+    """Create a :class:`RecommendationService` wired with explicit collaborators."""
+
+    bootstrap = model_bootstrap or RecommendationModelBootstrap(gpu_enabled=gpu_available)
+    model_registry = bootstrap.get_model_registry()
+
+    repository = repository or RecommendationRepository(db_session)
+    embedding_repository = embedding_repository or LoRAEmbeddingRepository(db_session)
+    embedding_manager = embedding_manager or EmbeddingManager(embedding_repository, model_registry)
+
+    persistence_manager = persistence_manager or RecommendationPersistenceManager(
+        embedding_manager,
+        model_registry.get_recommendation_engine,
+    )
+    persistence_service = persistence_service or RecommendationPersistenceService(
+        persistence_manager
+    )
+
+    metrics_tracker = metrics_tracker or RecommendationMetricsTracker()
+    config = config or RecommendationConfig(persistence_service)
+
+    similar_use_case = similar_use_case or SimilarLoraUseCase(
+        repository=repository,
+        embedding_workflow=embedding_manager,
+        engine_provider=model_registry.get_recommendation_engine,
+        metrics=metrics_tracker,
+    )
+    prompt_use_case = prompt_use_case or PromptRecommendationUseCase(
+        repository=repository,
+        embedder_provider=model_registry.get_semantic_embedder,
+        metrics=metrics_tracker,
+        device=bootstrap.device,
+    )
+
+    embedding_coordinator = embedding_coordinator or EmbeddingCoordinator(
+        bootstrap=bootstrap,
+        embedding_workflow=embedding_manager,
+        persistence_service=persistence_service,
+    )
+    feedback_manager = feedback_manager or FeedbackManager(repository)
+    stats_reporter = stats_reporter or StatsReporter(
+        metrics_tracker=metrics_tracker,
+        repository=repository,
+    )
+
+    builder = builder or RecommendationServiceBuilder()
+    return (
+        builder.with_components(
+            embedding_coordinator=embedding_coordinator,
+            feedback_manager=feedback_manager,
+            stats_reporter=stats_reporter,
+            similar_lora_use_case=similar_use_case,
+            prompt_recommendation_use_case=prompt_use_case,
+            config=config,
+        ).build()
+    )
+
+
+__all__ = [
+    "make_adapter_service",
+    "make_analytics_service",
+    "make_archive_service",
+    "make_compose_service",
+    "make_delivery_service",
+    "make_generation_coordinator",
+    "make_generation_service",
+    "make_recommendation_service",
+    "make_storage_service",
+    "make_system_service",
+    "make_websocket_service",
+]

--- a/backend/workers/context.py
+++ b/backend/workers/context.py
@@ -10,6 +10,8 @@ from sqlmodel import Session
 
 from backend.delivery.base import delivery_registry
 from backend.services import ServiceContainer
+from backend.services.analytics_repository import AnalyticsRepository
+from backend.services.delivery_repository import DeliveryJobRepository
 from backend.services.queue import (
     QueueBackend,
     QueueOrchestrator,
@@ -108,9 +110,18 @@ class WorkerContext:
     def create_service_container(self, db_session: Optional[Session]) -> ServiceContainer:
         """Instantiate a service container sharing this context's dependencies."""
 
+        delivery_repository = (
+            DeliveryJobRepository(db_session) if db_session is not None else None
+        )
+        analytics_repository = (
+            AnalyticsRepository(db_session) if db_session is not None else None
+        )
+
         return ServiceContainer(
             db_session,
             queue_orchestrator=self.queue_orchestrator,
+            delivery_repository=delivery_repository,
+            analytics_repository=analytics_repository,
             recommendation_gpu_available=self.recommendation_gpu_available,
         )
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -8,6 +8,8 @@ from backend.core.dependencies import get_service_container
 from backend.main import app as backend_app
 from backend.schemas import SDNextGenerationResult
 from backend.services import ServiceContainer
+from backend.services.analytics_repository import AnalyticsRepository
+from backend.services.delivery_repository import DeliveryJobRepository
 from backend.services.queue import QueueBackend, QueueOrchestrator
 from backend.services.storage import get_storage_service
 
@@ -253,9 +255,14 @@ def test_compose_uses_primary_queue_backend(
 
     def override_service_container():
         orchestrator = QueueOrchestrator(primary_backend=queue_backend)
+        repository = DeliveryJobRepository(db_session)
+        analytics_repository = AnalyticsRepository(db_session)
         return ServiceContainer(
             db_session,
             queue_orchestrator=orchestrator,
+            delivery_repository=repository,
+            analytics_repository=analytics_repository,
+            recommendation_gpu_available=False,
         )
 
     backend_app.dependency_overrides[get_service_container] = override_service_container
@@ -295,9 +302,14 @@ def test_compose_falls_back_to_background_queue(
             primary_backend=primary_queue,
             fallback_backend=fallback_queue,
         )
+        repository = DeliveryJobRepository(db_session)
+        analytics_repository = AnalyticsRepository(db_session)
         return ServiceContainer(
             db_session,
             queue_orchestrator=orchestrator,
+            delivery_repository=repository,
+            analytics_repository=analytics_repository,
+            recommendation_gpu_available=False,
         )
 
     backend_app.dependency_overrides[get_service_container] = override_service_container

--- a/tests/test_queue_configuration.py
+++ b/tests/test_queue_configuration.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from backend.core.config import settings
 from backend.services import ServiceContainer
+from backend.services.analytics_repository import AnalyticsRepository
+from backend.services.delivery_repository import DeliveryJobRepository
 from backend.services.queue import BackgroundTaskQueueBackend, QueueOrchestrator, RedisQueueBackend
 from backend.workers import tasks as worker_tasks
 from backend.workers.tasks import reset_worker_context, set_worker_context
@@ -26,7 +28,13 @@ def test_queue_factory_shared_backend_with_redis(db_session) -> None:
         assert isinstance(primary, RedisQueueBackend)
         assert isinstance(fallback, BackgroundTaskQueueBackend)
 
-        container = ServiceContainer(db_session, queue_orchestrator=orchestrator)
+        container = ServiceContainer(
+            db_session,
+            queue_orchestrator=orchestrator,
+            delivery_repository=DeliveryJobRepository(db_session),
+            analytics_repository=AnalyticsRepository(db_session),
+            recommendation_gpu_available=False,
+        )
         deliveries_service = container.deliveries
 
         assert deliveries_service.queue_orchestrator is orchestrator
@@ -57,7 +65,13 @@ def test_queue_factory_shared_backend_without_redis(db_session) -> None:
         assert primary is None
         assert isinstance(fallback, BackgroundTaskQueueBackend)
 
-        container = ServiceContainer(db_session, queue_orchestrator=orchestrator)
+        container = ServiceContainer(
+            db_session,
+            queue_orchestrator=orchestrator,
+            delivery_repository=DeliveryJobRepository(db_session),
+            analytics_repository=AnalyticsRepository(db_session),
+            recommendation_gpu_available=False,
+        )
         deliveries_service = container.deliveries
 
         assert deliveries_service.queue_orchestrator is orchestrator

--- a/tests/test_recommendations.py
+++ b/tests/test_recommendations.py
@@ -21,6 +21,7 @@ from backend.schemas.recommendations import (
     UserPreferenceRequest,
 )
 from backend.services import ServiceContainer
+from backend.services.analytics_repository import AnalyticsRepository
 from backend.services.recommendations import (
     EmbeddingBatchRunner,
     EmbeddingCoordinator,
@@ -550,7 +551,11 @@ class TestRecommendationService:
         assert service.device == "cpu"
 
     def test_service_container_builds_dependencies(self, db_session):
-        container = ServiceContainer(db_session)
+        container = ServiceContainer(
+            db_session,
+            analytics_repository=AnalyticsRepository(db_session),
+            recommendation_gpu_available=False,
+        )
         service = container.recommendations
 
         assert isinstance(service, RecommendationService)

--- a/tests/test_service_providers.py
+++ b/tests/test_service_providers.py
@@ -1,0 +1,196 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from backend.services.adapters.service import AdapterService
+from backend.services.archive import ArchiveService
+from backend.services.composition import ComposeService
+from backend.services.deliveries import DeliveryService
+from backend.services.delivery_repository import DeliveryJobRepository
+from backend.services.generation import GenerationCoordinator, GenerationService
+from backend.services.providers import (
+    make_adapter_service,
+    make_analytics_service,
+    make_archive_service,
+    make_compose_service,
+    make_delivery_service,
+    make_generation_coordinator,
+    make_generation_service,
+    make_recommendation_service,
+    make_storage_service,
+    make_system_service,
+    make_websocket_service,
+)
+from backend.services.queue import QueueOrchestrator
+from backend.services.recommendations import RecommendationServiceBuilder
+from backend.services.storage import StorageService
+from backend.services.system import SystemService
+from backend.services.websocket import WebSocketService
+
+
+class DummyRepository(DeliveryJobRepository):
+    def __init__(self):
+        self.created_jobs = []
+
+    def create_job(self, prompt, mode, params):  # type: ignore[override]
+        job = SimpleNamespace(id="job", prompt=prompt, mode=mode, params=params)
+        self.created_jobs.append(job)
+        return job
+
+
+def test_make_storage_service_uses_provided_backend():
+    backend = MagicMock()
+    service = make_storage_service(backend=backend)
+    assert isinstance(service, StorageService)
+    assert service.backend is backend
+
+
+def test_make_adapter_service_respects_storage_backend():
+    session = MagicMock()
+    storage_backend = MagicMock()
+    storage_service = StorageService(storage_backend)
+
+    service = make_adapter_service(
+        db_session=session,
+        storage_service=storage_service,
+    )
+
+    assert isinstance(service, AdapterService)
+    assert service.db_session is session
+    assert service.storage_backend is storage_backend
+
+
+def test_make_archive_service_injects_planner_and_executor():
+    adapter_service = MagicMock()
+    storage_service = MagicMock()
+    planner = MagicMock()
+    executor = MagicMock()
+
+    service = make_archive_service(
+        adapter_service,
+        storage_service,
+        planner=planner,
+        executor=executor,
+    )
+
+    assert isinstance(service, ArchiveService)
+    assert service.planner is planner
+    assert service.executor is executor
+
+
+def test_make_delivery_service_assigns_orchestrator():
+    repository = DummyRepository()
+    orchestrator = MagicMock(spec=QueueOrchestrator)
+
+    service = make_delivery_service(repository, queue_orchestrator=orchestrator)
+
+    assert isinstance(service, DeliveryService)
+    assert service.repository is repository
+    assert service.queue_orchestrator is orchestrator
+
+
+def test_make_compose_service_returns_instance():
+    assert isinstance(make_compose_service(), ComposeService)
+
+
+def test_make_generation_service_returns_instance():
+    assert isinstance(make_generation_service(), GenerationService)
+
+
+def test_make_generation_coordinator_uses_dependencies():
+    deliveries = MagicMock()
+    websocket = MagicMock(spec=WebSocketService)
+    generation = MagicMock(spec=GenerationService)
+
+    coordinator = make_generation_coordinator(deliveries, websocket, generation)
+
+    assert isinstance(coordinator, GenerationCoordinator)
+    assert coordinator._deliveries is deliveries
+    assert coordinator._websocket is websocket
+    assert coordinator._generation_service is generation
+
+
+def test_make_websocket_service_returns_existing_instance():
+    instance = WebSocketService()
+    assert make_websocket_service(service=instance) is instance
+
+
+def test_make_system_service_wires_delivery_service():
+    deliveries = MagicMock(spec=DeliveryService)
+    system_service = make_system_service(deliveries)
+    assert isinstance(system_service, SystemService)
+    assert system_service._delivery_service is deliveries
+
+
+def test_make_analytics_service_respects_injected_builder():
+    session = MagicMock()
+    repository = MagicMock()
+    time_series_builder = MagicMock()
+    insight_generator = MagicMock()
+
+    service = make_analytics_service(
+        session,
+        repository=repository,
+        time_series_builder=time_series_builder,
+        insight_generator=insight_generator,
+    )
+
+    assert service.db_session is session
+    assert service.repository is repository
+    assert service.time_series_builder is time_series_builder
+    assert service.insight_generator is insight_generator
+
+
+def test_make_recommendation_service_uses_custom_components():
+    session = MagicMock()
+    bootstrap = MagicMock()
+    bootstrap.device = "cpu"
+    bootstrap.gpu_enabled = False
+    model_registry = MagicMock()
+    bootstrap.get_model_registry.return_value = model_registry
+
+    embedding_repository = MagicMock()
+    embedding_manager = MagicMock()
+    repository = MagicMock()
+    persistence_manager = MagicMock()
+    persistence_service = MagicMock()
+    metrics_tracker = MagicMock()
+    config = MagicMock()
+    similar_use_case = MagicMock()
+    prompt_use_case = MagicMock()
+    embedding_coordinator = MagicMock()
+    feedback_manager = MagicMock()
+    stats_reporter = MagicMock()
+    builder = MagicMock(spec=RecommendationServiceBuilder)
+    builder.with_components.return_value = builder
+    built_service = MagicMock()
+    builder.build.return_value = built_service
+
+    service = make_recommendation_service(
+        session,
+        gpu_available=True,
+        model_bootstrap=bootstrap,
+        embedding_repository=embedding_repository,
+        embedding_manager=embedding_manager,
+        repository=repository,
+        persistence_manager=persistence_manager,
+        persistence_service=persistence_service,
+        metrics_tracker=metrics_tracker,
+        config=config,
+        similar_use_case=similar_use_case,
+        prompt_use_case=prompt_use_case,
+        embedding_coordinator=embedding_coordinator,
+        feedback_manager=feedback_manager,
+        stats_reporter=stats_reporter,
+        builder=builder,
+    )
+
+    builder.with_components.assert_called_once_with(
+        embedding_coordinator=embedding_coordinator,
+        feedback_manager=feedback_manager,
+        stats_reporter=stats_reporter,
+        similar_lora_use_case=similar_use_case,
+        prompt_recommendation_use_case=prompt_use_case,
+        config=config,
+    )
+    builder.build.assert_called_once_with()
+    assert service is built_service

--- a/tests/test_websocket_components.py
+++ b/tests/test_websocket_components.py
@@ -132,7 +132,7 @@ def test_delivery_job_state_repository_returns_persisted_state(
 
     @contextmanager
     def session_factory():
-        yield delivery_service.db_session
+        yield delivery_service.repository._session
 
     repository = DeliveryJobStateRepository(session_factory=session_factory)
     state = repository.get_job_state(job.id)


### PR DESCRIPTION
## Summary
- introduce backend.services.providers module supplying factory helpers for each service
- rework ServiceContainer, FastAPI dependencies, and worker context to inject explicit repositories and GPU flags via those providers
- expose generation status normalization constants and update tests to cover the new providers and container behavior

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d277f15f2883299e06214b473d926d