### PR TITLE
Harden configuration validation and share docker env defaults

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,41 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  backend-settings:
+    name: Backend settings validation
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt -r dev-requirements.txt
+      - name: Run pytest
+        run: pytest tests/unit/backend/test_settings.py
+
+  frontend-build:
+    name: Frontend build validation
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: package-lock.json
+      - name: Install dependencies
+        run: npm ci
+      - name: Build frontend
+        run: npm run build

--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ db.sqlite
 data_store.json
 .env
 .env.*
+infrastructure/docker/backend.env.local
 
 # Logs
 *.log

--- a/app/frontend/src/config/runtime.ts
+++ b/app/frontend/src/config/runtime.ts
@@ -1,0 +1,119 @@
+const DEFAULT_BACKEND_BASE = '/api/v1';
+
+interface WindowRuntimeSettings {
+  backendUrl?: string | null;
+  backendApiKey?: string | null;
+}
+
+interface AugmentedWindow extends Window {
+  BACKEND_URL?: string;
+  BACKEND_API_KEY?: string | null;
+  __APP_SETTINGS__?: WindowRuntimeSettings | null;
+}
+
+const sanitizeBasePath = (value?: string | null): string => {
+  if (!value) {
+    return DEFAULT_BACKEND_BASE;
+  }
+
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return DEFAULT_BACKEND_BASE;
+  }
+
+  const withoutTrailing = trimmed.replace(/\/+$/, '');
+  return withoutTrailing || DEFAULT_BACKEND_BASE;
+};
+
+const normalizeApiKey = (value?: string | null): string | null => {
+  if (value == null) {
+    return null;
+  }
+
+  const trimmed = `${value}`.trim();
+  return trimmed.length ? trimmed : null;
+};
+
+const readWindowSettings = (): WindowRuntimeSettings => {
+  if (typeof window === 'undefined') {
+    return {};
+  }
+
+  const win = window as AugmentedWindow;
+  const appSettings = win.__APP_SETTINGS__ ?? null;
+
+  return {
+    backendUrl: appSettings?.backendUrl ?? win.BACKEND_URL ?? null,
+    backendApiKey: appSettings?.backendApiKey ?? win.BACKEND_API_KEY ?? null,
+  };
+};
+
+const readEnvString = (value: unknown): string | undefined => {
+  if (typeof value === 'string') {
+    return value;
+  }
+  return undefined;
+};
+
+const readEnvBoolean = (value: unknown): boolean | undefined => {
+  if (typeof value === 'boolean') {
+    return value;
+  }
+
+  if (typeof value === 'string') {
+    const normalised = value.trim().toLowerCase();
+    if (['1', 'true', 'yes', 'on'].includes(normalised)) {
+      return true;
+    }
+    if (['0', 'false', 'no', 'off'].includes(normalised)) {
+      return false;
+    }
+  }
+
+  return undefined;
+};
+
+const envBackendBase = readEnvString(import.meta.env.VITE_BACKEND_BASE_URL);
+if (envBackendBase !== undefined && !envBackendBase.trim()) {
+  throw new Error(
+    'VITE_BACKEND_BASE_URL is set but empty. Remove it or provide a non-empty value.',
+  );
+}
+
+const envBackendApiKey = readEnvString(import.meta.env.VITE_BACKEND_API_KEY);
+const windowSettings = readWindowSettings();
+
+const backendBasePath = sanitizeBasePath(
+  envBackendBase ?? windowSettings.backendUrl ?? undefined,
+);
+
+const backendApiKey = normalizeApiKey(
+  envBackendApiKey ?? windowSettings.backendApiKey ?? null,
+);
+
+export interface RuntimeConfig {
+  mode: string;
+  isDev: boolean;
+  isProd: boolean;
+  isTest: boolean;
+  backendBasePath: string;
+  backendApiKey: string | null;
+}
+
+const mode =
+  readEnvString(import.meta.env.MODE) ?? (import.meta.env.DEV ? 'development' : 'production');
+const prod = readEnvBoolean(import.meta.env.PROD);
+const dev = readEnvBoolean(import.meta.env.DEV) ?? import.meta.env.DEV ?? false;
+
+export const runtimeConfig: RuntimeConfig = Object.freeze({
+  mode,
+  isDev: Boolean(dev),
+  isProd: typeof prod === 'boolean' ? prod : mode === 'production',
+  isTest: mode === 'test',
+  backendBasePath,
+  backendApiKey,
+}) as RuntimeConfig;
+
+export { DEFAULT_BACKEND_BASE };
+
+export default runtimeConfig;

--- a/app/frontend/src/env.d.ts
+++ b/app/frontend/src/env.d.ts
@@ -1,5 +1,14 @@
 /// <reference types="vite/client" />
 
+interface ImportMetaEnv {
+  readonly VITE_BACKEND_BASE_URL?: string;
+  readonly VITE_BACKEND_API_KEY?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}
+
 declare module '*.vue' {
   import type { DefineComponent } from 'vue';
   const component: DefineComponent<Record<string, unknown>, Record<string, unknown>, any>;

--- a/app/frontend/src/services/historyService.ts
+++ b/app/frontend/src/services/historyService.ts
@@ -2,6 +2,7 @@ import { computed, reactive, unref } from 'vue';
 import type { MaybeRefOrGetter } from 'vue';
 
 import { useApi } from '@/composables/useApi';
+import { DEFAULT_BACKEND_BASE } from '@/config/runtime';
 import { getFilenameFromContentDisposition, requestBlob } from '@/utils/api';
 
 import type {
@@ -18,13 +19,11 @@ import type {
   GenerationRatingUpdate,
 } from '@/types';
 
-const DEFAULT_BASE = '/api/v1';
-
 const sanitizeBaseUrl = (value?: string): string => {
   if (!value) {
-    return DEFAULT_BASE;
+    return DEFAULT_BACKEND_BASE;
   }
-  return value.replace(/\/+$/, '') || DEFAULT_BASE;
+  return value.replace(/\/+$/, '') || DEFAULT_BACKEND_BASE;
 };
 
 const resolveBaseUrl = (value: MaybeRefOrGetter<string>): string => {

--- a/app/frontend/src/services/loraService.ts
+++ b/app/frontend/src/services/loraService.ts
@@ -2,6 +2,7 @@ import { computed, reactive, unref, isRef } from 'vue';
 import type { MaybeRefOrGetter } from 'vue';
 
 import { useApi } from '@/composables/useApi';
+import { DEFAULT_BACKEND_BASE } from '@/config/runtime';
 import { resolveBackendUrl } from '@/utils/backend';
 
 import type {
@@ -18,7 +19,6 @@ import type {
   TopLoraPerformance,
 } from '@/types';
 
-const DEFAULT_BASE = '/api/v1';
 const DEFAULT_ADAPTER_LIST_QUERY: AdapterListQuery = { page: 1, perPage: 100 };
 
 const isBaseUrlInput = (value: unknown): value is MaybeRefOrGetter<string> => {
@@ -31,9 +31,9 @@ const isBaseUrlInput = (value: unknown): value is MaybeRefOrGetter<string> => {
 
 const sanitizeBaseUrl = (value?: string): string => {
   if (!value) {
-    return DEFAULT_BASE;
+    return DEFAULT_BACKEND_BASE;
   }
-  return value.replace(/\/+$/, '') || DEFAULT_BASE;
+  return value.replace(/\/+$/, '') || DEFAULT_BACKEND_BASE;
 };
 
 const resolveBase = (baseUrl: MaybeRefOrGetter<string>) => {

--- a/app/frontend/src/utils/backend.ts
+++ b/app/frontend/src/utils/backend.ts
@@ -1,9 +1,10 @@
 import { computed, unref, type ComputedRef, type MaybeRefOrGetter } from 'vue';
 import { storeToRefs } from 'pinia';
 
+import { runtimeConfig, DEFAULT_BACKEND_BASE } from '@/config/runtime';
 import { useSettingsStore } from '@/stores/settings';
 
-export const DEFAULT_BACKEND_BASE = '/api/v1';
+export { DEFAULT_BACKEND_BASE };
 
 export const trimTrailingSlash = (value: string): string => value.replace(/\/+$/, '');
 
@@ -82,7 +83,7 @@ const resolveMaybeRef = (
 
     return resolved ?? undefined;
   } catch (error) {
-    if (import.meta.env?.DEV) {
+    if (runtimeConfig.isDev) {
       console.warn('Failed to resolve backend override', error);
     }
     return undefined;
@@ -121,7 +122,7 @@ const resolvePathInput = (path: MaybeRefOrGetter<string>): string => {
     const resolved = typeof path === 'function' ? (path as () => string)() : unref(path);
     return typeof resolved === 'string' ? resolved : '';
   } catch (error) {
-    if (import.meta.env?.DEV) {
+    if (runtimeConfig.isDev) {
       console.warn('Failed to resolve backend path', error);
     }
     return '';

--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -1,64 +1,136 @@
 """Configuration settings for the application."""
 
-from typing import List, Optional
+from __future__ import annotations
 
-from pydantic_settings import BaseSettings
+from typing import ClassVar, List, Optional, Sequence
+
+from pydantic import Field, ValidationError, field_validator, model_validator
+from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
 class Settings(BaseSettings):
-    """Manages application settings."""
+    """Manages application settings loaded from the environment."""
+
+    model_config = SettingsConfigDict(env_prefix="", case_sensitive=False, extra="ignore")
+
+    REQUIRED_PRODUCTION_SETTINGS: ClassVar[Sequence[str]] = (
+        "DATABASE_URL",
+        "REDIS_URL",
+        "SDNEXT_BASE_URL",
+    )
+
+    # General environment management
+    ENVIRONMENT: str = "development"
 
     # Database URL (override default sqlite). Example: postgresql+psycopg://user:pw@host:5432/db
     DATABASE_URL: Optional[str] = None
     API_KEY: Optional[str] = None
-    
+
     # Backend API configuration
     BACKEND_HOST: str = "0.0.0.0"
     BACKEND_PORT: int = 8000
     BACKEND_URL: Optional[str] = None  # Full URL override if needed
-    
+
     # Redis URL for worker queue (optional)
     REDIS_URL: Optional[str] = None
-    
+
     # Directory to scan for LoRA files and metadata (inside container)
     IMPORT_PATH: Optional[str] = "/app/loras"
     # Poll interval (seconds) for the importer when running in polling mode
     IMPORT_POLL_SECONDS: int = 10
     # Optional glob-style patterns (relative to IMPORT_PATH) to skip during import
-    IMPORT_IGNORE_PATTERNS: List[str] = []
+    IMPORT_IGNORE_PATTERNS: List[str] = Field(default_factory=list)
     # Importer bootstrap behaviour
     IMPORT_ON_STARTUP: bool = False
     IMPORT_ON_STARTUP_FORCE_RESYNC: bool = False
     IMPORT_ON_STARTUP_DRY_RUN: bool = False
-    
+
     # SDNext Integration Settings
     SDNEXT_BASE_URL: Optional[str] = None  # e.g., "http://localhost:7860"
     SDNEXT_USERNAME: Optional[str] = None  # for --auth mode
-    SDNEXT_PASSWORD: Optional[str] = None  # for --auth mode  
+    SDNEXT_PASSWORD: Optional[str] = None  # for --auth mode
     SDNEXT_TIMEOUT: int = 120  # request timeout in seconds
     SDNEXT_POLL_INTERVAL: int = 2  # polling interval for progress
     SDNEXT_DEFAULT_STEPS: int = 20
     SDNEXT_DEFAULT_SAMPLER: str = "DPM++ 2M"
     SDNEXT_DEFAULT_CFG_SCALE: float = 7.0
     SDNEXT_OUTPUT_DIR: Optional[str] = None  # local storage for generated images
-    
+
     # CORS settings for backend API
-    CORS_ORIGINS: List[str] = [
-        "http://localhost:5173",
-        "http://127.0.0.1:5173",
-        "http://localhost:8782",
-        "http://127.0.0.1:8782",
-        "http://localhost:8000",
-        "http://127.0.0.1:8000",
-    ]
+    CORS_ORIGINS: List[str] = Field(
+        default_factory=lambda: [
+            "http://localhost:5173",
+            "http://127.0.0.1:5173",
+            "http://localhost:8782",
+            "http://127.0.0.1:8782",
+            "http://localhost:8000",
+            "http://127.0.0.1:8000",
+        ]
+    )
     CORS_ALLOW_CREDENTIALS: bool = True
-    
+
+    @field_validator("ENVIRONMENT", mode="before")
+    @classmethod
+    def _normalise_environment(cls, value: str | None) -> str:
+        """Normalise the ENVIRONMENT value and ensure it is supported."""
+
+        if value is None or (isinstance(value, str) and not value.strip()):
+            return "development"
+
+        if not isinstance(value, str):
+            raise TypeError("ENVIRONMENT must be a string")
+
+        normalised = value.strip().lower()
+        if normalised not in {"development", "production", "test"}:
+            raise ValueError("ENVIRONMENT must be one of: development, test, production")
+        return normalised
+
+    @model_validator(mode="after")
+    def _require_production_settings(self) -> "Settings":
+        """Enforce required settings when running in production."""
+
+        if self.ENVIRONMENT != "production":
+            return self
+
+        missing = []
+        for attr in self.REQUIRED_PRODUCTION_SETTINGS:
+            value = getattr(self, attr, None)
+            if value is None:
+                missing.append(attr)
+                continue
+            if isinstance(value, str) and not value.strip():
+                missing.append(attr)
+
+        if missing:
+            joined = ", ".join(sorted(missing))
+            raise ValueError(
+                f"Missing required configuration for production environment: {joined}"
+            )
+
+        return self
+
     @property
     def get_backend_url(self) -> str:
         """Get the backend URL, with automatic construction if not explicitly set."""
         if self.BACKEND_URL:
-            return self.BACKEND_URL.rstrip('/')
+            return self.BACKEND_URL.rstrip("/")
         return f"http://{self.BACKEND_HOST}:{self.BACKEND_PORT}"
 
+    @classmethod
+    def from_env(cls) -> "Settings":
+        """Load settings from the environment, surfacing validation errors."""
 
-settings = Settings()
+        try:
+            return cls()
+        except ValidationError as exc:  # pragma: no cover - defensive re-raise
+            details = []
+            for error in exc.errors():
+                location = "->".join(str(part) for part in error.get("loc", ())) or "?"
+                message = error.get("msg", "Invalid configuration")
+                details.append(f"{location}: {message}")
+
+            error_message = "Invalid application configuration:\n" + "\n".join(details)
+            raise RuntimeError(error_message) from exc
+
+
+settings = Settings.from_env()

--- a/infrastructure/docker/README.md
+++ b/infrastructure/docker/README.md
@@ -112,6 +112,13 @@ Your DeepVault model structure is automatically mounted:
 
 ## 🌍 Environment Variables
 
+### Shared Defaults (`backend.env`)
+
+- The API and worker services both load values from [`backend.env`](./backend.env).
+- Copy this file to `backend.env.local` (kept out of git) to provide custom values, then run `docker compose --env-file backend.env.local ...`.
+- Alternatively override individual settings inline: `SDNEXT_TIMEOUT=300 docker compose up`.
+- The shared file keeps Redis, PostgreSQL, and SDNext configuration in sync across compose variants.
+
 ### Backend Configuration
 - `REDIS_URL` - Redis connection string
 - `DATABASE_URL` - PostgreSQL connection string

--- a/infrastructure/docker/backend.env
+++ b/infrastructure/docker/backend.env
@@ -1,0 +1,12 @@
+# Shared backend environment defaults used by docker-compose services.
+# Copy to backend.env.local and override values as needed for your setup.
+
+REDIS_URL=redis://redis:6379/0
+DATABASE_URL=postgresql+psycopg://postgres:postgres@postgres:5432/lora
+SDNEXT_BASE_URL=http://sdnext:7860
+SDNEXT_TIMEOUT=120
+SDNEXT_POLL_INTERVAL=2
+SDNEXT_DEFAULT_STEPS=20
+SDNEXT_DEFAULT_SAMPLER=DPM++ 2M
+SDNEXT_DEFAULT_CFG_SCALE=7.0
+SDNEXT_OUTPUT_DIR=/app/outputs

--- a/infrastructure/docker/docker-compose.cpu.yml
+++ b/infrastructure/docker/docker-compose.cpu.yml
@@ -59,7 +59,7 @@ services:
       start_period: 240s  # CPU startup is slower
 
   api:
-    build: 
+    build:
       context: ../../
       dockerfile: infrastructure/docker/Dockerfile
     command: uvicorn backend.main:app --host 0.0.0.0 --port 8000 --reload
@@ -70,17 +70,13 @@ services:
       - sdnext_outputs:/app/outputs
     ports:
       - '8782:8000'
+    env_file:
+      - ./backend.env
     environment:
-      REDIS_URL: "redis://redis:6379/0"
-      DATABASE_URL: "postgresql+psycopg://postgres:postgres@postgres:5432/lora"
-      # SDNext integration with longer timeouts for CPU
-      SDNEXT_BASE_URL: "http://sdnext:7860"
       SDNEXT_TIMEOUT: "300"            # Longer timeout for CPU generation
       SDNEXT_POLL_INTERVAL: "5"       # Less frequent polling for CPU
       SDNEXT_DEFAULT_STEPS: "10"      # Fewer steps for faster CPU generation
       SDNEXT_DEFAULT_SAMPLER: "Euler"  # Faster sampler for CPU
-      SDNEXT_DEFAULT_CFG_SCALE: "7.0"
-      SDNEXT_OUTPUT_DIR: "/app/outputs"
       # Development settings
       API_KEY: "dev-api-key-123"
     depends_on:
@@ -98,7 +94,7 @@ services:
       start_period: 30s
 
   worker:
-    build: 
+    build:
       context: ../../
       dockerfile: infrastructure/docker/Dockerfile
     command: sh -c "rq worker --url $$REDIS_URL default"
@@ -107,17 +103,13 @@ services:
       - ../../app:/app/app
       - /home/anxilinux/DeepVault/models/Lora:/app/loras  # Your actual LoRA directory
       - sdnext_outputs:/app/outputs
+    env_file:
+      - ./backend.env
     environment:
-      REDIS_URL: "redis://redis:6379/0"
-      DATABASE_URL: "postgresql+psycopg://postgres:postgres@postgres:5432/lora"
-      # SDNext integration with CPU settings
-      SDNEXT_BASE_URL: "http://sdnext:7860"
       SDNEXT_TIMEOUT: "300"
       SDNEXT_POLL_INTERVAL: "5"
       SDNEXT_DEFAULT_STEPS: "10"
       SDNEXT_DEFAULT_SAMPLER: "Euler"
-      SDNEXT_DEFAULT_CFG_SCALE: "7.0"
-      SDNEXT_OUTPUT_DIR: "/app/outputs"
     depends_on:
       sdnext:
         condition: service_healthy

--- a/infrastructure/docker/docker-compose.gpu.yml
+++ b/infrastructure/docker/docker-compose.gpu.yml
@@ -69,7 +69,7 @@ services:
       start_period: 180s  # GPU initialization takes longer
 
   api:
-    build: 
+    build:
       context: ../../
       dockerfile: infrastructure/docker/Dockerfile
     command: uvicorn backend.main:app --host 0.0.0.0 --port 8000 --reload
@@ -80,17 +80,12 @@ services:
       - sdnext_outputs:/app/outputs   # Access to generated images
     ports:
       - '8782:8000'
+    env_file:
+      - ./backend.env
     environment:
-      REDIS_URL: "redis://redis:6379/0"
-      DATABASE_URL: "postgresql+psycopg://postgres:postgres@postgres:5432/lora"
-      # SDNext integration
-      SDNEXT_BASE_URL: "http://sdnext:7860"
       SDNEXT_TIMEOUT: "180"
       SDNEXT_POLL_INTERVAL: "1"        # Faster polling for development
       SDNEXT_DEFAULT_STEPS: "15"       # Faster generation for testing
-      SDNEXT_DEFAULT_SAMPLER: "DPM++ 2M"
-      SDNEXT_DEFAULT_CFG_SCALE: "7.0"
-      SDNEXT_OUTPUT_DIR: "/app/outputs"
       # Development settings
       API_KEY: "dev-api-key-123"       # Fixed API key for development
     depends_on:
@@ -108,7 +103,7 @@ services:
       start_period: 30s
 
   worker:
-    build: 
+    build:
       context: ../../
       dockerfile: infrastructure/docker/Dockerfile
     command: sh -c "rq worker --url $$REDIS_URL default"
@@ -117,17 +112,12 @@ services:
       - ../../app:/app/app
       - /home/anxilinux/DeepVault/models/Lora:/app/loras  # Your actual LoRA directory
       - sdnext_outputs:/app/outputs
+    env_file:
+      - ./backend.env
     environment:
-      REDIS_URL: "redis://redis:6379/0"
-      DATABASE_URL: "postgresql+psycopg://postgres:postgres@postgres:5432/lora"
-      # SDNext integration
-      SDNEXT_BASE_URL: "http://sdnext:7860"
       SDNEXT_TIMEOUT: "180"
       SDNEXT_POLL_INTERVAL: "1"
       SDNEXT_DEFAULT_STEPS: "15"
-      SDNEXT_DEFAULT_SAMPLER: "DPM++ 2M"
-      SDNEXT_DEFAULT_CFG_SCALE: "7.0"
-      SDNEXT_OUTPUT_DIR: "/app/outputs"
     depends_on:
       sdnext:
         condition: service_healthy

--- a/infrastructure/docker/docker-compose.rocm.yml
+++ b/infrastructure/docker/docker-compose.rocm.yml
@@ -109,20 +109,15 @@ services:
       - sdnext_outputs:/app/outputs   # Access to generated images
     ports:
       - '8782:8000'
+    env_file:
+      - ./backend.env
     environment:
       IMPORT_ON_STARTUP: 'True'
-      REDIS_URL: "redis://redis:6379/0"
-      DATABASE_URL: "postgresql+psycopg://postgres:postgres@postgres:5432/lora"
       # Backend URL for frontend-to-backend communication
       BACKEND_URL: "http://localhost:8782/api/v1"
       # SDNext integration
-      SDNEXT_BASE_URL: "http://sdnext:7860"
       SDNEXT_TIMEOUT: "240"             # Longer timeout for ROCm
       SDNEXT_POLL_INTERVAL: "2"        # Slightly slower polling for ROCm
-      SDNEXT_DEFAULT_STEPS: "20"       # Standard steps for ROCm
-      SDNEXT_DEFAULT_SAMPLER: "DPM++ 2M"
-      SDNEXT_DEFAULT_CFG_SCALE: "7.0"
-      SDNEXT_OUTPUT_DIR: "/app/outputs"
       # Your specific setup
       LORA_DIRECTORY: "/app/loras"
       # Development settings
@@ -151,18 +146,11 @@ services:
       - ../../app:/app/app
       - /home/anxilinux/DeepVault/models/Lora:/app/loras  # Your actual LoRA directory
       - sdnext_outputs:/app/outputs
+    env_file:
+      - ./backend.env
     environment:
-      REDIS_URL: "redis://redis:6379/0"
-      DATABASE_URL: "postgresql+psycopg://postgres:postgres@postgres:5432/lora"
-      # SDNext integration
-      SDNEXT_BASE_URL: "http://sdnext:7860"
       SDNEXT_TIMEOUT: "240"
       SDNEXT_POLL_INTERVAL: "2"
-      SDNEXT_DEFAULT_STEPS: "20"
-      SDNEXT_DEFAULT_SAMPLER: "DPM++ 2M"
-      SDNEXT_DEFAULT_CFG_SCALE: "7.0"
-      SDNEXT_OUTPUT_DIR: "/app/outputs"
-      # Your specific setup
       LORA_DIRECTORY: "/app/loras"
     depends_on:
       sdnext:

--- a/infrastructure/docker/docker-compose.yml
+++ b/infrastructure/docker/docker-compose.yml
@@ -53,7 +53,7 @@ services:
       start_period: 120s  # SDNext takes time to start
 
   api:
-    build: 
+    build:
       context: ../../
       dockerfile: infrastructure/docker/Dockerfile
     command: uvicorn backend.main:app --host 0.0.0.0 --port 8000 --reload
@@ -64,17 +64,8 @@ services:
       - ../../outputs:/app/outputs
     ports:
       - '8782:8000'
-    environment:
-      REDIS_URL: "redis://redis:6379/0"
-      DATABASE_URL: "postgresql+psycopg://postgres:postgres@postgres:5432/lora"
-      # SDNext integration configuration
-      SDNEXT_BASE_URL: "http://sdnext:7860"
-      SDNEXT_TIMEOUT: "120"
-      SDNEXT_POLL_INTERVAL: "2"
-      SDNEXT_DEFAULT_STEPS: "20"
-      SDNEXT_DEFAULT_SAMPLER: "DPM++ 2M"
-      SDNEXT_DEFAULT_CFG_SCALE: "7.0"
-      SDNEXT_OUTPUT_DIR: "/app/outputs"
+    env_file:
+      - ./backend.env
     depends_on:
       - redis
       - postgres
@@ -87,7 +78,7 @@ services:
       start_period: 30s
 
   worker:
-    build: 
+    build:
       context: ../../
       dockerfile: infrastructure/docker/Dockerfile
     command: sh -c "rq worker --url $$REDIS_URL default"
@@ -96,17 +87,8 @@ services:
       - ../../app:/app/app
       - ../../loras:/app/loras
       - ../../outputs:/app/outputs
-    environment:
-      REDIS_URL: "redis://redis:6379/0"
-      DATABASE_URL: "postgresql+psycopg://postgres:postgres@postgres:5432/lora"
-      # SDNext integration configuration for worker
-      SDNEXT_BASE_URL: "http://sdnext:7860"
-      SDNEXT_TIMEOUT: "120"
-      SDNEXT_POLL_INTERVAL: "2"
-      SDNEXT_DEFAULT_STEPS: "20"
-      SDNEXT_DEFAULT_SAMPLER: "DPM++ 2M"
-      SDNEXT_DEFAULT_CFG_SCALE: "7.0"
-      SDNEXT_OUTPUT_DIR: "/app/outputs"
+    env_file:
+      - ./backend.env
     depends_on:
       - redis
       - postgres

--- a/tests/unit/backend/test_settings.py
+++ b/tests/unit/backend/test_settings.py
@@ -1,0 +1,59 @@
+import pytest
+
+from backend.core.config import Settings
+
+
+@pytest.fixture(autouse=True)
+def reset_core_env(monkeypatch):
+    """Ensure core settings are reset between tests."""
+
+    for key in ('ENVIRONMENT', 'DATABASE_URL', 'REDIS_URL', 'SDNEXT_BASE_URL'):
+        monkeypatch.delenv(key, raising=False)
+
+
+def test_from_env_defaults_in_development(monkeypatch):
+    monkeypatch.setenv('ENVIRONMENT', 'development')
+
+    settings = Settings.from_env()
+
+    assert settings.ENVIRONMENT == 'development'
+    assert settings.DATABASE_URL is None
+    assert settings.REDIS_URL is None
+
+
+def test_production_requires_core_settings(monkeypatch):
+    monkeypatch.setenv('ENVIRONMENT', 'production')
+
+    with pytest.raises(RuntimeError) as exc:
+        Settings.from_env()
+
+    message = str(exc.value)
+    assert 'DATABASE_URL' in message
+    assert 'REDIS_URL' in message
+    assert 'SDNEXT_BASE_URL' in message
+
+
+def test_production_accepts_populated_settings(monkeypatch):
+    monkeypatch.setenv('ENVIRONMENT', ' Production ')
+    monkeypatch.setenv('DATABASE_URL', 'postgresql://user:pass@postgres:5432/lora')
+    monkeypatch.setenv('REDIS_URL', 'redis://redis:6379/0')
+    monkeypatch.setenv('SDNEXT_BASE_URL', 'http://sdnext:7860')
+
+    settings = Settings.from_env()
+
+    assert settings.ENVIRONMENT == 'production'
+    assert settings.DATABASE_URL == 'postgresql://user:pass@postgres:5432/lora'
+    assert settings.REDIS_URL == 'redis://redis:6379/0'
+    assert settings.SDNEXT_BASE_URL == 'http://sdnext:7860'
+
+
+def test_from_env_raises_runtime_error(monkeypatch):
+    monkeypatch.setenv('ENVIRONMENT', 'production')
+    monkeypatch.setenv('DATABASE_URL', 'sqlite:///tmp.db')
+    monkeypatch.setenv('REDIS_URL', 'redis://redis:6379/0')
+    monkeypatch.setenv('SDNEXT_BASE_URL', ' ')
+
+    with pytest.raises(RuntimeError) as exc:
+        Settings.from_env()
+
+    assert 'SDNEXT_BASE_URL' in str(exc.value)


### PR DESCRIPTION
## Summary
- add stricter backend Settings validation with a production guard and from_env loader
- add a runtime configuration module for the frontend and reuse shared backend defaults
- consolidate docker compose environment defaults and add CI checks for settings and the Vite build

## Testing
- pytest tests/unit/backend/test_settings.py
- npm run build *(fails: existing TypeScript type errors in ImportExport workflow components)*

------
https://chatgpt.com/codex/tasks/task_e_68d2981914088329a72cbedbb7ff3304