### PR TITLE
Refactor service container architecture with registries

### DIFF
--- a/backend/api/v1/analytics.py
+++ b/backend/api/v1/analytics.py
@@ -15,7 +15,7 @@ from backend.schemas.analytics import (
     PerformanceKpiSummary,
     PerformanceTimeRange,
 )
-from backend.services import ServiceContainer
+from backend.services import ServiceRegistry
 
 
 router = APIRouter(prefix="/analytics", tags=["analytics"])
@@ -24,7 +24,7 @@ router = APIRouter(prefix="/analytics", tags=["analytics"])
 @router.get("/summary", response_model=PerformanceAnalyticsSummary)
 def get_analytics_summary(
     time_range: PerformanceTimeRange = Query("24h"),
-    services: ServiceContainer = Depends(get_service_container),
+    services: ServiceRegistry = Depends(get_service_container),
 ) -> PerformanceAnalyticsSummary:
     """Return a comprehensive analytics snapshot for the requested range."""
 
@@ -34,7 +34,7 @@ def get_analytics_summary(
 @router.get("/stats", response_model=PerformanceKpiSummary)
 def get_generation_stats(
     time_range: PerformanceTimeRange = Query("24h"),
-    services: ServiceContainer = Depends(get_service_container),
+    services: ServiceRegistry = Depends(get_service_container),
 ) -> PerformanceKpiSummary:
     """Expose headline generation KPIs for the requested range."""
 
@@ -44,7 +44,7 @@ def get_generation_stats(
 @router.get("/errors", response_model=List[ErrorAnalysisEntry])
 def get_error_breakdown(
     time_range: PerformanceTimeRange = Query("24h"),
-    services: ServiceContainer = Depends(get_service_container),
+    services: ServiceRegistry = Depends(get_service_container),
 ) -> List[ErrorAnalysisEntry]:
     """Return error distribution for failed generation jobs."""
 
@@ -54,7 +54,7 @@ def get_error_breakdown(
 @router.get("/timeseries", response_model=PerformanceAnalyticsCharts)
 def get_time_series_metrics(
     time_range: PerformanceTimeRange = Query("24h"),
-    services: ServiceContainer = Depends(get_service_container),
+    services: ServiceRegistry = Depends(get_service_container),
 ) -> PerformanceAnalyticsCharts:
     """Return time-series metrics for dashboard visualisations."""
 
@@ -64,7 +64,7 @@ def get_time_series_metrics(
 @router.get("/insights", response_model=List[PerformanceInsightEntry])
 def get_performance_insights(
     time_range: PerformanceTimeRange = Query("24h"),
-    services: ServiceContainer = Depends(get_service_container),
+    services: ServiceRegistry = Depends(get_service_container),
 ) -> List[PerformanceInsightEntry]:
     """Return derived performance insights for the requested window."""
 

--- a/backend/api/v1/compose.py
+++ b/backend/api/v1/compose.py
@@ -11,7 +11,7 @@ from fastapi import APIRouter, BackgroundTasks, Depends
 from backend.core.dependencies import get_service_container
 from backend.schemas import ComposeRequest, ComposeResponse
 from backend.schemas.generation import SDNextGenerationParams
-from backend.services import ServiceContainer
+from backend.services import ServiceRegistry
 
 logger = structlog.get_logger(__name__)
 
@@ -22,7 +22,7 @@ router = APIRouter()
 async def compose(
     req: ComposeRequest,
     background_tasks: BackgroundTasks,
-    services: ServiceContainer = Depends(get_service_container),
+    services: ServiceRegistry = Depends(get_service_container),
 ):
     """Compose a prompt from active adapters and optionally schedule delivery."""
     # Compose prompt and collect warnings via the shared helper

--- a/backend/api/v1/dashboard.py
+++ b/backend/api/v1/dashboard.py
@@ -3,13 +3,13 @@
 from fastapi import APIRouter, Depends
 
 from backend.core.dependencies import get_service_container
-from backend.services import ServiceContainer
+from backend.services import ServiceRegistry
 
 router = APIRouter(prefix="/dashboard", tags=["dashboard"])
 
 
 @router.get("/stats")
-async def get_dashboard_stats(services: ServiceContainer = Depends(get_service_container)):
+async def get_dashboard_stats(services: ServiceRegistry = Depends(get_service_container)):
     """Get dashboard statistics and system health information."""
 
     stats = services.adapters.get_dashboard_statistics()
@@ -24,7 +24,7 @@ async def get_dashboard_stats(services: ServiceContainer = Depends(get_service_c
 
 
 @router.get("/featured-loras")
-async def get_featured_loras(services: ServiceContainer = Depends(get_service_container)):
+async def get_featured_loras(services: ServiceRegistry = Depends(get_service_container)):
     """Get featured LoRAs for the dashboard."""
 
     featured_loras = services.adapters.get_featured_adapters(limit=5)
@@ -44,7 +44,7 @@ async def get_featured_loras(services: ServiceContainer = Depends(get_service_co
 
 
 @router.get("/activity-feed")
-async def get_activity_feed(services: ServiceContainer = Depends(get_service_container)):
+async def get_activity_feed(services: ServiceRegistry = Depends(get_service_container)):
     """Get recent activity feed for the dashboard."""
 
     return services.deliveries.get_recent_activity(limit=10)

--- a/backend/api/v1/deliveries.py
+++ b/backend/api/v1/deliveries.py
@@ -9,7 +9,7 @@ from backend.schemas import (
     DeliveryRead,
     DeliveryWrapper,
 )
-from backend.services import ServiceContainer
+from backend.services import ServiceRegistry
 
 router = APIRouter()
 
@@ -18,7 +18,7 @@ router = APIRouter()
 async def create_delivery(
     delivery: DeliveryCreate,
     background_tasks: BackgroundTasks,
-    services: ServiceContainer = Depends(get_service_container),
+    services: ServiceRegistry = Depends(get_service_container),
 ):
     """Create a delivery job and either enqueue it or schedule a background task."""
     job = services.deliveries.schedule_job(
@@ -34,7 +34,7 @@ async def create_delivery(
 @router.get("/deliveries/{delivery_id}", response_model=DeliveryWrapper)
 def get_delivery(
     delivery_id: str,
-    services: ServiceContainer = Depends(get_service_container),
+    services: ServiceRegistry = Depends(get_service_container),
 ):
     """Return the delivery job state for `delivery_id`."""
     dj = services.deliveries.get_job(delivery_id)

--- a/backend/api/v1/generation.py
+++ b/backend/api/v1/generation.py
@@ -20,7 +20,7 @@ from backend.schemas import (
     SDNextGenerationParams,
     SDNextGenerationResult,
 )
-from backend.services import ServiceContainer
+from backend.services import ServiceRegistry
 from backend.services.generation import normalize_generation_status
 from backend.services.generation.presenter import build_active_job, build_result
 
@@ -47,7 +47,7 @@ async def generate_image(
     mode: str = "immediate",
     save_images: bool = True,
     return_format: str = "base64",
-    services: ServiceContainer = Depends(get_service_container),
+    services: ServiceRegistry = Depends(get_service_container),
 ):
     """Generate an image using the specified backend.
     
@@ -120,7 +120,7 @@ async def compose_and_generate(
     mode: str = "immediate",
     save_images: bool = True,
     return_format: str = "base64",
-    services: ServiceContainer = Depends(get_service_container),
+    services: ServiceRegistry = Depends(get_service_container),
 ):
     """Compose LoRA prompt and immediately generate images.
     
@@ -190,7 +190,7 @@ async def queue_generation_job(
     mode: str = "deferred",
     save_images: bool = True,
     return_format: str = "base64",
-    services: ServiceContainer = Depends(get_service_container),
+    services: ServiceRegistry = Depends(get_service_container),
 ):
     """Queue a generation job for background processing.
     
@@ -215,7 +215,7 @@ async def queue_generation_job(
 @router.get("/jobs/active", response_model=List[GenerationJobStatus])
 async def list_active_generation_jobs(
     limit: int = Query(50, ge=1, le=200),
-    services: ServiceContainer = Depends(get_service_container),
+    services: ServiceRegistry = Depends(get_service_container),
 ):
     """Return active generation jobs for frontend queues."""
 
@@ -240,7 +240,7 @@ async def list_active_generation_jobs(
 @router.get("/jobs/{job_id}", response_model=DeliveryWrapper)
 async def get_generation_job(
     job_id: str,
-    services: ServiceContainer = Depends(get_service_container),
+    services: ServiceRegistry = Depends(get_service_container),
 ):
     """Get generation job status and results."""
     job = services.deliveries.get_job(job_id)
@@ -271,7 +271,7 @@ async def get_generation_job(
 @router.post("/jobs/{job_id}/cancel", response_model=GenerationCancelResponse)
 async def cancel_generation_job(
     job_id: str,
-    services: ServiceContainer = Depends(get_service_container),
+    services: ServiceRegistry = Depends(get_service_container),
 ):
     """Cancel an active generation job."""
     job = services.deliveries.get_job(job_id)
@@ -291,7 +291,7 @@ async def cancel_generation_job(
 async def list_generation_results(
     limit: int = Query(20, ge=1, le=100),
     offset: int = Query(0, ge=0),
-    services: ServiceContainer = Depends(get_service_container),
+    services: ServiceRegistry = Depends(get_service_container),
 ):
     """Return recent completed generation results."""
     jobs = services.deliveries.list_jobs(status="succeeded", limit=limit, offset=offset)

--- a/backend/api/v1/system.py
+++ b/backend/api/v1/system.py
@@ -7,14 +7,14 @@ from typing import Any, Dict
 from fastapi import APIRouter, Depends
 
 from backend.core.dependencies import get_service_container
-from backend.services import ServiceContainer
+from backend.services import ServiceRegistry
 
 
 router = APIRouter(prefix="/system", tags=["system"])
 
 
 @router.get("/status")
-async def get_system_status(services: ServiceContainer = Depends(get_service_container)) -> Dict[str, Any]:
+async def get_system_status(services: ServiceRegistry = Depends(get_service_container)) -> Dict[str, Any]:
     """Return a snapshot of system status and telemetry data."""
 
     return services.system.get_system_status_payload()

--- a/backend/api/v1/websocket.py
+++ b/backend/api/v1/websocket.py
@@ -11,7 +11,7 @@ versioning is also provided by ``backend.main`` so older clients that still use
 from fastapi import APIRouter, Depends, WebSocket
 
 from backend.core.dependencies import get_service_container
-from backend.services import ServiceContainer
+from backend.services import ServiceRegistry
 
 router = APIRouter()
 
@@ -22,7 +22,7 @@ PROGRESS_WEBSOCKET_ROUTE = "/ws/progress"
 @router.websocket(PROGRESS_WEBSOCKET_ROUTE)
 async def websocket_progress_endpoint(
     websocket: WebSocket,
-    container: ServiceContainer = Depends(get_service_container),
+    container: ServiceRegistry = Depends(get_service_container),
 ):
     """WebSocket endpoint for real-time generation progress monitoring.
     

--- a/backend/core/dependencies.py
+++ b/backend/core/dependencies.py
@@ -4,46 +4,33 @@ from fastapi import Depends
 from sqlmodel import Session
 
 from backend.core.database import get_session
-from backend.services import ServiceContainer
-from backend.services.analytics_repository import AnalyticsRepository
-from backend.services.delivery_repository import DeliveryJobRepository
-from backend.services.queue import QueueOrchestrator, create_queue_orchestrator
+from backend.services import ServiceRegistry, get_service_container_builder
 from backend.services.adapters import AdapterService
 from backend.services.composition import ComposeService
 from backend.services.deliveries import DeliveryService
 from backend.services.archive import ArchiveService, BackupService
 from backend.services.recommendations import RecommendationService
-from backend.services.providers import make_compose_service
 
-_QUEUE_ORCHESTRATOR: QueueOrchestrator = create_queue_orchestrator()
-_GPU_AVAILABLE: bool = RecommendationService.is_gpu_available()
+_BUILDER = get_service_container_builder()
 
 
 def get_service_container(
     db_session: Session = Depends(get_session),  # noqa: B008 - FastAPI DI
-) -> ServiceContainer:
-    """Return a service container tied to the current database session."""
+) -> ServiceRegistry:
+    """Return a service registry tied to the current database session."""
 
-    repository = DeliveryJobRepository(db_session)
-    analytics_repository = AnalyticsRepository(db_session)
-    return ServiceContainer(
-        db_session,
-        queue_orchestrator=_QUEUE_ORCHESTRATOR,
-        delivery_repository=repository,
-        analytics_repository=analytics_repository,
-        recommendation_gpu_available=_GPU_AVAILABLE,
-    )
+    return _BUILDER.build(db_session)
 
 
 def get_adapter_service(
-    container: ServiceContainer = Depends(get_service_container),  # noqa: B008 - FastAPI DI
+    container: ServiceRegistry = Depends(get_service_container),  # noqa: B008 - FastAPI DI
 ) -> AdapterService:
     """Return an AdapterService instance."""
     return container.adapters
 
 
 def get_delivery_service(
-    container: ServiceContainer = Depends(get_service_container),  # noqa: B008 - FastAPI DI
+    container: ServiceRegistry = Depends(get_service_container),  # noqa: B008 - FastAPI DI
 ) -> DeliveryService:
     """Return a DeliveryService instance."""
     return container.deliveries
@@ -51,18 +38,18 @@ def get_delivery_service(
 
 def get_compose_service() -> ComposeService:
     """Get an instance of the ComposeService."""
-    return make_compose_service()
+    return _BUILDER.build(None).compose
 
 
 def get_recommendation_service(
-    container: ServiceContainer = Depends(get_service_container),  # noqa: B008 - FastAPI DI
+    container: ServiceRegistry = Depends(get_service_container),  # noqa: B008 - FastAPI DI
 ) -> RecommendationService:
     """Return a RecommendationService instance."""
     return container.recommendations
 
 
 def get_archive_service(
-    container: ServiceContainer = Depends(get_service_container),  # noqa: B008 - FastAPI DI
+    container: ServiceRegistry = Depends(get_service_container),  # noqa: B008 - FastAPI DI
 ) -> ArchiveService:
     """Return the archive helper service."""
 
@@ -70,7 +57,7 @@ def get_archive_service(
 
 
 def get_backup_service(
-    container: ServiceContainer = Depends(get_service_container),  # noqa: B008 - FastAPI DI
+    container: ServiceRegistry = Depends(get_service_container),  # noqa: B008 - FastAPI DI
 ) -> BackupService:
     """Return the backup service instance."""
 

--- a/backend/services/__init__.py
+++ b/backend/services/__init__.py
@@ -1,11 +1,10 @@
-"""Service layer initialization and dependency injection."""
+from __future__ import annotations
 
 from typing import Optional
 
 from sqlmodel import Session
 
-# Import file_exists for test compatibility - use root level for backward compatibility
-from backend.services.storage import get_storage_service
+from backend.core.database import get_session, get_session_context
 
 from .adapters import AdapterService
 from .analytics import AnalyticsService, InsightGenerator, TimeSeriesBuilder
@@ -31,38 +30,26 @@ from .providers import (
     make_recommendation_service,
     make_storage_service,
     make_system_service,
-    make_websocket_service,
 )
-from .queue import QueueOrchestrator, create_queue_orchestrator
-from .storage import StorageService
-from .recommendations import RecommendationService
+from .queue import QueueOrchestrator
+from .service_container_builder import ServiceContainerBuilder
+from .service_registry import ServiceRegistry
+from .storage import StorageService, get_storage_service
 from .system import SystemService
-from .websocket import WebSocketService, websocket_service
+from .websocket import WebSocketService
 
 
-_GPU_AVAILABLE: Optional[bool] = None
+_DEFAULT_BUILDER = ServiceContainerBuilder()
 
 
-def _get_recommendation_gpu_available() -> bool:
-    """Detect and cache GPU availability for recommendation services."""
+def get_service_container_builder() -> ServiceContainerBuilder:
+    """Return the shared service container builder."""
 
-    global _GPU_AVAILABLE
-    if _GPU_AVAILABLE is None:
-        _GPU_AVAILABLE = RecommendationService.is_gpu_available()
-    return _GPU_AVAILABLE
+    return _DEFAULT_BUILDER
 
 
-def file_exists(path: str) -> bool:
-    """Legacy file_exists function for backward compatibility."""
-    storage_service = get_storage_service()
-    return storage_service.validate_file_path(path)
-
-# Import db.get_session for backward compatibility with importer
-from backend.core.database import get_session, get_session_context
-
-
-class ServiceContainer:
-    """Container for managing service dependencies."""
+class ServiceContainer(ServiceRegistry):
+    """Backward compatible wrapper that delegates to :class:`ServiceRegistry`."""
 
     def __init__(
         self,
@@ -72,7 +59,7 @@ class ServiceContainer:
         delivery_repository: Optional[DeliveryJobRepository] = None,
         analytics_repository: Optional[AnalyticsRepository] = None,
         recommendation_gpu_available: Optional[bool] = None,
-        storage_provider=make_storage_service,
+        storage_provider=None,
         adapter_provider=make_adapter_service,
         archive_provider=make_archive_service,
         delivery_provider=make_delivery_service,
@@ -83,304 +70,122 @@ class ServiceContainer:
         system_provider=make_system_service,
         analytics_provider=make_analytics_service,
         recommendation_provider=make_recommendation_service,
-    ):
-        """Initialize service container.
-
-        Args:
-            db_session: Database session for services that need it.
-            queue_orchestrator: Optional queue orchestrator shared with workers.
-            delivery_repository: Optional pre-configured delivery repository.
-
-        """
-        self.db_session = db_session
-        self._storage_service: Optional[StorageService] = None
-        self._adapter_service: Optional[AdapterService] = None
-        self._delivery_service: Optional[DeliveryService] = None
-        self._compose_service: Optional[ComposeService] = None
-        self._generation_service: Optional[GenerationService] = None
-        self._generation_coordinator: Optional[GenerationCoordinator] = None
-        self._websocket_service: Optional[WebSocketService] = None
-        self._system_service: Optional[SystemService] = None
-        self._archive_service: Optional[ArchiveService] = None
-        self._analytics_service: Optional[AnalyticsService] = None
-        self._recommendation_service: Optional[RecommendationService] = None
-        self._analytics_repository = analytics_repository
-        self._recommendation_gpu_available: Optional[bool] = recommendation_gpu_available
-        self._queue_orchestrator = queue_orchestrator
-        self._delivery_repository = delivery_repository
-        self._backup_service: Optional[BackupService] = None
-        self._storage_provider = storage_provider
-        self._adapter_provider = adapter_provider
-        self._archive_provider = archive_provider
-        self._delivery_provider = delivery_provider
-        self._compose_provider = compose_provider
-        self._generation_provider = generation_provider
-        self._generation_coordinator_provider = generation_coordinator_provider
-        self._websocket_provider = (
-            websocket_provider
-            if websocket_provider is not None
-            else (lambda: make_websocket_service(service=websocket_service))
+    ) -> None:
+        effective_storage_provider = (
+            storage_provider if storage_provider is not None else _DEFAULT_BUILDER._storage_provider
         )
-        self._system_provider = system_provider
-        self._analytics_provider = analytics_provider
-        self._recommendation_provider = recommendation_provider
-    @property
-    def storage(self) -> StorageService:
-        """Get storage service instance."""
-        if self._storage_service is None:
-            self._storage_service = self._storage_provider()
-        return self._storage_service
-    
-    @property
-    def adapters(self) -> AdapterService:
-        """Get adapter service instance."""
-        if self.db_session is None:
-            raise ValueError("AdapterService requires an active database session")
 
-        if self._adapter_service is None:
-            self._adapter_service = self._adapter_provider(
-                db_session=self.db_session,
-                storage_service=self.storage,
-            )
-        return self._adapter_service
+        builder = ServiceContainerBuilder(
+            storage_provider=effective_storage_provider,
+            adapter_provider=adapter_provider,
+            archive_provider=archive_provider,
+            delivery_provider=delivery_provider,
+            compose_provider=compose_provider,
+            generation_provider=generation_provider,
+            generation_coordinator_provider=generation_coordinator_provider,
+            websocket_provider=websocket_provider,
+            system_provider=system_provider,
+            analytics_provider=analytics_provider,
+            recommendation_provider=recommendation_provider,
+        )
+        registry = builder.build(
+            db_session,
+            queue_orchestrator=queue_orchestrator,
+            delivery_repository=delivery_repository,
+            analytics_repository=analytics_repository,
+            recommendation_gpu_available=recommendation_gpu_available,
+        )
+        super().__init__(registry.core, registry.domain, registry.infrastructure)
+        self._builder = builder
+        self._generation_coordinator_override: Optional[GenerationCoordinator] = None
 
-    @property
-    def archive(self) -> ArchiveService:
-        """Get archive service instance."""
-
-        if self._archive_service is None:
-            self._archive_service = self._archive_provider(
-                self.adapters,
-                self.storage,
-            )
-        return self._archive_service
+    def __setattr__(self, name, value):
+        if name == "_generation_coordinator":
+            object.__setattr__(self, "_generation_coordinator_override", value)
+        else:
+            super().__setattr__(name, value)
 
     @property
-    def backups(self) -> BackupService:
-        """Get backup service instance."""
-
-        if self._backup_service is None:
-            self._backup_service = BackupService(self.archive)
-        return self._backup_service
-    
-    @property
-    def deliveries(self) -> DeliveryService:
-        """Get delivery service instance."""
-        if self.db_session is None:
-            raise ValueError("DeliveryService requires an active database session")
-
-        if self._delivery_repository is None:
-            raise ValueError("DeliveryService requires a delivery repository")
-        if self._queue_orchestrator is None:
-            raise ValueError("DeliveryService requires a queue orchestrator")
-
-        if self._delivery_service is None:
-            self._delivery_service = self._delivery_provider(
-                self._delivery_repository,
-                queue_orchestrator=self._queue_orchestrator,
-            )
-        return self._delivery_service
-    
-    @property
-    def compose(self) -> ComposeService:
-        """Get compose service instance."""
-        if self._compose_service is None:
-            self._compose_service = self._compose_provider()
-        return self._compose_service
-    
-    @property
-    def generation(self) -> GenerationService:
-        """Get generation service instance."""
-        if self._generation_service is None:
-            self._generation_service = self._generation_provider()
-        return self._generation_service
-
-    @property
-    def generation_coordinator(self) -> GenerationCoordinator:
-        """Get generation coordinator helper."""
-
-        if self._generation_coordinator is None:
-            self._generation_coordinator = self._generation_coordinator_provider(
-                self.deliveries,
-                self.websocket,
-                self.generation,
-            )
-        return self._generation_coordinator
-
-    @property
-    def websocket(self) -> WebSocketService:
-        """Get WebSocket service instance."""
-        if self._websocket_service is None:
-            self._websocket_service = self._websocket_provider()
-        return self._websocket_service
-
-    @property
-    def system(self) -> SystemService:
-        """Get system monitoring service instance."""
-
-        if self._system_service is None:
-            self._system_service = self._system_provider(self.deliveries)
-        return self._system_service
-
-    @property
-    def analytics(self) -> AnalyticsService:
-        """Get analytics service instance."""
-
-        if self.db_session is None:
-            raise ValueError("AnalyticsService requires an active database session")
-
-        if self._analytics_repository is None:
-            raise ValueError("AnalyticsService requires an analytics repository")
-
-        if self._analytics_service is None:
-            self._analytics_service = self._analytics_provider(
-                self.db_session,
-                repository=self._analytics_repository,
-            )
-        return self._analytics_service
-
-    @property
-    def recommendations(self) -> RecommendationService:
-        """Get recommendation service instance with cached GPU availability."""
-
-        if self.db_session is None:
-            raise ValueError("RecommendationService requires an active database session")
-
-        if self._recommendation_gpu_available is None:
-            raise ValueError(
-                "RecommendationService requires an explicit recommendation_gpu_available flag"
-            )
-
-        if self._recommendation_service is None:
-            self._recommendation_service = self._recommendation_provider(
-                self.db_session,
-                gpu_available=self._recommendation_gpu_available,
-            )
-
-        return self._recommendation_service
+    def generation_coordinator(self) -> GenerationCoordinator:  # type: ignore[override]
+        override = getattr(self, "_generation_coordinator_override", None)
+        if override is not None:
+            return override
+        return super().generation_coordinator
 
 
-# Factory function for creating service containers
-def create_service_container(db_session: Session) -> ServiceContainer:
-    """Create a service container with the given database session.
+def create_service_container(db_session: Session) -> ServiceRegistry:
+    """Create a service registry for the provided database session."""
 
-    Args:
-        db_session: Database session
-        
-    Returns:
-        ServiceContainer instance
-
-    """
-    delivery_repository = DeliveryJobRepository(db_session)
-    analytics_repository = AnalyticsRepository(db_session)
-    queue_orchestrator = create_queue_orchestrator()
-
-    return ServiceContainer(
-        db_session,
-        queue_orchestrator=queue_orchestrator,
-        delivery_repository=delivery_repository,
-        analytics_repository=analytics_repository,
-        recommendation_gpu_available=_get_recommendation_gpu_available(),
-    )
+    return _DEFAULT_BUILDER.build(db_session)
 
 
-# Legacy compatibility functions for existing code
+def file_exists(path: str) -> bool:
+    """Legacy helper to validate file paths via the storage service."""
+
+    storage_service = get_storage_service()
+    return storage_service.validate_file_path(path)
+
+
 def get_adapter_service(db_session: Session) -> AdapterService:
-    """Get an adapter service instance (legacy compatibility).
+    """Return an adapter service instance for the provided session."""
 
-    Args:
-        db_session: Database session
-
-    Returns:
-        AdapterService instance
-
-    """
-    storage_service = make_storage_service()
-    return make_adapter_service(db_session=db_session, storage_service=storage_service)
+    container = _DEFAULT_BUILDER.build(db_session)
+    return container.adapters
 
 
 def get_delivery_service(db_session: Session) -> DeliveryService:
-    """Get a delivery service instance (legacy compatibility).
+    """Return a delivery service instance for the provided session."""
 
-    Args:
-        db_session: Database session
-
-    Returns:
-        DeliveryService instance
-
-    """
-    repository = DeliveryJobRepository(db_session)
-    queue_orchestrator = create_queue_orchestrator()
-    return make_delivery_service(
-        repository,
-        queue_orchestrator=queue_orchestrator,
-    )
+    container = _DEFAULT_BUILDER.build(db_session)
+    return container.deliveries
 
 
 def get_compose_service() -> ComposeService:
-    """Get a compose service instance (legacy compatibility).
+    """Return a compose service instance."""
 
-    Returns:
-        ComposeService instance
-
-    """
-    return make_compose_service()
+    container = _DEFAULT_BUILDER.build(None)
+    return container.compose
 
 
 def get_generation_service() -> GenerationService:
-    """Get a generation service instance (legacy compatibility).
+    """Return a generation service instance."""
 
-    Returns:
-        GenerationService instance
-
-    """
-    return make_generation_service()
+    container = _DEFAULT_BUILDER.build(None)
+    return container.generation
 
 
-# Legacy compatibility function for importer
 def upsert_adapter_from_payload(payload):
-    """Upsert an adapter from payload (legacy compatibility).
-    
-    This provides compatibility for the importer module.
-    
-    Args:
-        payload: AdapterCreate instance or dict
-        
-    Returns:
-        Adapter instance
+    """Upsert an adapter from payload for importer compatibility."""
 
-    """
-    from backend.core.database import get_session
-    from backend.models import Adapter
     from backend.schemas import AdapterCreate
-    
-    # Convert dict to AdapterCreate if needed
+
     if isinstance(payload, dict):
         payload = AdapterCreate(**payload)
-    
-    # Use the same pattern as the legacy function
+
     with get_session_context() as session:
-        container = create_service_container(session)
+        container = _DEFAULT_BUILDER.build(session)
         return container.adapters.upsert_adapter(payload)
 
 
-# Export everything for package-level access
 __all__ = [
-    'ServiceContainer',
-    'create_service_container',
-    'AdapterService',
-    'AnalyticsService',
-    'DeliveryService',
-    'DeliveryJobRepository',
-    'ComposeService',
-    'GenerationService',
-    'StorageService',
-    'QueueOrchestrator',
-    'get_adapter_service',
-    'get_delivery_service',
-    'get_compose_service',
-    'get_generation_service',
-    'get_session',
-    'file_exists',
-    'upsert_adapter_from_payload',
+    "ServiceRegistry",
+    "ServiceContainer",
+    "ServiceContainerBuilder",
+    "create_service_container",
+    "AdapterService",
+    "AnalyticsService",
+    "DeliveryService",
+    "DeliveryJobRepository",
+    "ComposeService",
+    "GenerationService",
+    "StorageService",
+    "QueueOrchestrator",
+    "get_adapter_service",
+    "get_delivery_service",
+    "get_compose_service",
+    "get_generation_service",
+    "get_session",
+    "file_exists",
+    "upsert_adapter_from_payload",
+    "get_service_container_builder",
 ]

--- a/backend/services/core_container.py
+++ b/backend/services/core_container.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from typing import Callable, Optional
+
+from sqlmodel import Session
+
+from .analytics_repository import AnalyticsRepository
+from .delivery_repository import DeliveryJobRepository
+from .providers import make_storage_service
+from .storage import StorageService
+
+
+class CoreServiceRegistry:
+    """Provide access to infrastructure primitives shared across services."""
+
+    def __init__(
+        self,
+        db_session: Optional[Session],
+        *,
+        storage_provider: Callable[[], StorageService] = make_storage_service,
+        delivery_repository: Optional[DeliveryJobRepository] = None,
+        analytics_repository: Optional[AnalyticsRepository] = None,
+    ) -> None:
+        self.db_session = db_session
+        self._storage_provider = storage_provider
+        self._storage_service: Optional[StorageService] = None
+        self._delivery_repository = delivery_repository
+        self._analytics_repository = analytics_repository
+
+    @property
+    def storage(self) -> StorageService:
+        """Return the lazily constructed storage service."""
+
+        if self._storage_service is None:
+            self._storage_service = self._storage_provider()
+        return self._storage_service
+
+    @property
+    def delivery_repository(self) -> DeliveryJobRepository:
+        """Return the delivery repository configured for this registry."""
+
+        if self._delivery_repository is None:
+            raise ValueError("DeliveryService requires a delivery repository")
+        return self._delivery_repository
+
+    @property
+    def analytics_repository(self) -> AnalyticsRepository:
+        """Return the analytics repository configured for this registry."""
+
+        if self._analytics_repository is None:
+            raise ValueError("AnalyticsService requires an analytics repository")
+        return self._analytics_repository
+
+
+__all__ = ["CoreServiceRegistry"]

--- a/backend/services/domain_container.py
+++ b/backend/services/domain_container.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+from typing import Callable, Optional
+
+from sqlmodel import Session
+
+from .adapters import AdapterService
+from .analytics import AnalyticsService
+from .analytics_repository import AnalyticsRepository
+from .composition import ComposeService
+from .core_container import CoreServiceRegistry
+from .generation import GenerationService
+from .providers import (
+    make_adapter_service,
+    make_analytics_service,
+    make_compose_service,
+    make_generation_service,
+    make_recommendation_service,
+)
+from .recommendations import RecommendationService
+
+
+class DomainServiceRegistry:
+    """Aggregate domain specific service factories."""
+
+    def __init__(
+        self,
+        core: CoreServiceRegistry,
+        *,
+        db_session: Optional[Session],
+        analytics_repository: Optional[AnalyticsRepository],
+        adapter_provider: Callable[..., AdapterService] = make_adapter_service,
+        compose_provider: Callable[[], ComposeService] = make_compose_service,
+        generation_provider: Callable[[], GenerationService] = make_generation_service,
+        analytics_provider: Callable[..., AnalyticsService] = make_analytics_service,
+        recommendation_provider: Callable[..., RecommendationService] = make_recommendation_service,
+        recommendation_gpu_available: Optional[bool] = None,
+    ) -> None:
+        self._core = core
+        self.db_session = db_session
+        self._analytics_repository = analytics_repository
+        self._adapter_provider = adapter_provider
+        self._compose_provider = compose_provider
+        self._generation_provider = generation_provider
+        self._analytics_provider = analytics_provider
+        self._recommendation_provider = recommendation_provider
+        self._recommendation_gpu_available = recommendation_gpu_available
+
+        self._adapter_service: Optional[AdapterService] = None
+        self._compose_service: Optional[ComposeService] = None
+        self._generation_service: Optional[GenerationService] = None
+        self._analytics_service: Optional[AnalyticsService] = None
+        self._recommendation_service: Optional[RecommendationService] = None
+
+    @property
+    def adapters(self) -> AdapterService:
+        """Return the adapter service bound to the configured session."""
+
+        if self.db_session is None:
+            raise ValueError("AdapterService requires an active database session")
+        if self._adapter_service is None:
+            self._adapter_service = self._adapter_provider(
+                db_session=self.db_session,
+                storage_service=self._core.storage,
+            )
+        return self._adapter_service
+
+    @property
+    def compose(self) -> ComposeService:
+        """Return the compose service."""
+
+        if self._compose_service is None:
+            self._compose_service = self._compose_provider()
+        return self._compose_service
+
+    @property
+    def generation(self) -> GenerationService:
+        """Return the generation service."""
+
+        if self._generation_service is None:
+            self._generation_service = self._generation_provider()
+        return self._generation_service
+
+    @property
+    def analytics(self) -> AnalyticsService:
+        """Return the analytics service bound to the configured session."""
+
+        if self.db_session is None:
+            raise ValueError("AnalyticsService requires an active database session")
+        if self._analytics_repository is None:
+            raise ValueError("AnalyticsService requires an analytics repository")
+        if self._analytics_service is None:
+            self._analytics_service = self._analytics_provider(
+                self.db_session,
+                repository=self._analytics_repository,
+            )
+        return self._analytics_service
+
+    @property
+    def recommendations(self) -> RecommendationService:
+        """Return the recommendation service bound to the configured session."""
+
+        if self.db_session is None:
+            raise ValueError("RecommendationService requires an active database session")
+        if self._recommendation_gpu_available is None:
+            raise ValueError(
+                "RecommendationService requires an explicit recommendation_gpu_available flag"
+            )
+        if self._recommendation_service is None:
+            self._recommendation_service = self._recommendation_provider(
+                self.db_session,
+                gpu_available=self._recommendation_gpu_available,
+            )
+        return self._recommendation_service
+
+
+__all__ = ["DomainServiceRegistry"]

--- a/backend/services/infra_container.py
+++ b/backend/services/infra_container.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+from typing import Callable, Optional
+
+from .archive import ArchiveService, BackupService
+from .core_container import CoreServiceRegistry
+from .deliveries import DeliveryService
+from .domain_container import DomainServiceRegistry
+from .generation import GenerationCoordinator
+from .providers import (
+    make_archive_service,
+    make_delivery_service,
+    make_generation_coordinator,
+    make_system_service,
+    make_websocket_service,
+)
+from .queue import QueueOrchestrator
+from .system import SystemService
+from .websocket import WebSocketService, websocket_service
+
+
+class InfrastructureServiceRegistry:
+    """Provide infrastructure oriented services built on domain registries."""
+
+    def __init__(
+        self,
+        core: CoreServiceRegistry,
+        domain: DomainServiceRegistry,
+        *,
+        queue_orchestrator: Optional[QueueOrchestrator],
+        archive_provider: Callable[..., ArchiveService] = make_archive_service,
+        delivery_provider: Callable[..., DeliveryService] = make_delivery_service,
+        generation_coordinator_provider: Callable[..., GenerationCoordinator] = make_generation_coordinator,
+        websocket_provider: Optional[Callable[[], WebSocketService]] = None,
+        system_provider: Callable[[DeliveryService], SystemService] = make_system_service,
+    ) -> None:
+        self._core = core
+        self._domain = domain
+        self._queue_orchestrator = queue_orchestrator
+        self._archive_provider = archive_provider
+        self._delivery_provider = delivery_provider
+        self._generation_coordinator_provider = generation_coordinator_provider
+        self._websocket_provider = (
+            websocket_provider
+            if websocket_provider is not None
+            else (lambda: make_websocket_service(service=websocket_service))
+        )
+        self._system_provider = system_provider
+
+        self._archive_service: Optional[ArchiveService] = None
+        self._backup_service: Optional[BackupService] = None
+        self._delivery_service: Optional[DeliveryService] = None
+        self._generation_coordinator: Optional[GenerationCoordinator] = None
+        self._websocket_service: Optional[WebSocketService] = None
+        self._system_service: Optional[SystemService] = None
+
+    @property
+    def archive(self) -> ArchiveService:
+        """Return the archive service."""
+
+        if self._archive_service is None:
+            self._archive_service = self._archive_provider(
+                self._domain.adapters,
+                self._core.storage,
+            )
+        return self._archive_service
+
+    @property
+    def backups(self) -> BackupService:
+        """Return the backup service derived from the archive service."""
+
+        if self._backup_service is None:
+            self._backup_service = BackupService(self.archive)
+        return self._backup_service
+
+    @property
+    def deliveries(self) -> DeliveryService:
+        """Return the delivery service configured with orchestrator and repository."""
+
+        if self._domain.db_session is None:
+            raise ValueError("DeliveryService requires an active database session")
+        if self._queue_orchestrator is None:
+            raise ValueError("DeliveryService requires a queue orchestrator")
+        if self._delivery_service is None:
+            repository = self._core.delivery_repository
+            self._delivery_service = self._delivery_provider(
+                repository,
+                queue_orchestrator=self._queue_orchestrator,
+            )
+        return self._delivery_service
+
+    @property
+    def websocket(self) -> WebSocketService:
+        """Return the websocket service."""
+
+        if self._websocket_service is None:
+            self._websocket_service = self._websocket_provider()
+        return self._websocket_service
+
+    @property
+    def system(self) -> SystemService:
+        """Return the system service monitoring delivery status."""
+
+        if self._system_service is None:
+            self._system_service = self._system_provider(self.deliveries)
+        return self._system_service
+
+    @property
+    def generation_coordinator(self) -> GenerationCoordinator:
+        """Return the generation coordinator tying together key services."""
+
+        if self._generation_coordinator is None:
+            self._generation_coordinator = self._generation_coordinator_provider(
+                self.deliveries,
+                self.websocket,
+                self._domain.generation,
+            )
+        return self._generation_coordinator
+
+
+__all__ = ["InfrastructureServiceRegistry"]

--- a/backend/services/service_container_builder.py
+++ b/backend/services/service_container_builder.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+from typing import Callable, Optional
+
+from sqlmodel import Session
+
+from .analytics import AnalyticsService
+from .analytics_repository import AnalyticsRepository
+from .core_container import CoreServiceRegistry
+from .delivery_repository import DeliveryJobRepository
+from .deliveries import DeliveryService
+from .domain_container import DomainServiceRegistry
+from .infra_container import InfrastructureServiceRegistry
+from .providers import (
+    make_adapter_service,
+    make_analytics_service,
+    make_archive_service,
+    make_compose_service,
+    make_delivery_service,
+    make_generation_coordinator,
+    make_generation_service,
+    make_recommendation_service,
+    make_storage_service,
+    make_system_service,
+    make_websocket_service,
+)
+from .queue import QueueOrchestrator, create_queue_orchestrator
+from .recommendations import RecommendationService
+from .service_registry import ServiceRegistry
+from .storage import StorageService
+from .system import SystemService
+from .websocket import WebSocketService, websocket_service
+
+
+class ServiceContainerBuilder:
+    """Build composed service registries with cached infrastructure dependencies."""
+
+    def __init__(
+        self,
+        *,
+        storage_provider: Callable[[], StorageService] = make_storage_service,
+        adapter_provider=make_adapter_service,
+        archive_provider=make_archive_service,
+        delivery_provider=make_delivery_service,
+        compose_provider=make_compose_service,
+        generation_provider=make_generation_service,
+        generation_coordinator_provider=make_generation_coordinator,
+        websocket_provider: Optional[Callable[[], WebSocketService]] = None,
+        system_provider: Callable[[DeliveryService], SystemService] = make_system_service,
+        analytics_provider: Callable[..., AnalyticsService] = make_analytics_service,
+        recommendation_provider=make_recommendation_service,
+        queue_orchestrator_factory: Callable[[], QueueOrchestrator] = create_queue_orchestrator,
+        analytics_repository_factory: Callable[[Session], AnalyticsRepository] = AnalyticsRepository,
+        delivery_repository_factory: Callable[[Session], DeliveryJobRepository] = DeliveryJobRepository,
+        recommendation_gpu_detector: Callable[[], bool] = RecommendationService.is_gpu_available,
+    ) -> None:
+        self._storage_provider = storage_provider
+        self._adapter_provider = adapter_provider
+        self._archive_provider = archive_provider
+        self._delivery_provider = delivery_provider
+        self._compose_provider = compose_provider
+        self._generation_provider = generation_provider
+        self._generation_coordinator_provider = generation_coordinator_provider
+        self._websocket_provider = (
+            websocket_provider
+            if websocket_provider is not None
+            else (lambda: make_websocket_service(service=websocket_service))
+        )
+        self._system_provider = system_provider
+        self._analytics_provider = analytics_provider
+        self._recommendation_provider = recommendation_provider
+        self._queue_orchestrator_factory = queue_orchestrator_factory
+        self._analytics_repository_factory = analytics_repository_factory
+        self._delivery_repository_factory = delivery_repository_factory
+        self._recommendation_gpu_detector = recommendation_gpu_detector
+
+        self._cached_queue_orchestrator: Optional[QueueOrchestrator] = None
+        self._cached_gpu_available: Optional[bool] = None
+
+    def _get_queue_orchestrator(self) -> QueueOrchestrator:
+        if self._cached_queue_orchestrator is None:
+            self._cached_queue_orchestrator = self._queue_orchestrator_factory()
+        return self._cached_queue_orchestrator
+
+    def _get_gpu_available(self) -> bool:
+        if self._cached_gpu_available is None:
+            self._cached_gpu_available = self._recommendation_gpu_detector()
+        return self._cached_gpu_available
+
+    def build(
+        self,
+        db_session: Optional[Session],
+        *,
+        queue_orchestrator: Optional[QueueOrchestrator] = None,
+        delivery_repository: Optional[DeliveryJobRepository] = None,
+        analytics_repository: Optional[AnalyticsRepository] = None,
+        recommendation_gpu_available: Optional[bool] = None,
+    ) -> ServiceRegistry:
+        """Create a :class:`ServiceRegistry` wired with the configured dependencies."""
+
+        queue = queue_orchestrator or self._get_queue_orchestrator()
+        gpu_available = (
+            recommendation_gpu_available
+            if recommendation_gpu_available is not None
+            else self._get_gpu_available()
+        )
+
+        if db_session is not None:
+            delivery_repository = (
+                delivery_repository
+                if delivery_repository is not None
+                else self._delivery_repository_factory(db_session)
+            )
+            analytics_repository = (
+                analytics_repository
+                if analytics_repository is not None
+                else self._analytics_repository_factory(db_session)
+            )
+
+        core = CoreServiceRegistry(
+            db_session,
+            storage_provider=self._storage_provider,
+            delivery_repository=delivery_repository,
+            analytics_repository=analytics_repository,
+        )
+
+        domain = DomainServiceRegistry(
+            core,
+            db_session=db_session,
+            analytics_repository=analytics_repository,
+            adapter_provider=self._adapter_provider,
+            compose_provider=self._compose_provider,
+            generation_provider=self._generation_provider,
+            analytics_provider=self._analytics_provider,
+            recommendation_provider=self._recommendation_provider,
+            recommendation_gpu_available=gpu_available,
+        )
+
+        infrastructure = InfrastructureServiceRegistry(
+            core,
+            domain,
+            queue_orchestrator=queue,
+            archive_provider=self._archive_provider,
+            delivery_provider=self._delivery_provider,
+            generation_coordinator_provider=self._generation_coordinator_provider,
+            websocket_provider=self._websocket_provider,
+            system_provider=self._system_provider,
+        )
+
+        return ServiceRegistry(core, domain, infrastructure)
+
+
+__all__ = ["ServiceContainerBuilder"]

--- a/backend/services/service_registry.py
+++ b/backend/services/service_registry.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+from .adapters import AdapterService
+from .analytics import AnalyticsService
+from .archive import ArchiveService, BackupService
+from .composition import ComposeService
+from .core_container import CoreServiceRegistry
+from .deliveries import DeliveryService
+from .domain_container import DomainServiceRegistry
+from .generation import GenerationCoordinator, GenerationService
+from .infra_container import InfrastructureServiceRegistry
+from .recommendations import RecommendationService
+from .storage import StorageService
+from .system import SystemService
+from .websocket import WebSocketService
+
+
+class ServiceRegistry:
+    """Facade exposing lazily constructed services from dedicated registries."""
+
+    def __init__(
+        self,
+        core: CoreServiceRegistry,
+        domain: DomainServiceRegistry,
+        infrastructure: InfrastructureServiceRegistry,
+    ) -> None:
+        self._core = core
+        self._domain = domain
+        self._infrastructure = infrastructure
+
+    @property
+    def core(self) -> CoreServiceRegistry:
+        """Return the underlying core registry."""
+
+        return self._core
+
+    @property
+    def domain(self) -> DomainServiceRegistry:
+        """Return the underlying domain registry."""
+
+        return self._domain
+
+    @property
+    def infrastructure(self) -> InfrastructureServiceRegistry:
+        """Return the underlying infrastructure registry."""
+
+        return self._infrastructure
+
+    @property
+    def db_session(self):
+        """Expose the database session associated with the registries."""
+
+        return self._core.db_session
+
+    @property
+    def storage(self) -> StorageService:
+        return self._core.storage
+
+    @property
+    def adapters(self) -> AdapterService:
+        return self._domain.adapters
+
+    @property
+    def archive(self) -> ArchiveService:
+        return self._infrastructure.archive
+
+    @property
+    def backups(self) -> BackupService:
+        return self._infrastructure.backups
+
+    @property
+    def deliveries(self) -> DeliveryService:
+        return self._infrastructure.deliveries
+
+    @property
+    def compose(self) -> ComposeService:
+        return self._domain.compose
+
+    @property
+    def generation(self) -> GenerationService:
+        return self._domain.generation
+
+    @property
+    def generation_coordinator(self) -> GenerationCoordinator:
+        return self._infrastructure.generation_coordinator
+
+    @property
+    def websocket(self) -> WebSocketService:
+        return self._infrastructure.websocket
+
+    @property
+    def system(self) -> SystemService:
+        return self._infrastructure.system
+
+    @property
+    def analytics(self) -> AnalyticsService:
+        return self._domain.analytics
+
+    @property
+    def recommendations(self) -> RecommendationService:
+        return self._domain.recommendations
+
+
+__all__ = ["ServiceRegistry"]

--- a/backend/workers/context.py
+++ b/backend/workers/context.py
@@ -9,7 +9,7 @@ from typing import Any, Callable, Coroutine, Optional, TypeVar
 from sqlmodel import Session
 
 from backend.delivery.base import delivery_registry
-from backend.services import ServiceContainer
+from backend.services import ServiceRegistry, get_service_container_builder
 from backend.services.analytics_repository import AnalyticsRepository
 from backend.services.delivery_repository import DeliveryJobRepository
 from backend.services.queue import (
@@ -107,7 +107,7 @@ class WorkerContext:
                 return None
         return None
 
-    def create_service_container(self, db_session: Optional[Session]) -> ServiceContainer:
+    def create_service_container(self, db_session: Optional[Session]) -> ServiceRegistry:
         """Instantiate a service container sharing this context's dependencies."""
 
         delivery_repository = (
@@ -117,7 +117,8 @@ class WorkerContext:
             AnalyticsRepository(db_session) if db_session is not None else None
         )
 
-        return ServiceContainer(
+        builder = get_service_container_builder()
+        return builder.build(
             db_session,
             queue_orchestrator=self.queue_orchestrator,
             delivery_repository=delivery_repository,


### PR DESCRIPTION
## Summary
- split the legacy service container into dedicated core, domain, and infrastructure registries that are composed by a new `ServiceContainerBuilder`
- expose a lightweight `ServiceRegistry` facade from the builder and update API dependencies plus worker context to consume it while keeping the legacy `ServiceContainer` wrapper
- adjust test fixtures to patch the shared builder and keep storage mocking compatible with the new wiring

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68d28a182f8483299fd59973b6f3ed09