### PR TITLE
Add indexes for adapter ingestion metadata and user preferences

### DIFF
--- a/backend/models/adapters.py
+++ b/backend/models/adapters.py
@@ -4,12 +4,24 @@ from datetime import datetime, timezone
 from typing import Optional
 from uuid import uuid4
 
-from sqlalchemy import JSON, Column
+from sqlalchemy import JSON, Column, Index
 from sqlmodel import Field, SQLModel
+
+
+adapter_table_args = (
+    Index("ux_adapter_name_version", "name", "version", unique=True),
+    Index("idx_adapter_active", "active"),
+    Index("idx_adapter_json_file_path", "json_file_path"),
+    Index("idx_adapter_created_at", "created_at"),
+    Index("idx_adapter_updated_at", "updated_at"),
+    Index("idx_adapter_last_ingested_at", "last_ingested_at"),
+)
 
 
 class Adapter(SQLModel, table=True):
     """Metadata model describing a LoRA adapter file and hints for composition."""
+
+    __table_args__ = adapter_table_args
 
     id: str = Field(default_factory=lambda: str(uuid4()), primary_key=True)
     name: str

--- a/backend/models/recommendations.py
+++ b/backend/models/recommendations.py
@@ -4,7 +4,7 @@ from datetime import datetime, timezone
 from typing import Optional
 from uuid import uuid4
 
-from sqlalchemy import JSON, Column, LargeBinary, Text
+from sqlalchemy import JSON, Column, Index, LargeBinary, Text
 from sqlmodel import Field, SQLModel
 
 
@@ -23,7 +23,15 @@ class RecommendationSession(SQLModel, table=True):
 
 class UserPreference(SQLModel, table=True):
     """Track learned user preferences."""
-    
+
+    __table_args__ = (
+        Index(
+            "ix_userpreference_type_value",
+            "preference_type",
+            "preference_value",
+        ),
+    )
+
     id: str = Field(default_factory=lambda: str(uuid4()), primary_key=True)
     preference_type: str  # 'archetype', 'style', 'technical', 'author', 'tag'
     preference_value: str

--- a/infrastructure/alembic/versions/a1f4d5d0b6c7_add_adapter_indexes_and_userpreference_idx.py
+++ b/infrastructure/alembic/versions/a1f4d5d0b6c7_add_adapter_indexes_and_userpreference_idx.py
@@ -1,0 +1,43 @@
+"""Restore adapter indexes and add user preference composite index.
+
+Revision ID: a1f4d5d0b6c7
+Revises: 7ef61e651ef8
+Create Date: 2025-08-30 00:00:00.000000
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "a1f4d5d0b6c7"
+down_revision = "7ef61e651ef8"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    """Apply index additions for adapters and user preferences."""
+    op.create_index("idx_adapter_active", "adapter", ["active"], unique=False)
+    op.create_index(
+        "idx_adapter_json_file_path", "adapter", ["json_file_path"], unique=False
+    )
+    op.create_index("idx_adapter_created_at", "adapter", ["created_at"], unique=False)
+    op.create_index("idx_adapter_updated_at", "adapter", ["updated_at"], unique=False)
+    op.create_index(
+        "idx_adapter_last_ingested_at", "adapter", ["last_ingested_at"], unique=False
+    )
+    op.create_index(
+        "ix_userpreference_type_value",
+        "userpreference",
+        ["preference_type", "preference_value"],
+        unique=False,
+    )
+
+
+def downgrade():
+    """Remove index additions for adapters and user preferences."""
+    op.drop_index("ix_userpreference_type_value", table_name="userpreference")
+    op.drop_index("idx_adapter_last_ingested_at", table_name="adapter")
+    op.drop_index("idx_adapter_updated_at", table_name="adapter")
+    op.drop_index("idx_adapter_created_at", table_name="adapter")
+    op.drop_index("idx_adapter_json_file_path", table_name="adapter")
+    op.drop_index("idx_adapter_active", table_name="adapter")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -84,14 +84,6 @@ def db_session_fixture():
     original_engine = core_database.ENGINE
     core_database.ENGINE = engine
     SQLModel.metadata.create_all(engine)
-    # Ensure tests enforce the same uniqueness we add via Alembic
-    # Create a unique index on (name, version) for the adapter table so
-    # test behavior matches production DB expectations.
-    with engine.begin() as conn:
-        conn.exec_driver_sql(
-            "CREATE UNIQUE INDEX IF NOT EXISTS ux_adapter_name_version "
-            "ON adapter (name, version)",
-        )
     try:
         with Session(engine) as session:
             yield session


### PR DESCRIPTION
## Summary
- define SQLModel table args for Adapter to enforce unique name/version and add indexes for planner/statistics queries
- add a composite index on user preferences and remove redundant manual index creation in tests
- create an Alembic migration to apply the new database indexes

## Testing
- pytest tests/integration

------
https://chatgpt.com/codex/tasks/task_e_68d29805ab9c8329ab1ad9d3d186bc4e