### PR TITLE
Refactor prompt composition into specialized composables

### DIFF
--- a/app/frontend/src/composables/prompt-composer/services.ts
+++ b/app/frontend/src/composables/prompt-composer/services.ts
@@ -1,0 +1,18 @@
+import { copyPromptToClipboard } from '@/utils/promptClipboard';
+import { triggerPromptGeneration, type PromptGenerationPayload } from '@/utils/promptGeneration';
+
+export interface PromptClipboardService {
+  copy: (value: string) => Promise<boolean>;
+}
+
+export interface PromptGenerationService {
+  trigger: (payload: PromptGenerationPayload) => Promise<boolean>;
+}
+
+export const createPromptClipboardService = (): PromptClipboardService => ({
+  copy: (value: string) => copyPromptToClipboard(value),
+});
+
+export const createPromptGenerationService = (): PromptGenerationService => ({
+  trigger: (payload: PromptGenerationPayload) => triggerPromptGeneration(payload),
+});

--- a/app/frontend/src/composables/prompt-composer/usePromptCompositionPersistence.ts
+++ b/app/frontend/src/composables/prompt-composer/usePromptCompositionPersistence.ts
@@ -1,0 +1,99 @@
+import { onBeforeUnmount, ref, watch, type Ref } from 'vue';
+
+import {
+  createPromptCompositionPersistence,
+  parseSavedComposition,
+  type PromptCompositionPersistence,
+} from '@/utils/promptCompositionPersistence';
+
+import type { CompositionEntry, SavedComposition } from '@/types';
+
+export interface PromptCompositionPersistenceBindings {
+  lastSaved: Ref<SavedComposition | null>;
+  saveComposition: () => void;
+  loadComposition: () => void;
+}
+
+interface UsePromptCompositionPersistenceOptions {
+  activeLoras: Ref<CompositionEntry[]>;
+  basePrompt: Ref<string>;
+  negativePrompt: Ref<string>;
+  basePromptError: Ref<string>;
+  persistence?: PromptCompositionPersistence;
+}
+
+const cloneEntries = (entries: CompositionEntry[]): CompositionEntry[] => entries.map((entry) => ({ ...entry }));
+
+const buildPayload = (
+  activeLoras: Ref<CompositionEntry[]>,
+  basePrompt: Ref<string>,
+  negativePrompt: Ref<string>,
+): SavedComposition => ({
+  items: cloneEntries(activeLoras.value),
+  base: basePrompt.value,
+  neg: negativePrompt.value,
+});
+
+export const usePromptCompositionPersistence = ({
+  activeLoras,
+  basePrompt,
+  negativePrompt,
+  basePromptError,
+  persistence = createPromptCompositionPersistence(),
+}: UsePromptCompositionPersistenceOptions): PromptCompositionPersistenceBindings => {
+  const lastSaved = ref<SavedComposition | null>(null);
+
+  const persistPayload = (payload: SavedComposition) => {
+    lastSaved.value = payload;
+    persistence.save(payload);
+  };
+
+  const saveComposition = (): void => {
+    persistPayload(buildPayload(activeLoras, basePrompt, negativePrompt));
+  };
+
+  const loadComposition = (): void => {
+    const payload = persistence.load() ?? lastSaved.value;
+
+    if (!payload) {
+      return;
+    }
+
+    const parsed = parseSavedComposition(payload);
+
+    if (!parsed) {
+      return;
+    }
+
+    activeLoras.value = cloneEntries(parsed.items);
+    basePrompt.value = parsed.base;
+    negativePrompt.value = parsed.neg;
+    basePromptError.value = '';
+    lastSaved.value = parsed;
+  };
+
+  watch(
+    [activeLoras, basePrompt, negativePrompt],
+    ([items, base, neg]: [CompositionEntry[], string, string]) => {
+      const payload: SavedComposition = {
+        items: cloneEntries(items),
+        base,
+        neg,
+      };
+
+      lastSaved.value = payload;
+      persistence.scheduleSave(payload);
+    },
+    { deep: true },
+  );
+
+  onBeforeUnmount(() => {
+    persistence.cancel();
+  });
+
+  return {
+    lastSaved,
+    saveComposition,
+    loadComposition,
+  };
+};

--- a/app/frontend/src/composables/prompt-composer/usePromptCompositionState.ts
+++ b/app/frontend/src/composables/prompt-composer/usePromptCompositionState.ts
@@ -1,0 +1,192 @@
+import { computed, ref, type ComputedRef, type Ref } from 'vue';
+
+import { PROMPT_COMPOSITION_DEFAULT_WEIGHT } from '@/constants/promptComposer';
+
+import type { AdapterSummary, CompositionEntry } from '@/types';
+
+const formatWeightToken = (value: number | string | null | undefined): string => {
+  const parsed = typeof value === 'number' ? value : Number(value);
+  const numeric = Number.isFinite(parsed) ? parsed : PROMPT_COMPOSITION_DEFAULT_WEIGHT;
+  const fixed = numeric.toFixed(2);
+  const trimmed = fixed
+    .replace(/(\.\d*?[1-9])0+$/u, '$1')
+    .replace(/\.0+$/u, '');
+  return trimmed.includes('.') ? trimmed : `${trimmed}.0`;
+};
+
+const buildFinalPrompt = (base: string, items: CompositionEntry[]): string => {
+  const trimmedBase = base.trim();
+
+  if (!trimmedBase) {
+    return '';
+  }
+
+  const tokens = items.map((entry) => `<lora:${entry.name}:${formatWeightToken(entry.weight)}>`);
+  return [trimmedBase, ...tokens].join(' ');
+};
+
+const normaliseWeight = (value: number): number => {
+  if (!Number.isFinite(value)) {
+    return PROMPT_COMPOSITION_DEFAULT_WEIGHT;
+  }
+
+  if (value < 0) {
+    return 0;
+  }
+
+  if (value > 2) {
+    return 2;
+  }
+
+  return value;
+};
+
+export interface PromptCompositionStateBindings {
+  activeLoras: Ref<CompositionEntry[]>;
+  basePrompt: Ref<string>;
+  negativePrompt: Ref<string>;
+  basePromptError: Ref<string>;
+  finalPrompt: ComputedRef<string>;
+  canSave: ComputedRef<boolean>;
+  addToComposition: (lora: AdapterSummary) => void;
+  removeFromComposition: (index: number) => void;
+  moveUp: (index: number) => void;
+  moveDown: (index: number) => void;
+  updateWeight: (index: number, weight: number) => void;
+  balanceWeights: () => void;
+  duplicateComposition: () => void;
+  clearComposition: () => void;
+  setBasePrompt: (value: string) => void;
+  setNegativePrompt: (value: string) => void;
+  isInComposition: (id: AdapterSummary['id']) => boolean;
+  validate: () => boolean;
+}
+
+export const usePromptCompositionState = (): PromptCompositionStateBindings => {
+  const activeLoras = ref<CompositionEntry[]>([]);
+  const basePrompt = ref('');
+  const negativePrompt = ref('');
+  const basePromptError = ref('');
+
+  const finalPrompt = computed<string>(() => buildFinalPrompt(basePrompt.value, activeLoras.value));
+  const canSave = computed<boolean>(() => activeLoras.value.length > 0);
+
+  const setBasePrompt = (value: string) => {
+    basePrompt.value = value;
+  };
+
+  const setNegativePrompt = (value: string) => {
+    negativePrompt.value = value;
+  };
+
+  const isInComposition = (id: AdapterSummary['id']): boolean => {
+    return activeLoras.value.some((entry) => String(entry.id) === String(id));
+  };
+
+  const addToComposition = (lora: AdapterSummary): void => {
+    if (isInComposition(lora.id)) {
+      return;
+    }
+
+    activeLoras.value.push({ id: lora.id, name: lora.name, weight: PROMPT_COMPOSITION_DEFAULT_WEIGHT });
+  };
+
+  const removeFromComposition = (index: number): void => {
+    if (index < 0 || index >= activeLoras.value.length) {
+      return;
+    }
+
+    activeLoras.value.splice(index, 1);
+  };
+
+  const moveUp = (index: number): void => {
+    if (index <= 0 || index >= activeLoras.value.length) {
+      return;
+    }
+
+    const [item] = activeLoras.value.splice(index, 1);
+
+    if (!item) {
+      return;
+    }
+
+    activeLoras.value.splice(index - 1, 0, item);
+  };
+
+  const moveDown = (index: number): void => {
+    if (index < 0 || index >= activeLoras.value.length - 1) {
+      return;
+    }
+
+    const [item] = activeLoras.value.splice(index, 1);
+
+    if (!item) {
+      return;
+    }
+
+    activeLoras.value.splice(index + 1, 0, item);
+  };
+
+  const updateWeight = (index: number, weight: number): void => {
+    if (index < 0 || index >= activeLoras.value.length) {
+      return;
+    }
+
+    activeLoras.value[index].weight = normaliseWeight(weight);
+  };
+
+  const balanceWeights = (): void => {
+    if (activeLoras.value.length === 0) {
+      return;
+    }
+
+    activeLoras.value.forEach((entry) => {
+      entry.weight = PROMPT_COMPOSITION_DEFAULT_WEIGHT;
+    });
+  };
+
+  const duplicateComposition = (): void => {
+    activeLoras.value = activeLoras.value.map((entry) => ({ ...entry }));
+  };
+
+  const clearComposition = (): void => {
+    activeLoras.value = [];
+  };
+
+  const validate = (): boolean => {
+    basePromptError.value = '';
+
+    if (!basePrompt.value.trim()) {
+      basePromptError.value = 'Base prompt is required';
+      return false;
+    }
+
+    if (basePrompt.value.length > 1000) {
+      basePromptError.value = 'Base prompt is too long';
+      return false;
+    }
+
+    return true;
+  };
+
+  return {
+    activeLoras,
+    basePrompt,
+    negativePrompt,
+    basePromptError,
+    finalPrompt,
+    canSave,
+    addToComposition,
+    removeFromComposition,
+    moveUp,
+    moveDown,
+    updateWeight,
+    balanceWeights,
+    duplicateComposition,
+    clearComposition,
+    setBasePrompt,
+    setNegativePrompt,
+    isInComposition,
+    validate,
+  };
+};

--- a/app/frontend/src/composables/prompt-composer/usePromptGenerationActions.ts
+++ b/app/frontend/src/composables/prompt-composer/usePromptGenerationActions.ts
@@ -1,0 +1,69 @@
+import { computed, ref, type ComputedRef, type Ref } from 'vue';
+
+import type { CompositionEntry } from '@/types';
+
+import {
+  createPromptClipboardService,
+  createPromptGenerationService,
+  type PromptClipboardService,
+  type PromptGenerationService,
+} from './services';
+
+interface UsePromptGenerationActionsOptions {
+  finalPrompt: ComputedRef<string>;
+  negativePrompt: Ref<string>;
+  activeLoras: Ref<CompositionEntry[]>;
+  validate: () => boolean;
+  clipboard?: PromptClipboardService;
+  generator?: PromptGenerationService;
+}
+
+export interface PromptGenerationActionsBindings {
+  isGenerating: Ref<boolean>;
+  canGenerate: ComputedRef<boolean>;
+  copyPrompt: () => Promise<boolean>;
+  generateImage: () => Promise<boolean>;
+}
+
+export const usePromptGenerationActions = ({
+  finalPrompt,
+  negativePrompt,
+  activeLoras,
+  validate,
+  clipboard = createPromptClipboardService(),
+  generator = createPromptGenerationService(),
+}: UsePromptGenerationActionsOptions): PromptGenerationActionsBindings => {
+  const isGenerating = ref(false);
+  const canGenerate = computed(() => !isGenerating.value);
+
+  const copyPrompt = async (): Promise<boolean> => {
+    return clipboard.copy(finalPrompt.value || '');
+  };
+
+  const generateImage = async (): Promise<boolean> => {
+    if (!validate()) {
+      return false;
+    }
+
+    isGenerating.value = true;
+
+    try {
+      const success = await generator.trigger({
+        prompt: finalPrompt.value,
+        negativePrompt: negativePrompt.value,
+        loras: activeLoras.value,
+      });
+
+      return success;
+    } finally {
+      isGenerating.value = false;
+    }
+  };
+
+  return {
+    isGenerating,
+    canGenerate,
+    copyPrompt,
+    generateImage,
+  };
+};

--- a/app/frontend/src/composables/usePromptComposition.ts
+++ b/app/frontend/src/composables/usePromptComposition.ts
@@ -1,53 +1,11 @@
-import { computed, onBeforeUnmount, ref, watch, type ComputedRef, type Ref } from 'vue';
+import type { ComputedRef, Ref } from 'vue';
 
-import { PROMPT_COMPOSITION_DEFAULT_WEIGHT } from '@/constants/promptComposer';
-import { copyPromptToClipboard } from '@/utils/promptClipboard';
-import {
-  createPromptCompositionPersistence,
-  parseSavedComposition,
-} from '@/utils/promptCompositionPersistence';
-import { triggerPromptGeneration } from '@/utils/promptGeneration';
-
-import type { AdapterSummary, CompositionEntry, SavedComposition } from '@/types';
+import type { AdapterSummary, CompositionEntry } from '@/types';
 
 import { useAdapterCatalog, type AdapterCatalogApi } from './useAdapterCatalog';
-
-const formatWeightToken = (value: number | string | null | undefined): string => {
-  const parsed = typeof value === 'number' ? value : Number(value);
-  const numeric = Number.isFinite(parsed) ? parsed : PROMPT_COMPOSITION_DEFAULT_WEIGHT;
-  const fixed = numeric.toFixed(2);
-  const trimmed = fixed
-    .replace(/(\.\d*?[1-9])0+$/u, '$1')
-    .replace(/\.0+$/u, '');
-  return trimmed.includes('.') ? trimmed : `${trimmed}.0`;
-};
-
-const buildFinalPrompt = (base: string, items: CompositionEntry[]): string => {
-  const trimmedBase = base.trim();
-
-  if (!trimmedBase) {
-    return '';
-  }
-
-  const tokens = items.map((entry) => `<lora:${entry.name}:${formatWeightToken(entry.weight)}>`);
-  return [trimmedBase, ...tokens].join(' ');
-};
-
-const normaliseWeight = (value: number): number => {
-  if (!Number.isFinite(value)) {
-    return PROMPT_COMPOSITION_DEFAULT_WEIGHT;
-  }
-
-  if (value < 0) {
-    return 0;
-  }
-
-  if (value > 2) {
-    return 2;
-  }
-
-  return value;
-};
+import { usePromptCompositionPersistence } from './prompt-composer/usePromptCompositionPersistence';
+import { usePromptCompositionState } from './prompt-composer/usePromptCompositionState';
+import { usePromptGenerationActions } from './prompt-composer/usePromptGenerationActions';
 
 export interface PromptCompositionState {
   catalog: AdapterCatalogApi;
@@ -81,218 +39,44 @@ export interface PromptCompositionActions {
 
 export const usePromptComposition = (): PromptCompositionState & PromptCompositionActions => {
   const catalog = useAdapterCatalog();
-  const persistence = createPromptCompositionPersistence();
-  const lastSaved = ref<SavedComposition | null>(null);
-  const activeLoras = ref<CompositionEntry[]>([]);
-  const basePrompt = ref('');
-  const negativePrompt = ref('');
-  const basePromptError = ref('');
-  const isGenerating = ref(false);
-
-  const finalPrompt = computed<string>(() => buildFinalPrompt(basePrompt.value, activeLoras.value));
-  const canGenerate = computed<boolean>(() => !isGenerating.value);
-  const canSave = computed<boolean>(() => activeLoras.value.length > 0);
-
-  const setBasePrompt = (value: string) => {
-    basePrompt.value = value;
-  };
-
-  const setNegativePrompt = (value: string) => {
-    negativePrompt.value = value;
-  };
-
-  const isInComposition = (id: AdapterSummary['id']): boolean => {
-    return activeLoras.value.some((entry) => String(entry.id) === String(id));
-  };
-
-  const addToComposition = (lora: AdapterSummary): void => {
-    if (isInComposition(lora.id)) {
-      return;
-    }
-
-    activeLoras.value.push({ id: lora.id, name: lora.name, weight: PROMPT_COMPOSITION_DEFAULT_WEIGHT });
-  };
-
-  const removeFromComposition = (index: number): void => {
-    if (index < 0 || index >= activeLoras.value.length) {
-      return;
-    }
-
-    activeLoras.value.splice(index, 1);
-  };
-
-  const moveUp = (index: number): void => {
-    if (index <= 0 || index >= activeLoras.value.length) {
-      return;
-    }
-
-    const [item] = activeLoras.value.splice(index, 1);
-
-    if (!item) {
-      return;
-    }
-
-    activeLoras.value.splice(index - 1, 0, item);
-  };
-
-  const moveDown = (index: number): void => {
-    if (index < 0 || index >= activeLoras.value.length - 1) {
-      return;
-    }
-
-    const [item] = activeLoras.value.splice(index, 1);
-
-    if (!item) {
-      return;
-    }
-
-    activeLoras.value.splice(index + 1, 0, item);
-  };
-
-  const updateWeight = (index: number, weight: number): void => {
-    if (index < 0 || index >= activeLoras.value.length) {
-      return;
-    }
-
-    activeLoras.value[index].weight = normaliseWeight(weight);
-  };
-
-  const balanceWeights = (): void => {
-    if (activeLoras.value.length === 0) {
-      return;
-    }
-
-    activeLoras.value.forEach((entry) => {
-      entry.weight = PROMPT_COMPOSITION_DEFAULT_WEIGHT;
-    });
-  };
-
-  const duplicateComposition = (): void => {
-    activeLoras.value = activeLoras.value.map((entry) => ({ ...entry }));
-  };
-
-  const clearComposition = (): void => {
-    activeLoras.value = [];
-  };
-
-  const validate = (): boolean => {
-    basePromptError.value = '';
-
-    if (!basePrompt.value.trim()) {
-      basePromptError.value = 'Base prompt is required';
-      return false;
-    }
-
-    if (basePrompt.value.length > 1000) {
-      basePromptError.value = 'Base prompt is too long';
-      return false;
-    }
-
-    return true;
-  };
-
-  const copyPrompt = async (): Promise<boolean> => {
-    return copyPromptToClipboard(finalPrompt.value || '');
-  };
-
-  const persistPayload = (payload: SavedComposition) => {
-    lastSaved.value = payload;
-    persistence.save(payload);
-  };
-
-  const saveComposition = (): void => {
-    const payload: SavedComposition = {
-      items: activeLoras.value.map((entry) => ({ ...entry })),
-      base: basePrompt.value,
-      neg: negativePrompt.value,
-    };
-
-    persistPayload(payload);
-  };
-
-  const loadComposition = (): void => {
-    const payload = persistence.load() ?? lastSaved.value;
-
-    if (!payload) {
-      return;
-    }
-
-    const parsed = parseSavedComposition(payload);
-
-    if (!parsed) {
-      return;
-    }
-
-    activeLoras.value = parsed.items.map((entry) => ({ ...entry }));
-    basePrompt.value = parsed.base;
-    negativePrompt.value = parsed.neg;
-    basePromptError.value = '';
-    lastSaved.value = parsed;
-  };
-
-  const generateImage = async (): Promise<boolean> => {
-    if (!validate()) {
-      return false;
-    }
-
-    isGenerating.value = true;
-
-    try {
-      const success = await triggerPromptGeneration({
-        prompt: finalPrompt.value,
-        negativePrompt: negativePrompt.value,
-        loras: activeLoras.value,
-      });
-
-      return success;
-    } finally {
-      isGenerating.value = false;
-    }
-  };
-
-  watch(
-    [activeLoras, basePrompt, negativePrompt],
-    ([items, base, neg]: [CompositionEntry[], string, string]) => {
-      const payload: SavedComposition = {
-        items: items.map((entry) => ({ ...entry })),
-        base,
-        neg,
-      };
-
-      lastSaved.value = payload;
-      persistence.scheduleSave(payload);
-    },
-    { deep: true },
-  );
-
-  onBeforeUnmount(() => {
-    persistence.cancel();
+  const state = usePromptCompositionState();
+  const persistence = usePromptCompositionPersistence({
+    activeLoras: state.activeLoras,
+    basePrompt: state.basePrompt,
+    negativePrompt: state.negativePrompt,
+    basePromptError: state.basePromptError,
+  });
+  const generation = usePromptGenerationActions({
+    finalPrompt: state.finalPrompt,
+    negativePrompt: state.negativePrompt,
+    activeLoras: state.activeLoras,
+    validate: state.validate,
   });
 
   return {
     catalog,
-    activeLoras,
-    basePrompt,
-    negativePrompt,
-    finalPrompt,
-    basePromptError,
-    isGenerating,
-    canGenerate,
-    canSave,
-    addToComposition,
-    removeFromComposition,
-    moveUp,
-    moveDown,
-    updateWeight,
-    balanceWeights,
-    duplicateComposition,
-    clearComposition,
-    setBasePrompt,
-    setNegativePrompt,
-    copyPrompt,
-    saveComposition,
-    loadComposition,
-    generateImage,
-    isInComposition,
+    activeLoras: state.activeLoras,
+    basePrompt: state.basePrompt,
+    negativePrompt: state.negativePrompt,
+    finalPrompt: state.finalPrompt,
+    basePromptError: state.basePromptError,
+    isGenerating: generation.isGenerating,
+    canGenerate: generation.canGenerate,
+    canSave: state.canSave,
+    addToComposition: state.addToComposition,
+    removeFromComposition: state.removeFromComposition,
+    moveUp: state.moveUp,
+    moveDown: state.moveDown,
+    updateWeight: state.updateWeight,
+    balanceWeights: state.balanceWeights,
+    duplicateComposition: state.duplicateComposition,
+    clearComposition: state.clearComposition,
+    setBasePrompt: state.setBasePrompt,
+    setNegativePrompt: state.setNegativePrompt,
+    copyPrompt: generation.copyPrompt,
+    saveComposition: persistence.saveComposition,
+    loadComposition: persistence.loadComposition,
+    generateImage: generation.generateImage,
+    isInComposition: state.isInComposition,
   };
 };


### PR DESCRIPTION
## Summary
- extract prompt-composer state, persistence, and generation concerns into dedicated composables
- wrap clipboard and generation helpers in injectable services and rework `usePromptComposition` as a thin orchestrator
- refresh PromptComposer unit tests to exercise the new helpers alongside the existing facade

## Testing
- npx vitest run tests/vue/usePromptComposition.spec.ts tests/vue/PromptComposer.spec.js
- npm run lint *(fails: `TypeError: Cannot use 'in' operator to search for 'type' in undefined` within `ImportExport.vue`)*

------
https://chatgpt.com/codex/tasks/task_e_68d297f588548329b2f4bed49892a920