### PR TITLE
Refactor admin metrics polling utilities

### DIFF
--- a/app/frontend/src/composables/usePolling.ts
+++ b/app/frontend/src/composables/usePolling.ts
@@ -1,0 +1,126 @@
+import { computed, ref, type ComputedRef, type Ref } from 'vue';
+
+interface UsePollingOptions {
+  interval?: number;
+  minInterval?: number;
+}
+
+type PollingCallback = () => void | Promise<void>;
+
+export interface PollingController {
+  intervalMs: Ref<number>;
+  isActive: ComputedRef<boolean>;
+  subscriberCount: Ref<number>;
+  start: () => void;
+  stop: () => void;
+  setInterval: (value: number) => void;
+  subscribe: (interval?: number) => boolean;
+  unsubscribe: () => boolean;
+}
+
+export const usePolling = (
+  callback: PollingCallback,
+  options: UsePollingOptions = {},
+): PollingController => {
+  const minInterval = Math.max(1, Math.floor(options.minInterval ?? 1_000));
+  const initialInterval = Math.max(minInterval, Math.floor(options.interval ?? 5_000));
+
+  const intervalMs = ref(initialInterval);
+  const timer = ref<ReturnType<typeof setInterval> | null>(null);
+  const subscribers = ref(0);
+
+  const runCallback = () => {
+    try {
+      const result = callback();
+      if (result instanceof Promise) {
+        result.catch((error) => {
+          if (import.meta.env?.DEV) {
+            console.error('[usePolling] Polling callback rejected', error);
+          }
+        });
+      }
+    } catch (error) {
+      if (import.meta.env?.DEV) {
+        console.error('[usePolling] Polling callback threw an error', error);
+      }
+    }
+  };
+
+  const start = () => {
+    if (timer.value) {
+      return;
+    }
+
+    timer.value = setInterval(() => {
+      runCallback();
+    }, intervalMs.value);
+  };
+
+  const stop = () => {
+    if (!timer.value) {
+      return;
+    }
+
+    clearInterval(timer.value);
+    timer.value = null;
+  };
+
+  const setIntervalMs = (value: number) => {
+    if (!Number.isFinite(value) || value <= 0) {
+      return;
+    }
+
+    const normalised = Math.max(minInterval, Math.floor(value));
+    if (normalised === intervalMs.value) {
+      return;
+    }
+
+    intervalMs.value = normalised;
+
+    if (timer.value) {
+      stop();
+      start();
+    }
+  };
+
+  const subscribe = (value?: number): boolean => {
+    if (typeof value === 'number') {
+      setIntervalMs(value);
+    }
+
+    subscribers.value += 1;
+    const shouldStart = subscribers.value === 1;
+    if (shouldStart) {
+      start();
+    }
+
+    return shouldStart;
+  };
+
+  const unsubscribe = (): boolean => {
+    if (subscribers.value === 0) {
+      return false;
+    }
+
+    subscribers.value = Math.max(0, subscribers.value - 1);
+    const shouldStop = subscribers.value === 0;
+    if (shouldStop) {
+      stop();
+    }
+
+    return shouldStop;
+  };
+
+  const isActive = computed(() => timer.value !== null);
+
+  return {
+    intervalMs,
+    isActive,
+    subscriberCount: subscribers,
+    start,
+    stop,
+    setInterval: setIntervalMs,
+    subscribe,
+    unsubscribe,
+  };
+};

--- a/app/frontend/src/stores/adminMetrics.ts
+++ b/app/frontend/src/stores/adminMetrics.ts
@@ -1,4 +1,4 @@
-import { computed, ref, type Ref } from 'vue';
+import { ref } from 'vue';
 import { defineStore } from 'pinia';
 
 import {
@@ -7,6 +7,14 @@ import {
   fetchDashboardStats,
 } from '@/services/systemService';
 import { useBackendBase } from '@/utils/backend';
+import {
+  buildResourceStats,
+  defaultResourceStats,
+  defaultSystemStatus,
+  deriveSeverityFromMetrics,
+  mergeStatusLevels,
+  normaliseStatus,
+} from '@/utils/systemMetrics';
 
 import type {
   DashboardStatsSummary,
@@ -15,146 +23,28 @@ import type {
   SystemStatusLevel,
 } from '@/types';
 
-const DEFAULT_STATS: SystemResourceStatsSummary = {
-  uptime: 'N/A',
-  active_workers: 0,
-  total_workers: 0,
-  database_size: 0,
-  total_records: 0,
-  gpu_memory_used: 'N/A',
-  gpu_memory_total: 'N/A',
-};
-
-const DEFAULT_STATUS: SystemStatusLevel = 'unknown';
-
-const MIN_POLL_INTERVAL = 1_000;
-const DEFAULT_POLL_INTERVAL = 5_000;
-
 interface RefreshOptions {
   showLoader?: boolean;
 }
-
-const clampPercent = (value?: number | null): number => {
-  if (typeof value !== 'number' || Number.isNaN(value)) {
-    return 0;
-  }
-  return Math.min(100, Math.max(0, Math.round(value)));
-};
-
-const formatBytes = (value?: number | null): string => {
-  if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) {
-    return 'N/A';
-  }
-
-  const units = ['Bytes', 'KB', 'MB', 'GB', 'TB'];
-  let size = value;
-  let unitIndex = 0;
-
-  while (size >= 1024 && unitIndex < units.length - 1) {
-    size /= 1024;
-    unitIndex += 1;
-  }
-
-  const formatted = unitIndex === 0 ? size.toFixed(0) : size.toFixed(2);
-  return `${Number.parseFloat(formatted).toString()} ${units[unitIndex]}`;
-};
-
-const normaliseStatus = (status?: string | null): SystemStatusLevel => {
-  if (!status) {
-    return DEFAULT_STATUS;
-  }
-
-  const value = status.toLowerCase();
-  if (value === 'healthy' || value === 'warning' || value === 'error') {
-    return value;
-  }
-
-  return DEFAULT_STATUS;
-};
-
-const deriveSeverityFromMetrics = (metrics: SystemMetricsSnapshot): SystemStatusLevel => {
-  const memoryPercent = clampPercent(metrics.memory_percent);
-  const diskPercent = clampPercent(metrics.disk_percent);
-  const gpus = metrics.gpus ?? [];
-
-  const hasCriticalGpu = gpus.some((gpu) => {
-    const temperature = typeof gpu.temperature === 'number' ? gpu.temperature : 0;
-    const memory = clampPercent(gpu.memory_percent);
-    return temperature > 85 || memory > 95;
-  });
-
-  if (memoryPercent > 95 || diskPercent > 95 || hasCriticalGpu) {
-    return 'error';
-  }
-
-  const hasWarningGpu = gpus.some((gpu) => {
-    const temperature = typeof gpu.temperature === 'number' ? gpu.temperature : 0;
-    const memory = clampPercent(gpu.memory_percent);
-    return temperature > 75 || memory > 85;
-  });
-
-  if (memoryPercent > 85 || diskPercent > 85 || hasWarningGpu) {
-    return 'warning';
-  }
-
-  return 'healthy';
-};
-
-const mergeStatusLevels = (base: SystemStatusLevel, derived: SystemStatusLevel): SystemStatusLevel => {
-  if (base === 'error' || derived === 'error') {
-    return 'error';
-  }
-  if (base === 'warning' || derived === 'warning') {
-    return 'warning';
-  }
-  if (base === 'healthy' && derived === 'healthy') {
-    return 'healthy';
-  }
-  return DEFAULT_STATUS;
-};
-
-const applyStatsFromSummary = (
-  statsRef: Ref<SystemResourceStatsSummary>,
-  summary: DashboardStatsSummary | null,
-  metrics: SystemMetricsSnapshot,
-) => {
-  const next: SystemResourceStatsSummary = { ...DEFAULT_STATS };
-  const stats = summary?.stats ?? null;
-
-  next.total_records = stats?.total_loras ?? 0;
-  next.active_workers = (stats as Record<string, number | undefined>)?.active_workers ?? 0;
-  next.total_workers = (stats as Record<string, number | undefined>)?.total_workers ?? 0;
-  next.database_size = (stats as Record<string, number | undefined>)?.database_size ?? 0;
-  next.gpu_memory_used = formatBytes(metrics.memory_used);
-  next.gpu_memory_total = formatBytes(metrics.memory_total);
-
-  statsRef.value = next;
-};
 
 export const useAdminMetricsStore = defineStore('adminMetrics', () => {
   const backendBase = useBackendBase();
 
   const summary = ref<DashboardStatsSummary | null>(null);
   const metrics = ref<SystemMetricsSnapshot>(emptyMetricsSnapshot());
-  const stats = ref<SystemResourceStatsSummary>({ ...DEFAULT_STATS });
-  const status = ref<SystemStatusLevel>(DEFAULT_STATUS);
+  const stats = ref<SystemResourceStatsSummary>(defaultResourceStats());
+  const status = ref<SystemStatusLevel>(defaultSystemStatus);
   const lastUpdated = ref<Date | null>(null);
   const error = ref<Error | null>(null);
   const apiAvailable = ref(true);
   const isReady = ref(false);
   const isLoading = ref(false);
-
-  const pollIntervalMs = ref(DEFAULT_POLL_INTERVAL);
-  const pollTimer = ref<ReturnType<typeof setInterval> | null>(null);
-  const subscribers = ref(0);
   const isRefreshing = ref(false);
-
-  const isPolling = computed(() => pollTimer.value !== null);
 
   const applySummary = (payload: DashboardStatsSummary | null) => {
     summary.value = payload;
     metrics.value = deriveMetricsFromDashboard(payload);
-    applyStatsFromSummary(stats, payload, metrics.value);
+    stats.value = buildResourceStats(payload, metrics.value);
 
     const baseStatus = normaliseStatus(payload?.system_health?.status);
     const derivedStatus = deriveSeverityFromMetrics(metrics.value);
@@ -169,7 +59,7 @@ export const useAdminMetricsStore = defineStore('adminMetrics', () => {
     const message = err instanceof Error ? err : new Error('Failed to load admin metrics');
     error.value = message instanceof Error ? message : new Error(String(message));
     apiAvailable.value = false;
-    status.value = status.value === DEFAULT_STATUS ? 'error' : status.value;
+    status.value = status.value === defaultSystemStatus ? 'error' : status.value;
     lastUpdated.value = new Date();
   };
 
@@ -204,61 +94,6 @@ export const useAdminMetricsStore = defineStore('adminMetrics', () => {
     }
   };
 
-  const stopPolling = () => {
-    if (pollTimer.value) {
-      clearInterval(pollTimer.value);
-      pollTimer.value = null;
-    }
-  };
-
-  const startPolling = () => {
-    if (pollTimer.value) {
-      return;
-    }
-
-    pollTimer.value = setInterval(() => {
-      void refresh({ showLoader: false });
-    }, pollIntervalMs.value);
-  };
-
-  const setPollInterval = (interval: number) => {
-    if (!Number.isFinite(interval) || interval <= 0) {
-      return;
-    }
-
-    const normalised = Math.max(MIN_POLL_INTERVAL, Math.floor(interval));
-    if (normalised === pollIntervalMs.value) {
-      return;
-    }
-
-    pollIntervalMs.value = normalised;
-
-    if (pollTimer.value) {
-      stopPolling();
-      startPolling();
-    }
-  };
-
-  const subscribe = (interval?: number) => {
-    subscribers.value += 1;
-
-    if (interval) {
-      setPollInterval(interval);
-    }
-
-    if (subscribers.value === 1) {
-      void refresh({ showLoader: !isReady.value });
-      startPolling();
-    }
-  };
-
-  const unsubscribe = () => {
-    subscribers.value = Math.max(0, subscribers.value - 1);
-    if (subscribers.value === 0) {
-      stopPolling();
-    }
-  };
-
   return {
     summary,
     metrics,
@@ -269,14 +104,9 @@ export const useAdminMetricsStore = defineStore('adminMetrics', () => {
     apiAvailable,
     isReady,
     isLoading,
-    pollIntervalMs,
-    isPolling,
+    isRefreshing,
     refresh,
-    subscribe,
-    unsubscribe,
-    setPollInterval,
-    startPolling,
-    stopPolling,
+    applySummary,
   };
 });
 

--- a/app/frontend/src/utils/systemMetrics.ts
+++ b/app/frontend/src/utils/systemMetrics.ts
@@ -1,0 +1,119 @@
+import type {
+  DashboardStatsSummary,
+  SystemMetricsSnapshot,
+  SystemResourceStatsSummary,
+  SystemStatusLevel,
+} from '@/types';
+
+const BYTE_UNITS = ['Bytes', 'KB', 'MB', 'GB', 'TB'];
+const DEFAULT_STATUS: SystemStatusLevel = 'unknown';
+const DEFAULT_STATS: SystemResourceStatsSummary = {
+  uptime: 'N/A',
+  active_workers: 0,
+  total_workers: 0,
+  database_size: 0,
+  total_records: 0,
+  gpu_memory_used: 'N/A',
+  gpu_memory_total: 'N/A',
+};
+
+const clampPercent = (value?: number | null): number => {
+  if (typeof value !== 'number' || Number.isNaN(value)) {
+    return 0;
+  }
+  return Math.min(100, Math.max(0, Math.round(value)));
+};
+
+export const formatBytes = (value?: number | null): string => {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) {
+    return 'N/A';
+  }
+
+  let size = value;
+  let unitIndex = 0;
+
+  while (size >= 1024 && unitIndex < BYTE_UNITS.length - 1) {
+    size /= 1024;
+    unitIndex += 1;
+  }
+
+  const formatted = unitIndex === 0 ? size.toFixed(0) : size.toFixed(2);
+  return `${Number.parseFloat(formatted).toString()} ${BYTE_UNITS[unitIndex]}`;
+};
+
+export const normaliseStatus = (status?: string | null): SystemStatusLevel => {
+  if (!status) {
+    return DEFAULT_STATUS;
+  }
+
+  const value = status.toLowerCase();
+  if (value === 'healthy' || value === 'warning' || value === 'error') {
+    return value;
+  }
+
+  return DEFAULT_STATUS;
+};
+
+export const deriveSeverityFromMetrics = (metrics: SystemMetricsSnapshot): SystemStatusLevel => {
+  const memoryPercent = clampPercent(metrics.memory_percent);
+  const diskPercent = clampPercent(metrics.disk_percent);
+  const gpus = metrics.gpus ?? [];
+
+  const hasCriticalGpu = gpus.some((gpu) => {
+    const temperature = typeof gpu.temperature === 'number' ? gpu.temperature : 0;
+    const memory = clampPercent(gpu.memory_percent);
+    return temperature > 85 || memory > 95;
+  });
+
+  if (memoryPercent > 95 || diskPercent > 95 || hasCriticalGpu) {
+    return 'error';
+  }
+
+  const hasWarningGpu = gpus.some((gpu) => {
+    const temperature = typeof gpu.temperature === 'number' ? gpu.temperature : 0;
+    const memory = clampPercent(gpu.memory_percent);
+    return temperature > 75 || memory > 85;
+  });
+
+  if (memoryPercent > 85 || diskPercent > 85 || hasWarningGpu) {
+    return 'warning';
+  }
+
+  return 'healthy';
+};
+
+export const mergeStatusLevels = (
+  base: SystemStatusLevel,
+  derived: SystemStatusLevel,
+): SystemStatusLevel => {
+  if (base === 'error' || derived === 'error') {
+    return 'error';
+  }
+  if (base === 'warning' || derived === 'warning') {
+    return 'warning';
+  }
+  if (base === 'healthy' && derived === 'healthy') {
+    return 'healthy';
+  }
+  return DEFAULT_STATUS;
+};
+
+export const buildResourceStats = (
+  summary: DashboardStatsSummary | null,
+  metrics: SystemMetricsSnapshot,
+): SystemResourceStatsSummary => {
+  const next: SystemResourceStatsSummary = { ...DEFAULT_STATS };
+  const stats = summary?.stats ?? null;
+
+  next.total_records = stats?.total_loras ?? 0;
+  next.active_workers = (stats as Record<string, number | undefined>)?.active_workers ?? 0;
+  next.total_workers = (stats as Record<string, number | undefined>)?.total_workers ?? 0;
+  next.database_size = (stats as Record<string, number | undefined>)?.database_size ?? 0;
+  next.gpu_memory_used = formatBytes(metrics.memory_used);
+  next.gpu_memory_total = formatBytes(metrics.memory_total);
+
+  return next;
+};
+
+export const defaultSystemStatus = DEFAULT_STATUS;
+export const defaultResourceStats = (): SystemResourceStatsSummary => ({ ...DEFAULT_STATS });

--- a/tests/vue/useAdminMetrics.spec.ts
+++ b/tests/vue/useAdminMetrics.spec.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+vi.mock('@/services/systemService', () => ({
+  deriveMetricsFromDashboard: vi.fn(),
+  emptyMetricsSnapshot: vi.fn(),
+  fetchDashboardStats: vi.fn(),
+}));
+
+import { mount } from '@vue/test-utils';
+import { defineComponent } from 'vue';
+import { createPinia, setActivePinia } from 'pinia';
+
+import { useAdminMetrics } from '@/composables/useAdminMetrics';
+import {
+  deriveMetricsFromDashboard,
+  emptyMetricsSnapshot,
+  fetchDashboardStats,
+} from '@/services/systemService';
+
+const fetchDashboardStatsMock = vi.mocked(fetchDashboardStats);
+const deriveMetricsFromDashboardMock = vi.mocked(deriveMetricsFromDashboard);
+const emptyMetricsSnapshotMock = vi.mocked(emptyMetricsSnapshot);
+
+const flushAsync = async () => {
+  await Promise.resolve();
+  await Promise.resolve();
+};
+
+const createMetricsPayload = () => ({
+  cpu_percent: 10,
+  memory_percent: 20,
+  memory_used: 1024,
+  memory_total: 2048,
+  disk_percent: 30,
+  disk_used: 512,
+  disk_total: 1024,
+  gpus: [],
+});
+
+const createSummaryPayload = () => ({
+  stats: {
+    total_loras: 5,
+    active_loras: 2,
+    embeddings_coverage: 75,
+    recent_imports: 1,
+  },
+  system_health: { status: 'healthy' },
+});
+
+describe('useAdminMetrics composable', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    setActivePinia(createPinia());
+
+    emptyMetricsSnapshotMock.mockReturnValue(createMetricsPayload());
+    deriveMetricsFromDashboardMock.mockReturnValue(createMetricsPayload());
+    fetchDashboardStatsMock.mockResolvedValue(createSummaryPayload());
+  });
+
+  afterEach(() => {
+    vi.runOnlyPendingTimers();
+    vi.clearAllTimers();
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  const createHarness = (intervalMs: number) =>
+    defineComponent({
+      setup() {
+        useAdminMetrics({ intervalMs });
+        return () => null;
+      },
+    });
+
+  it('starts polling on mount and stops after unmounting', async () => {
+    const wrapper = mount(createHarness(1_000));
+    await flushAsync();
+    expect(fetchDashboardStatsMock).toHaveBeenCalledTimes(1);
+
+    vi.advanceTimersByTime(1_000);
+    await flushAsync();
+    expect(fetchDashboardStatsMock).toHaveBeenCalledTimes(2);
+
+    wrapper.unmount();
+
+    vi.advanceTimersByTime(1_000);
+    await flushAsync();
+    expect(fetchDashboardStatsMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('shares a single polling loop across multiple consumers', async () => {
+    const first = mount(createHarness(1_000));
+    await flushAsync();
+    expect(fetchDashboardStatsMock).toHaveBeenCalledTimes(1);
+
+    const second = mount(createHarness(2_000));
+    await flushAsync();
+    expect(fetchDashboardStatsMock).toHaveBeenCalledTimes(1);
+
+    vi.advanceTimersByTime(1_000);
+    await flushAsync();
+    expect(fetchDashboardStatsMock).toHaveBeenCalledTimes(1);
+
+    vi.advanceTimersByTime(1_000);
+    await flushAsync();
+    expect(fetchDashboardStatsMock).toHaveBeenCalledTimes(2);
+
+    second.unmount();
+
+    vi.advanceTimersByTime(2_000);
+    await flushAsync();
+    expect(fetchDashboardStatsMock).toHaveBeenCalledTimes(3);
+
+    first.unmount();
+
+    vi.advanceTimersByTime(2_000);
+    await flushAsync();
+    expect(fetchDashboardStatsMock).toHaveBeenCalledTimes(3);
+  });
+});

--- a/tests/vue/usePolling.spec.ts
+++ b/tests/vue/usePolling.spec.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+import { usePolling } from '@/composables/usePolling';
+
+describe('usePolling composable', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.runOnlyPendingTimers();
+    vi.clearAllTimers();
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it('starts polling when the first subscriber registers and stops after the last unsubscribe', () => {
+    const callback = vi.fn();
+    const polling = usePolling(callback, { interval: 250, minInterval: 100 });
+
+    expect(polling.isActive.value).toBe(false);
+
+    const started = polling.subscribe();
+    expect(started).toBe(true);
+    expect(polling.isActive.value).toBe(true);
+
+    vi.advanceTimersByTime(250);
+    expect(callback).toHaveBeenCalledTimes(1);
+
+    const stopped = polling.unsubscribe();
+    expect(stopped).toBe(true);
+    expect(polling.isActive.value).toBe(false);
+
+    vi.advanceTimersByTime(500);
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+
+  it('normalises interval updates and restarts the timer when changed', () => {
+    const callback = vi.fn();
+    const polling = usePolling(callback, { interval: 500, minInterval: 200 });
+
+    polling.subscribe();
+    expect(polling.intervalMs.value).toBe(500);
+
+    polling.setInterval(150);
+    expect(polling.intervalMs.value).toBe(200);
+
+    vi.advanceTimersByTime(200);
+    expect(callback).toHaveBeenCalledTimes(1);
+
+    polling.setInterval(600);
+    expect(polling.intervalMs.value).toBe(600);
+
+    vi.advanceTimersByTime(600);
+    expect(callback).toHaveBeenCalledTimes(2);
+  });
+
+  it('tracks multiple subscribers and only stops after the last unsubscribe', () => {
+    const callback = vi.fn();
+    const polling = usePolling(callback, { interval: 400, minInterval: 100 });
+
+    const first = polling.subscribe();
+    const second = polling.subscribe();
+
+    expect(first).toBe(true);
+    expect(second).toBe(false);
+    expect(polling.subscriberCount.value).toBe(2);
+    expect(polling.isActive.value).toBe(true);
+
+    vi.advanceTimersByTime(400);
+    expect(callback).toHaveBeenCalledTimes(1);
+
+    const secondStopped = polling.unsubscribe();
+    expect(secondStopped).toBe(false);
+    expect(polling.isActive.value).toBe(true);
+    expect(polling.subscriberCount.value).toBe(1);
+
+    const firstStopped = polling.unsubscribe();
+    expect(firstStopped).toBe(true);
+    expect(polling.isActive.value).toBe(false);
+    expect(polling.subscriberCount.value).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- extract system metric formatting and status helpers into a shared utility
- add a reusable polling composable and migrate the admin metrics store to use it via the `useAdminMetrics` wrapper
- cover the new polling flow with focused vitest specs for the utility and store integration

## Testing
- `npx vitest run tests/vue/usePolling.spec.ts tests/vue/useAdminMetrics.spec.ts`
- `npm run test:unit` *(fails: existing LoraCard/LoraGallery specs error with duplicate defineExpose call)*

------
https://chatgpt.com/codex/tasks/task_e_68d277f325f88329a09c48aebb030bd8