### PR TITLE
Improve typed config update emits for import/export workflow

### DIFF
--- a/app/frontend/src/components/ImportExport.vue
+++ b/app/frontend/src/components/ImportExport.vue
@@ -81,7 +81,7 @@
           :estimated-size="estimatedSize"
           :estimated-time="estimatedTime"
           :is-exporting="isExporting"
-          @update-config="onExportConfigUpdate"
+          @update-config="handleExportConfigUpdate"
           @validate="validateExport"
           @preview="previewExport"
           @start="() => startExport()"
@@ -96,7 +96,7 @@
           :is-importing="isImporting"
           :format-file-size="formatFileSize"
           :get-status-classes="getStatusClasses"
-          @update-config="onImportConfigUpdate"
+          @update-config="handleImportConfigUpdate"
           @add-files="onImportFilesAdded"
           @remove-file="onImportFileRemoved"
           @analyze="() => analyzeFiles()"
@@ -120,7 +120,7 @@
         <MigrationWorkflowPanel
           v-show="activeTab === 'migration'"
           :config="migrationConfig"
-          @update-config="onMigrationConfigUpdate"
+          @update-config="handleMigrationConfigUpdate"
           @start-version-migration="startVersionMigration"
           @start-platform-migration="startPlatformMigration"
         />
@@ -210,21 +210,6 @@ import { useMigrationWorkflow, type MigrationConfig } from '@/composables/useMig
 import { formatDateTime, formatFileSize as formatBytes } from '@/utils/format';
 
 type OperationType = 'export' | 'import' | 'migration';
-
-type ExportConfigUpdate = {
-  key: keyof ExportConfig;
-  value: ExportConfig[keyof ExportConfig];
-};
-
-type ImportConfigUpdate = {
-  key: keyof ImportConfig;
-  value: ImportConfig[keyof ImportConfig];
-};
-
-type MigrationConfigUpdate = {
-  key: keyof MigrationConfig;
-  value: MigrationConfig[keyof MigrationConfig];
-};
 
 const isInitialized = ref(false);
 const activeTab = ref<'export' | 'import' | 'backup' | 'migration'>('export');
@@ -369,17 +354,17 @@ const getStatusClasses = (status: string) => {
   return statusClasses[status] ?? 'bg-gray-100 text-gray-800';
 };
 
-const onExportConfigUpdate = (payload: ExportConfigUpdate) => {
-  exportWorkflow.updateConfig(payload.key, payload.value);
-};
+function handleExportConfigUpdate<K extends keyof ExportConfig>(key: K, value: ExportConfig[K]) {
+  exportWorkflow.updateConfig(key, value);
+}
 
-const onImportConfigUpdate = (payload: ImportConfigUpdate) => {
-  importWorkflow.updateConfig(payload.key, payload.value);
-};
+function handleImportConfigUpdate<K extends keyof ImportConfig>(key: K, value: ImportConfig[K]) {
+  importWorkflow.updateConfig(key, value);
+}
 
-const onMigrationConfigUpdate = (payload: MigrationConfigUpdate) => {
-  migrationWorkflow.updateConfig(payload.key, payload.value);
-};
+function handleMigrationConfigUpdate<K extends keyof MigrationConfig>(key: K, value: MigrationConfig[K]) {
+  migrationWorkflow.updateConfig(key, value);
+}
 
 const onImportFilesAdded = (files: readonly File[]) => {
   importWorkflow.addFiles([...files]);

--- a/app/frontend/src/components/import-export/ExportConfigurationPanel.vue
+++ b/app/frontend/src/components/import-export/ExportConfigurationPanel.vue
@@ -307,50 +307,55 @@ const props = defineProps<{
   isExporting: boolean;
 }>();
 
-const emit = defineEmits<{
-  (e: 'update-config', payload: { key: ExportConfigKey; value: ExportConfig[ExportConfigKey] }): void;
-  (e: 'validate'): void;
-  (e: 'preview'): void;
-  (e: 'start'): void;
-}>();
-
-const updateConfig = (key: ExportConfigKey, value: ExportConfig[ExportConfigKey]) => {
-  emit('update-config', { key, value });
+type UpdateConfigEmitter<TConfig> = {
+  <K extends keyof TConfig>(event: 'update-config', key: K, value: TConfig[K]): void;
 };
 
-const onCheckboxChange = (key: ExportConfigKey, event: Event) => {
+const emit = defineEmits<
+  UpdateConfigEmitter<ExportConfig> & {
+    (e: 'validate'): void;
+    (e: 'preview'): void;
+    (e: 'start'): void;
+  }
+>();
+
+const updateConfig = <K extends ExportConfigKey>(key: K, value: ExportConfig[K]) => {
+  emit('update-config', key, value);
+};
+
+const onCheckboxChange = <K extends ExportConfigKey>(key: K, event: Event) => {
   const target = event.target as HTMLInputElement | null;
   if (target) {
-    updateConfig(key, target.checked as ExportConfig[ExportConfigKey]);
+    updateConfig(key, target.checked as ExportConfig[K]);
   }
 };
 
-const onRadioChange = (key: ExportConfigKey, event: Event) => {
+const onRadioChange = <K extends ExportConfigKey>(key: K, event: Event) => {
   const target = event.target as HTMLInputElement | null;
   if (target) {
-    updateConfig(key, target.value as ExportConfig[ExportConfigKey]);
+    updateConfig(key, target.value as ExportConfig[K]);
   }
 };
 
-const onSelectChange = (key: ExportConfigKey, event: Event) => {
+const onSelectChange = <K extends ExportConfigKey>(key: K, event: Event) => {
   const target = event.target as HTMLSelectElement | null;
   if (target) {
-    updateConfig(key, target.value as ExportConfig[ExportConfigKey]);
+    updateConfig(key, target.value as ExportConfig[K]);
   }
 };
 
-const onInputChange = (key: ExportConfigKey, event: Event) => {
+const onInputChange = <K extends ExportConfigKey>(key: K, event: Event) => {
   const target = event.target as HTMLInputElement | null;
   if (target) {
-    updateConfig(key, target.value as ExportConfig[ExportConfigKey]);
+    updateConfig(key, target.value as ExportConfig[K]);
   }
 };
 
-const onNumberInput = (key: ExportConfigKey, event: Event) => {
+const onNumberInput = <K extends ExportConfigKey>(key: K, event: Event) => {
   const target = event.target as HTMLInputElement | null;
   if (target) {
     const parsed = Number(target.value);
-    updateConfig(key, (Number.isNaN(parsed) ? 0 : parsed) as ExportConfig[ExportConfigKey]);
+    updateConfig(key, (Number.isNaN(parsed) ? 0 : parsed) as ExportConfig[K]);
   }
 };
 </script>

--- a/app/frontend/src/components/import-export/ImportProcessingPanel.vue
+++ b/app/frontend/src/components/import-export/ImportProcessingPanel.vue
@@ -220,37 +220,42 @@ const props = defineProps<{
   getStatusClasses: (status: string) => string;
 }>();
 
-const emit = defineEmits<{
-  (e: 'update-config', payload: { key: ImportConfigKey; value: ImportConfig[ImportConfigKey] }): void;
-  (e: 'add-files', payload: readonly File[]): void;
-  (e: 'remove-file', payload: File): void;
-  (e: 'analyze'): void;
-  (e: 'validate'): void;
-  (e: 'start'): void;
-}>();
-
-const updateConfig = (key: ImportConfigKey, value: ImportConfig[ImportConfigKey]) => {
-  emit('update-config', { key, value });
+type UpdateConfigEmitter<TConfig> = {
+  <K extends keyof TConfig>(event: 'update-config', key: K, value: TConfig[K]): void;
 };
 
-const onCheckboxChange = (key: ImportConfigKey, event: Event) => {
+const emit = defineEmits<
+  UpdateConfigEmitter<ImportConfig> & {
+    (e: 'add-files', payload: readonly File[]): void;
+    (e: 'remove-file', payload: File): void;
+    (e: 'analyze'): void;
+    (e: 'validate'): void;
+    (e: 'start'): void;
+  }
+>();
+
+const updateConfig = <K extends ImportConfigKey>(key: K, value: ImportConfig[K]) => {
+  emit('update-config', key, value);
+};
+
+const onCheckboxChange = <K extends ImportConfigKey>(key: K, event: Event) => {
   const target = event.target as HTMLInputElement | null;
   if (target) {
-    updateConfig(key, target.checked as ImportConfig[ImportConfigKey]);
+    updateConfig(key, target.checked as ImportConfig[K]);
   }
 };
 
-const onSelectChange = (key: ImportConfigKey, event: Event) => {
+const onSelectChange = <K extends ImportConfigKey>(key: K, event: Event) => {
   const target = event.target as HTMLSelectElement | null;
   if (target) {
-    updateConfig(key, target.value as ImportConfig[ImportConfigKey]);
+    updateConfig(key, target.value as ImportConfig[K]);
   }
 };
 
-const onInputChange = (key: ImportConfigKey, event: Event) => {
+const onInputChange = <K extends ImportConfigKey>(key: K, event: Event) => {
   const target = event.target as HTMLInputElement | null;
   if (target) {
-    updateConfig(key, target.value as ImportConfig[ImportConfigKey]);
+    updateConfig(key, target.value as ImportConfig[K]);
   }
 };
 

--- a/app/frontend/src/components/import-export/MigrationWorkflowPanel.vue
+++ b/app/frontend/src/components/import-export/MigrationWorkflowPanel.vue
@@ -76,27 +76,32 @@ const props = defineProps<{
   config: MigrationConfig;
 }>();
 
-const emit = defineEmits<{
-  (e: 'update-config', payload: { key: MigrationConfigKey; value: MigrationConfig[MigrationConfigKey] }): void;
-  (e: 'start-version-migration'): void;
-  (e: 'start-platform-migration'): void;
-}>();
-
-const updateConfig = (key: MigrationConfigKey, value: MigrationConfig[MigrationConfigKey]) => {
-  emit('update-config', { key, value });
+type UpdateConfigEmitter<TConfig> = {
+  <K extends keyof TConfig>(event: 'update-config', key: K, value: TConfig[K]): void;
 };
 
-const onSelectChange = (key: MigrationConfigKey, event: Event) => {
+const emit = defineEmits<
+  UpdateConfigEmitter<MigrationConfig> & {
+    (e: 'start-version-migration'): void;
+    (e: 'start-platform-migration'): void;
+  }
+>();
+
+const updateConfig = <K extends MigrationConfigKey>(key: K, value: MigrationConfig[K]) => {
+  emit('update-config', key, value);
+};
+
+const onSelectChange = <K extends MigrationConfigKey>(key: K, event: Event) => {
   const target = event.target as HTMLSelectElement | null;
   if (target) {
-    updateConfig(key, target.value as MigrationConfig[MigrationConfigKey]);
+    updateConfig(key, target.value as MigrationConfig[K]);
   }
 };
 
-const onInputChange = (key: MigrationConfigKey, event: Event) => {
+const onInputChange = <K extends MigrationConfigKey>(key: K, event: Event) => {
   const target = event.target as HTMLInputElement | null;
   if (target) {
-    updateConfig(key, target.value as MigrationConfig[MigrationConfigKey]);
+    updateConfig(key, target.value as MigrationConfig[K]);
   }
 };
 </script>


### PR DESCRIPTION
## Summary
- refactor import/export panel emits to send key and value as strongly typed arguments
- update ImportExport parent handlers to use generic helpers for export, import, and migration configs
- ensure migration workflow emit signatures match the new key/value contract

## Testing
- npm run type-check

------
https://chatgpt.com/codex/tasks/task_e_68d298403ebc83298265e4716001a9cb