### PR TITLE
Make import/export props readonly and fix chart typing

### DIFF
--- a/app/frontend/src/components/ImportExport.vue
+++ b/app/frontend/src/components/ImportExport.vue
@@ -212,16 +212,19 @@ import { formatDateTime, formatFileSize as formatBytes } from '@/utils/format';
 type OperationType = 'export' | 'import' | 'migration';
 
 type ExportConfigUpdate = {
-  [K in keyof ExportConfig]: { key: K; value: ExportConfig[K] }
-}[keyof ExportConfig];
+  key: keyof ExportConfig;
+  value: ExportConfig[keyof ExportConfig];
+};
 
 type ImportConfigUpdate = {
-  [K in keyof ImportConfig]: { key: K; value: ImportConfig[K] }
-}[keyof ImportConfig];
+  key: keyof ImportConfig;
+  value: ImportConfig[keyof ImportConfig];
+};
 
 type MigrationConfigUpdate = {
-  [K in keyof MigrationConfig]: { key: K; value: MigrationConfig[K] }
-}[keyof MigrationConfig];
+  key: keyof MigrationConfig;
+  value: MigrationConfig[keyof MigrationConfig];
+};
 
 const isInitialized = ref(false);
 const activeTab = ref<'export' | 'import' | 'backup' | 'migration'>('export');
@@ -378,8 +381,8 @@ const onMigrationConfigUpdate = (payload: MigrationConfigUpdate) => {
   migrationWorkflow.updateConfig(payload.key, payload.value);
 };
 
-const onImportFilesAdded = (files: File[]) => {
-  importWorkflow.addFiles(files);
+const onImportFilesAdded = (files: readonly File[]) => {
+  importWorkflow.addFiles([...files]);
 };
 
 const onImportFileRemoved = (file: File) => {

--- a/app/frontend/src/components/analytics/GenerationVolumeChart.vue
+++ b/app/frontend/src/components/analytics/GenerationVolumeChart.vue
@@ -53,12 +53,17 @@ const applyDataToChart = () => {
 };
 
 const createChart = () => {
-  if (chartRef.value || !canvasRef.value) {
+  if (chartRef.value) {
+    return;
+  }
+
+  const canvas = canvasRef.value;
+  if (!canvas || !(canvas instanceof HTMLCanvasElement)) {
     return;
   }
 
   const options = createBaseTimeSeriesOptions();
-  chartRef.value = new Chart(canvasRef.value, {
+  chartRef.value = new Chart(canvas, {
     type: 'line',
     data: buildChartData(),
     options,

--- a/app/frontend/src/components/analytics/LoraUsageChart.vue
+++ b/app/frontend/src/components/analytics/LoraUsageChart.vue
@@ -48,11 +48,16 @@ const applyDataToChart = () => {
 };
 
 const createChart = () => {
-  if (chartRef.value || !canvasRef.value) {
+  if (chartRef.value) {
     return;
   }
 
-  chartRef.value = new Chart(canvasRef.value, {
+  const canvas = canvasRef.value;
+  if (!canvas || !(canvas instanceof HTMLCanvasElement)) {
+    return;
+  }
+
+  chartRef.value = new Chart(canvas, {
     type: 'doughnut',
     data: buildChartData(),
     options: createDoughnutChartOptions(),

--- a/app/frontend/src/components/analytics/PerformanceTrendChart.vue
+++ b/app/frontend/src/components/analytics/PerformanceTrendChart.vue
@@ -94,11 +94,16 @@ const applyDataToChart = () => {
 };
 
 const createChart = () => {
-  if (chartRef.value || !canvasRef.value) {
+  if (chartRef.value) {
     return;
   }
 
-  chartRef.value = new Chart(canvasRef.value, {
+  const canvas = canvasRef.value;
+  if (!canvas || !(canvas instanceof HTMLCanvasElement)) {
+    return;
+  }
+
+  chartRef.value = new Chart(canvas, {
     type: 'line',
     data: buildChartData(),
     options: buildChartOptions(),

--- a/app/frontend/src/components/analytics/ResourceUsageChart.vue
+++ b/app/frontend/src/components/analytics/ResourceUsageChart.vue
@@ -92,11 +92,16 @@ const applyDataToChart = () => {
 };
 
 const createChart = () => {
-  if (chartRef.value || !canvasRef.value) {
+  if (chartRef.value) {
     return;
   }
 
-  chartRef.value = new Chart(canvasRef.value, {
+  const canvas = canvasRef.value;
+  if (!canvas || !(canvas instanceof HTMLCanvasElement)) {
+    return;
+  }
+
+  chartRef.value = new Chart(canvas, {
     type: 'line',
     data: buildChartData(),
     options: buildChartOptions(),

--- a/app/frontend/src/components/import-export/BackupManagementPanel.vue
+++ b/app/frontend/src/components/import-export/BackupManagementPanel.vue
@@ -95,7 +95,7 @@
 import type { BackupEntry } from '@/composables/useBackupWorkflow';
 
 const props = defineProps<{
-  history: BackupEntry[];
+  history: readonly BackupEntry[];
   formatFileSize: (bytes: number) => string;
   formatDate: (input: string) => string;
 }>();

--- a/app/frontend/src/components/import-export/ImportProcessingPanel.vue
+++ b/app/frontend/src/components/import-export/ImportProcessingPanel.vue
@@ -212,8 +212,8 @@ type ImportConfigKey = keyof ImportConfig;
 
 const props = defineProps<{
   config: ImportConfig;
-  files: File[];
-  preview: ImportPreviewItem[];
+  files: readonly File[];
+  preview: readonly ImportPreviewItem[];
   hasEncryptedFiles: boolean;
   isImporting: boolean;
   formatFileSize: (bytes: number) => string;
@@ -222,7 +222,7 @@ const props = defineProps<{
 
 const emit = defineEmits<{
   (e: 'update-config', payload: { key: ImportConfigKey; value: ImportConfig[ImportConfigKey] }): void;
-  (e: 'add-files', payload: File[]): void;
+  (e: 'add-files', payload: readonly File[]): void;
   (e: 'remove-file', payload: File): void;
   (e: 'analyze'): void;
   (e: 'validate'): void;

--- a/app/frontend/src/composables/useExportWorkflow.ts
+++ b/app/frontend/src/composables/useExportWorkflow.ts
@@ -1,4 +1,4 @@
-import { computed, reactive, ref, watch } from 'vue';
+import { computed, reactive, ref, watch, type ComputedRef } from 'vue';
 
 import { ensureData, getFilenameFromContentDisposition, postJson, requestBlob } from '@/utils/api';
 import { downloadFile } from '@/utils/browser';
@@ -46,10 +46,10 @@ interface UseExportWorkflowOptions {
 
 export interface UseExportWorkflow {
   exportConfig: ExportConfig;
-  canExport: Readonly<boolean>;
-  estimatedSize: Readonly<string>;
-  estimatedTime: Readonly<string>;
-  isExporting: Readonly<boolean>;
+  canExport: ComputedRef<boolean>;
+  estimatedSize: ComputedRef<string>;
+  estimatedTime: ComputedRef<string>;
+  isExporting: ComputedRef<boolean>;
   initialize: () => Promise<void>;
   updateConfig: <K extends keyof ExportConfig>(key: K, value: ExportConfig[K]) => void;
   validateExport: () => void;

--- a/app/frontend/src/composables/useImportWorkflow.ts
+++ b/app/frontend/src/composables/useImportWorkflow.ts
@@ -1,4 +1,4 @@
-import { computed, reactive, ref } from 'vue';
+import { computed, reactive, ref, type ComputedRef } from 'vue';
 
 import { ensureData, requestJson } from '@/utils/api';
 import type { NotifyFn, ProgressCallbacks } from './useExportWorkflow';
@@ -29,10 +29,10 @@ interface UseImportWorkflowOptions {
 
 export interface UseImportWorkflow {
   importConfig: ImportConfig;
-  importFiles: Readonly<File[]>;
-  importPreview: Readonly<ImportPreviewItem[]>;
-  hasEncryptedFiles: Readonly<boolean>;
-  isImporting: Readonly<boolean>;
+  importFiles: ComputedRef<readonly File[]>;
+  importPreview: ComputedRef<readonly ImportPreviewItem[]>;
+  hasEncryptedFiles: ComputedRef<boolean>;
+  isImporting: ComputedRef<boolean>;
   updateConfig: <K extends keyof ImportConfig>(key: K, value: ImportConfig[K]) => void;
   addFiles: (files: File[]) => void;
   removeFile: (file: File) => void;


### PR DESCRIPTION
## Summary
- update import/export panels to accept readonly workflow arrays and emit readonly payloads
- adjust ImportExport container to treat workflow collections as immutable and align composable typings
- add canvas guards in chart components to satisfy stricter vue-tsc checks triggered by readonly props

## Testing
- npm run type-check

------
https://chatgpt.com/codex/tasks/task_e_68d29666dcf48329a4f3d4ce893736a2