### PR TITLE
Refactor job queue composables

### DIFF
--- a/app/frontend/src/components/JobQueue.vue
+++ b/app/frontend/src/components/JobQueue.vue
@@ -78,6 +78,7 @@
 import { computed } from 'vue';
 
 import { useJobQueue } from '@/composables/useJobQueue';
+import { useJobQueueActions } from '@/composables/useJobQueueActions';
 import { formatElapsedTime } from '@/utils/format';
 
 import type { GenerationJob } from '@/types';
@@ -104,16 +105,12 @@ const props = withDefaults(defineProps<Props>(), {
   showClearCompleted: false,
 });
 
-const {
-  jobs,
-  isReady,
-  isCancelling,
-  clearCompletedJobs,
-  cancelJob: cancelQueueJob,
-} = useJobQueue({
+const { jobs, isReady } = useJobQueue({
   pollInterval: computed(() => props.pollingInterval),
   disabled: computed(() => props.disabled),
 });
+
+const { isCancelling, clearCompletedJobs, cancelJob: cancelQueueJob } = useJobQueueActions();
 
 const title = computed(() => props.title);
 const emptyStateTitle = computed(() => props.emptyStateTitle);

--- a/app/frontend/src/composables/useJobQueueActions.ts
+++ b/app/frontend/src/composables/useJobQueueActions.ts
@@ -1,0 +1,100 @@
+import { ref, unref, type MaybeRefOrGetter } from 'vue';
+import { storeToRefs } from 'pinia';
+
+import { cancelGenerationJob, cancelLegacyJob } from '@/services/generationService';
+import { useGenerationQueueStore } from '@/stores/generation';
+import { useNotifications } from '@/composables/useNotifications';
+import { useBackendBase } from '@/utils/backend';
+
+export interface UseJobQueueActionsOptions {
+  backendBase?: MaybeRefOrGetter<string>;
+}
+
+export const useJobQueueActions = (options: UseJobQueueActionsOptions = {}) => {
+  const queueStore = useGenerationQueueStore();
+  const notifications = useNotifications();
+  const backendBase = options.backendBase ?? useBackendBase();
+  const { activeJobs } = storeToRefs(queueStore);
+
+  const isCancelling = ref(false);
+
+  const resolveBackendBase = (): string => {
+    try {
+      const resolved = typeof backendBase === 'function' ? backendBase() : unref(backendBase);
+      return typeof resolved === 'string' ? resolved : '';
+    } catch (error) {
+      if (import.meta.env.DEV) {
+        console.warn('[JobQueue] Failed to resolve backend base for actions', error);
+      }
+      return '';
+    }
+  };
+
+  const cancelJob = async (jobId: string): Promise<boolean> => {
+    if (!jobId || isCancelling.value) {
+      return false;
+    }
+
+    const job = activeJobs.value.find((item) => item.id === jobId);
+    if (!job) {
+      notifications.showError('Job not found');
+      return false;
+    }
+
+    const backendJobId = job.jobId ?? job.id;
+    if (!backendJobId) {
+      notifications.showError('Job not found');
+      return false;
+    }
+
+    isCancelling.value = true;
+
+    try {
+      const backendBaseUrl = resolveBackendBase();
+      let cancelled = false;
+
+      try {
+        const response = await cancelGenerationJob(backendJobId, backendBaseUrl);
+        cancelled = response?.success !== false;
+      } catch (error) {
+        if (import.meta.env.DEV) {
+          console.info('[JobQueue] Generation cancellation failed, retrying legacy endpoint', error);
+        }
+      }
+
+      if (!cancelled) {
+        try {
+          cancelled = await cancelLegacyJob(backendJobId, backendBaseUrl);
+        } catch (error) {
+          if (import.meta.env.DEV) {
+            console.warn('[JobQueue] Legacy cancellation failed', error);
+          }
+          cancelled = false;
+        }
+      }
+
+      if (!cancelled) {
+        notifications.showError('Failed to cancel job');
+        return false;
+      }
+
+      queueStore.removeJob(jobId);
+      notifications.showInfo('Job cancelled');
+      return true;
+    } finally {
+      isCancelling.value = false;
+    }
+  };
+
+  const clearCompletedJobs = (): void => {
+    queueStore.clearCompletedJobs();
+  };
+
+  return {
+    isCancelling,
+    cancelJob,
+    clearCompletedJobs,
+  } as const;
+};
+
+export type UseJobQueueActionsReturn = ReturnType<typeof useJobQueueActions>;

--- a/app/frontend/src/composables/useJobQueuePolling.ts
+++ b/app/frontend/src/composables/useJobQueuePolling.ts
@@ -1,0 +1,111 @@
+import { onBeforeUnmount, onMounted, ref, watch, type ComputedRef, type Ref } from 'vue';
+
+import type { JobQueueRecord } from '@/composables/useJobQueueTransport';
+
+export interface UseJobQueuePollingOptions {
+  disabled: ComputedRef<boolean>;
+  pollInterval: ComputedRef<number>;
+  apiAvailable: Ref<boolean>;
+  fetchJobs: () => Promise<JobQueueRecord[] | null>;
+  onRecord: (record: JobQueueRecord) => void;
+}
+
+export const useJobQueuePolling = ({
+  disabled,
+  pollInterval,
+  apiAvailable,
+  fetchJobs,
+  onRecord,
+}: UseJobQueuePollingOptions) => {
+  const isReady = ref(false);
+  const isPolling = ref(false);
+  const pollTimer = ref<ReturnType<typeof setInterval> | null>(null);
+
+  const applyRecords = (records: JobQueueRecord[] | null | undefined): void => {
+    if (!Array.isArray(records) || records.length === 0) {
+      return;
+    }
+
+    records.forEach((record) => onRecord(record));
+  };
+
+  const refresh = async (): Promise<void> => {
+    if (isPolling.value || disabled.value || !apiAvailable.value) {
+      if (!isReady.value) {
+        isReady.value = true;
+      }
+      return;
+    }
+
+    isPolling.value = true;
+
+    try {
+      const records = await fetchJobs();
+      applyRecords(records ?? undefined);
+    } finally {
+      isPolling.value = false;
+      if (!isReady.value) {
+        isReady.value = true;
+      }
+    }
+  };
+
+  const stopPolling = (): void => {
+    if (pollTimer.value) {
+      clearInterval(pollTimer.value);
+      pollTimer.value = null;
+    }
+    isPolling.value = false;
+  };
+
+  const startPolling = (): void => {
+    if (pollTimer.value || disabled.value) {
+      if (!isReady.value) {
+        isReady.value = true;
+      }
+      return;
+    }
+
+    isReady.value = true;
+    void refresh();
+
+    pollTimer.value = setInterval(() => {
+      if (!isPolling.value && !disabled.value && apiAvailable.value) {
+        void refresh();
+      }
+    }, pollInterval.value);
+  };
+
+  watch(disabled, (nextDisabled) => {
+    if (nextDisabled) {
+      stopPolling();
+    } else if (!pollTimer.value && apiAvailable.value) {
+      startPolling();
+    }
+  });
+
+  watch(pollInterval, () => {
+    if (pollTimer.value) {
+      stopPolling();
+      startPolling();
+    }
+  });
+
+  onMounted(() => {
+    startPolling();
+  });
+
+  onBeforeUnmount(() => {
+    stopPolling();
+  });
+
+  return {
+    isReady,
+    isPolling,
+    refresh,
+    startPolling,
+    stopPolling,
+  } as const;
+};
+
+export type UseJobQueuePollingReturn = ReturnType<typeof useJobQueuePolling>;

--- a/app/frontend/src/composables/useJobQueueTransport.ts
+++ b/app/frontend/src/composables/useJobQueueTransport.ts
@@ -1,0 +1,108 @@
+import { computed, ref, unref, type ComputedRef, type MaybeRefOrGetter, type Ref } from 'vue';
+
+import { ApiError } from '@/composables/useApi';
+import { fetchActiveGenerationJobs, fetchLegacyJobStatuses } from '@/services/generationService';
+import { DEFAULT_BACKEND_BASE } from '@/utils/backend';
+
+const PRIMARY_FAILURE_LOG_COOLDOWN = 5000;
+
+export type JobQueueRecord = Record<string, unknown>;
+
+export interface UseJobQueueTransportOptions {
+  backendBase: MaybeRefOrGetter<string>;
+}
+
+export interface UseJobQueueTransportReturn {
+  fetchJobs: () => Promise<JobQueueRecord[] | null>;
+  apiAvailable: Ref<boolean>;
+  legacyEndpointMissing: Ref<boolean>;
+  isLegacyFallbackAvailable: ComputedRef<boolean>;
+}
+
+const resolveBackendBase = (backendBase: MaybeRefOrGetter<string>): string => {
+  try {
+    const resolved =
+      typeof backendBase === 'function'
+        ? (backendBase as () => string)()
+        : unref(backendBase);
+
+    return typeof resolved === 'string' && resolved.trim() ? resolved : DEFAULT_BACKEND_BASE;
+  } catch (error) {
+    if (import.meta.env.DEV) {
+      console.warn('[JobQueue] Failed to resolve backend base', error);
+    }
+    return DEFAULT_BACKEND_BASE;
+  }
+};
+
+const createPrimaryFailureLogger = () => {
+  const lastPrimaryFailureLogAt = ref<number | null>(null);
+
+  return (error: unknown) => {
+    if (!import.meta.env.DEV) {
+      return;
+    }
+
+    const now = Date.now();
+    if (!lastPrimaryFailureLogAt.value || now - lastPrimaryFailureLogAt.value >= PRIMARY_FAILURE_LOG_COOLDOWN) {
+      console.info('[JobQueue] Generation endpoint unavailable, falling back', error);
+      lastPrimaryFailureLogAt.value = now;
+    }
+  };
+};
+
+export const useJobQueueTransport = (
+  options: UseJobQueueTransportOptions,
+): UseJobQueueTransportReturn => {
+  const apiAvailable = ref(true);
+  const legacyEndpointMissing = ref(false);
+  const legacyMissingLogged = ref(false);
+  const logPrimaryFailure = createPrimaryFailureLogger();
+
+  const fetchJobs = async (): Promise<JobQueueRecord[] | null> => {
+    const backendBase = resolveBackendBase(options.backendBase);
+
+    try {
+      const records = await fetchActiveGenerationJobs(backendBase);
+      apiAvailable.value = true;
+      return records;
+    } catch (error) {
+      logPrimaryFailure(error);
+
+      if (legacyEndpointMissing.value) {
+        return null;
+      }
+
+      try {
+        const fallbackRecords = await fetchLegacyJobStatuses(backendBase);
+        apiAvailable.value = true;
+        legacyEndpointMissing.value = false;
+        legacyMissingLogged.value = false;
+        return fallbackRecords;
+      } catch (fallbackError) {
+        if (fallbackError instanceof ApiError && fallbackError.status === 404) {
+          legacyEndpointMissing.value = true;
+          if (import.meta.env.DEV && !legacyMissingLogged.value) {
+            console.info(
+              '[JobQueue] Legacy job endpoint missing, continuing without fallback',
+            );
+            legacyMissingLogged.value = true;
+          }
+        } else if (import.meta.env.DEV) {
+          console.info('[JobQueue] Legacy job endpoint failed', fallbackError);
+        }
+
+        return null;
+      }
+    }
+  };
+
+  return {
+    fetchJobs,
+    apiAvailable,
+    legacyEndpointMissing,
+    isLegacyFallbackAvailable: computed(() => !legacyEndpointMissing.value),
+  } as const;
+};
+
+export type UseJobQueueTransportReturnType = ReturnType<typeof useJobQueueTransport>;

--- a/tests/vue/useJobQueueActions.spec.ts
+++ b/tests/vue/useJobQueueActions.spec.ts
@@ -1,0 +1,113 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { computed, effectScope } from 'vue';
+import { storeToRefs } from 'pinia';
+
+import { useJobQueueActions } from '@/composables/useJobQueueActions';
+import { useGenerationQueueStore } from '@/stores/generation';
+
+const serviceMocks = vi.hoisted(() => ({
+  cancelGenerationJob: vi.fn(),
+  cancelLegacyJob: vi.fn(),
+}));
+
+vi.mock('@/services/generationService', () => ({
+  fetchActiveGenerationJobs: vi.fn(),
+  fetchLegacyJobStatuses: vi.fn(),
+  cancelGenerationJob: serviceMocks.cancelGenerationJob,
+  cancelLegacyJob: serviceMocks.cancelLegacyJob,
+}));
+
+const notificationMocks = vi.hoisted(() => ({
+  notifications: { value: [] as unknown[] },
+  showSuccess: vi.fn(),
+  showError: vi.fn(),
+  showInfo: vi.fn(),
+  showWarning: vi.fn(),
+  addNotification: vi.fn(),
+  removeNotification: vi.fn(),
+  clearAll: vi.fn(),
+}));
+
+vi.mock('@/composables/useNotifications', () => ({
+  useNotifications: () => notificationMocks,
+}));
+
+vi.mock('@/utils/backend', () => ({
+  useBackendBase: () => computed(() => '/api/v1'),
+}));
+
+const withActions = async (
+  run: (actions: ReturnType<typeof useJobQueueActions>) => Promise<void>,
+) => {
+  const scope = effectScope();
+  let actionsInstance: ReturnType<typeof useJobQueueActions>;
+
+  scope.run(() => {
+    actionsInstance = useJobQueueActions();
+  });
+
+  try {
+    await run(actionsInstance!);
+  } finally {
+    scope.stop();
+  }
+};
+
+describe('useJobQueueActions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    notificationMocks.notifications.value = [];
+  });
+
+  it('cancels a job via the primary endpoint', async () => {
+    serviceMocks.cancelGenerationJob.mockResolvedValueOnce({ success: true });
+
+    await withActions(async (actions) => {
+      const queueStore = useGenerationQueueStore();
+      const { jobs } = storeToRefs(queueStore);
+      queueStore.enqueueJob({ id: 'job-1', jobId: 'backend-1', status: 'processing' });
+
+      const result = await actions.cancelJob('job-1');
+
+      expect(result).toBe(true);
+      expect(serviceMocks.cancelLegacyJob).not.toHaveBeenCalled();
+      expect(notificationMocks.showInfo).toHaveBeenCalledWith('Job cancelled');
+      expect(jobs.value).toHaveLength(0);
+    });
+  });
+
+  it('falls back to the legacy endpoint when the primary fails', async () => {
+    serviceMocks.cancelGenerationJob.mockRejectedValueOnce(new Error('primary failed'));
+    serviceMocks.cancelLegacyJob.mockResolvedValueOnce(true);
+
+    await withActions(async (actions) => {
+      const queueStore = useGenerationQueueStore();
+      const { jobs } = storeToRefs(queueStore);
+      queueStore.enqueueJob({ id: 'job-2', jobId: 'backend-2', status: 'queued' });
+
+      const result = await actions.cancelJob('job-2');
+
+      expect(result).toBe(true);
+      expect(serviceMocks.cancelLegacyJob).toHaveBeenCalledWith('backend-2', '/api/v1');
+      expect(notificationMocks.showInfo).toHaveBeenCalledWith('Job cancelled');
+      expect(jobs.value).toHaveLength(0);
+    });
+  });
+
+  it('notifies when cancellation fails', async () => {
+    serviceMocks.cancelGenerationJob.mockRejectedValueOnce(new Error('primary failed'));
+    serviceMocks.cancelLegacyJob.mockResolvedValueOnce(false);
+
+    await withActions(async (actions) => {
+      const queueStore = useGenerationQueueStore();
+      const { jobs } = storeToRefs(queueStore);
+      queueStore.enqueueJob({ id: 'job-3', jobId: 'backend-3', status: 'queued' });
+
+      const result = await actions.cancelJob('job-3');
+
+      expect(result).toBe(false);
+      expect(notificationMocks.showError).toHaveBeenCalledWith('Failed to cancel job');
+      expect(jobs.value).toHaveLength(1);
+    });
+  });
+});

--- a/tests/vue/useJobQueuePolling.spec.ts
+++ b/tests/vue/useJobQueuePolling.spec.ts
@@ -1,0 +1,60 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { computed, ref } from 'vue';
+import { mount } from '@vue/test-utils';
+
+import { useJobQueuePolling } from '@/composables/useJobQueuePolling';
+
+describe('useJobQueuePolling', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('executes the fetch callback on an interval and stops when disabled', async () => {
+    const disabled = ref(false);
+    const pollInterval = ref(100);
+    const apiAvailable = ref(true);
+    const fetchJobs = vi.fn().mockResolvedValue([{ id: 'job-1' }, { id: 'job-2' }]);
+    const onRecord = vi.fn();
+
+    let polling: ReturnType<typeof useJobQueuePolling> | undefined;
+
+    const wrapper = mount({
+      setup() {
+        polling = useJobQueuePolling({
+          disabled: computed(() => disabled.value),
+          pollInterval: computed(() => pollInterval.value),
+          apiAvailable,
+          fetchJobs,
+          onRecord,
+        });
+        return () => null;
+      },
+    });
+
+    await polling!.refresh();
+    await Promise.resolve();
+
+    expect(fetchJobs).toHaveBeenCalledTimes(1);
+
+    polling!.startPolling();
+
+    await vi.advanceTimersByTimeAsync(100);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(fetchJobs).toHaveBeenCalledTimes(2);
+
+    disabled.value = true;
+    await Promise.resolve();
+
+    await vi.advanceTimersByTimeAsync(200);
+
+    expect(fetchJobs).toHaveBeenCalledTimes(2);
+
+    wrapper.unmount();
+  });
+});

--- a/tests/vue/useJobQueueTransport.spec.ts
+++ b/tests/vue/useJobQueueTransport.spec.ts
@@ -1,0 +1,78 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { computed, effectScope } from 'vue';
+
+import { useJobQueueTransport } from '@/composables/useJobQueueTransport';
+import { ApiError } from '@/composables/useApi';
+
+const serviceMocks = vi.hoisted(() => ({
+  fetchActiveGenerationJobs: vi.fn(),
+  fetchLegacyJobStatuses: vi.fn(),
+}));
+
+vi.mock('@/services/generationService', () => ({
+  fetchActiveGenerationJobs: serviceMocks.fetchActiveGenerationJobs,
+  fetchLegacyJobStatuses: serviceMocks.fetchLegacyJobStatuses,
+  cancelGenerationJob: vi.fn(),
+  cancelLegacyJob: vi.fn(),
+}));
+
+const createTransport = () => {
+  const scope = effectScope();
+  let transport: ReturnType<typeof useJobQueueTransport>;
+
+  scope.run(() => {
+    transport = useJobQueueTransport({ backendBase: computed(() => '/api/v1') });
+  });
+
+  return {
+    transport: transport!,
+    stop: () => scope.stop(),
+  };
+};
+
+describe('useJobQueueTransport', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('falls back to the legacy endpoint when the primary fails', async () => {
+    const records = [{ id: 'job-1' }];
+    serviceMocks.fetchActiveGenerationJobs.mockRejectedValueOnce(new Error('primary failed'));
+    serviceMocks.fetchLegacyJobStatuses.mockResolvedValueOnce(records);
+
+    const { transport, stop } = createTransport();
+
+    await expect(transport.fetchJobs()).resolves.toEqual(records);
+    expect(transport.apiAvailable.value).toBe(true);
+    expect(transport.legacyEndpointMissing.value).toBe(false);
+    expect(serviceMocks.fetchLegacyJobStatuses).toHaveBeenCalledWith('/api/v1');
+
+    stop();
+  });
+
+  it('marks the legacy endpoint as unavailable when it returns 404', async () => {
+    const notFoundError = new ApiError({
+      message: 'Not Found',
+      status: 404,
+      statusText: 'Not Found',
+      payload: null,
+      meta: { ok: false, status: 404, statusText: 'Not Found' },
+    });
+
+    serviceMocks.fetchActiveGenerationJobs.mockRejectedValue(new Error('primary failed'));
+    serviceMocks.fetchLegacyJobStatuses.mockRejectedValueOnce(notFoundError);
+
+    const { transport, stop } = createTransport();
+
+    await expect(transport.fetchJobs()).resolves.toBeNull();
+    expect(transport.legacyEndpointMissing.value).toBe(true);
+    expect(transport.isLegacyFallbackAvailable.value).toBe(false);
+
+    serviceMocks.fetchActiveGenerationJobs.mockResolvedValueOnce([{ id: 'job-2' }]);
+
+    await expect(transport.fetchJobs()).resolves.toEqual([{ id: 'job-2' }]);
+    expect(serviceMocks.fetchLegacyJobStatuses).toHaveBeenCalledTimes(1);
+
+    stop();
+  });
+});


### PR DESCRIPTION
## Summary
- extract polling, transport, and action logic from `useJobQueue` into dedicated composables
- update the queue component to compose the new hooks and streamline job record updates
- add focused unit tests covering the polling, transport, actions, and updated queue composables

## Testing
- npx vitest run tests/vue/useJobQueue.spec.ts tests/vue/useJobQueueActions.spec.ts tests/vue/useJobQueuePolling.spec.ts tests/vue/useJobQueueTransport.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68d28a4149a083298eb30b545024abf8