### PR TITLE
Refactor service facades and update dependencies

### DIFF
--- a/backend/api/v1/analytics.py
+++ b/backend/api/v1/analytics.py
@@ -6,7 +6,7 @@ from typing import List
 
 from fastapi import APIRouter, Depends, Query
 
-from backend.core.dependencies import get_service_container
+from backend.core.dependencies import get_domain_services
 from backend.schemas.analytics import (
     ErrorAnalysisEntry,
     PerformanceAnalyticsCharts,
@@ -15,7 +15,7 @@ from backend.schemas.analytics import (
     PerformanceKpiSummary,
     PerformanceTimeRange,
 )
-from backend.services import ServiceRegistry
+from backend.services import DomainServices
 
 
 router = APIRouter(prefix="/analytics", tags=["analytics"])
@@ -24,7 +24,7 @@ router = APIRouter(prefix="/analytics", tags=["analytics"])
 @router.get("/summary", response_model=PerformanceAnalyticsSummary)
 def get_analytics_summary(
     time_range: PerformanceTimeRange = Query("24h"),
-    services: ServiceRegistry = Depends(get_service_container),
+    services: DomainServices = Depends(get_domain_services),
 ) -> PerformanceAnalyticsSummary:
     """Return a comprehensive analytics snapshot for the requested range."""
 
@@ -34,7 +34,7 @@ def get_analytics_summary(
 @router.get("/stats", response_model=PerformanceKpiSummary)
 def get_generation_stats(
     time_range: PerformanceTimeRange = Query("24h"),
-    services: ServiceRegistry = Depends(get_service_container),
+    services: DomainServices = Depends(get_domain_services),
 ) -> PerformanceKpiSummary:
     """Expose headline generation KPIs for the requested range."""
 
@@ -44,7 +44,7 @@ def get_generation_stats(
 @router.get("/errors", response_model=List[ErrorAnalysisEntry])
 def get_error_breakdown(
     time_range: PerformanceTimeRange = Query("24h"),
-    services: ServiceRegistry = Depends(get_service_container),
+    services: DomainServices = Depends(get_domain_services),
 ) -> List[ErrorAnalysisEntry]:
     """Return error distribution for failed generation jobs."""
 
@@ -54,7 +54,7 @@ def get_error_breakdown(
 @router.get("/timeseries", response_model=PerformanceAnalyticsCharts)
 def get_time_series_metrics(
     time_range: PerformanceTimeRange = Query("24h"),
-    services: ServiceRegistry = Depends(get_service_container),
+    services: DomainServices = Depends(get_domain_services),
 ) -> PerformanceAnalyticsCharts:
     """Return time-series metrics for dashboard visualisations."""
 
@@ -64,7 +64,7 @@ def get_time_series_metrics(
 @router.get("/insights", response_model=List[PerformanceInsightEntry])
 def get_performance_insights(
     time_range: PerformanceTimeRange = Query("24h"),
-    services: ServiceRegistry = Depends(get_service_container),
+    services: DomainServices = Depends(get_domain_services),
 ) -> List[PerformanceInsightEntry]:
     """Return derived performance insights for the requested window."""
 

--- a/backend/api/v1/deliveries.py
+++ b/backend/api/v1/deliveries.py
@@ -2,14 +2,14 @@
 
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException
 
-from backend.core.dependencies import get_service_container
+from backend.core.dependencies import get_application_services
 from backend.schemas import (
     DeliveryCreate,
     DeliveryCreateResponse,
     DeliveryRead,
     DeliveryWrapper,
 )
-from backend.services import ServiceRegistry
+from backend.services import ApplicationServices
 
 router = APIRouter()
 
@@ -18,7 +18,7 @@ router = APIRouter()
 async def create_delivery(
     delivery: DeliveryCreate,
     background_tasks: BackgroundTasks,
-    services: ServiceRegistry = Depends(get_service_container),
+    services: ApplicationServices = Depends(get_application_services),
 ):
     """Create a delivery job and either enqueue it or schedule a background task."""
     job = services.deliveries.schedule_job(
@@ -34,7 +34,7 @@ async def create_delivery(
 @router.get("/deliveries/{delivery_id}", response_model=DeliveryWrapper)
 def get_delivery(
     delivery_id: str,
-    services: ServiceRegistry = Depends(get_service_container),
+    services: ApplicationServices = Depends(get_application_services),
 ):
     """Return the delivery job state for `delivery_id`."""
     dj = services.deliveries.get_job(delivery_id)

--- a/backend/api/v1/system.py
+++ b/backend/api/v1/system.py
@@ -6,15 +6,17 @@ from typing import Any, Dict
 
 from fastapi import APIRouter, Depends
 
-from backend.core.dependencies import get_service_container
-from backend.services import ServiceRegistry
+from backend.core.dependencies import get_application_services
+from backend.services import ApplicationServices
 
 
 router = APIRouter(prefix="/system", tags=["system"])
 
 
 @router.get("/status")
-async def get_system_status(services: ServiceRegistry = Depends(get_service_container)) -> Dict[str, Any]:
+async def get_system_status(
+    services: ApplicationServices = Depends(get_application_services),
+) -> Dict[str, Any]:
     """Return a snapshot of system status and telemetry data."""
 
     return services.system.get_system_status_payload()

--- a/backend/api/v1/websocket.py
+++ b/backend/api/v1/websocket.py
@@ -10,8 +10,8 @@ versioning is also provided by ``backend.main`` so older clients that still use
 
 from fastapi import APIRouter, Depends, WebSocket
 
-from backend.core.dependencies import get_service_container
-from backend.services import ServiceRegistry
+from backend.core.dependencies import get_application_services
+from backend.services import ApplicationServices
 
 router = APIRouter()
 
@@ -22,7 +22,7 @@ PROGRESS_WEBSOCKET_ROUTE = "/ws/progress"
 @router.websocket(PROGRESS_WEBSOCKET_ROUTE)
 async def websocket_progress_endpoint(
     websocket: WebSocket,
-    container: ServiceRegistry = Depends(get_service_container),
+    container: ApplicationServices = Depends(get_application_services),
 ):
     """WebSocket endpoint for real-time generation progress monitoring.
     

--- a/backend/core/dependencies.py
+++ b/backend/core/dependencies.py
@@ -4,12 +4,13 @@ from fastapi import Depends
 from sqlmodel import Session
 
 from backend.core.database import get_session
-from backend.services import ServiceRegistry, get_service_container_builder
-from backend.services.adapters import AdapterService
-from backend.services.composition import ComposeService
-from backend.services.deliveries import DeliveryService
-from backend.services.archive import ArchiveService, BackupService
-from backend.services.recommendations import RecommendationService
+from backend.services import (
+    ApplicationServices,
+    CoreServices,
+    DomainServices,
+    ServiceRegistry,
+    get_service_container_builder,
+)
 
 _BUILDER = get_service_container_builder()
 
@@ -22,43 +23,25 @@ def get_service_container(
     return _BUILDER.build(db_session)
 
 
-def get_adapter_service(
+def get_core_services(
     container: ServiceRegistry = Depends(get_service_container),  # noqa: B008 - FastAPI DI
-) -> AdapterService:
-    """Return an AdapterService instance."""
-    return container.adapters
+) -> CoreServices:
+    """Return the core service facade."""
+
+    return container.core
 
 
-def get_delivery_service(
+def get_domain_services(
     container: ServiceRegistry = Depends(get_service_container),  # noqa: B008 - FastAPI DI
-) -> DeliveryService:
-    """Return a DeliveryService instance."""
-    return container.deliveries
+) -> DomainServices:
+    """Return the domain service facade."""
+
+    return container.domain
 
 
-def get_compose_service() -> ComposeService:
-    """Get an instance of the ComposeService."""
-    return _BUILDER.build(None).compose
-
-
-def get_recommendation_service(
+def get_application_services(
     container: ServiceRegistry = Depends(get_service_container),  # noqa: B008 - FastAPI DI
-) -> RecommendationService:
-    """Return a RecommendationService instance."""
-    return container.recommendations
+) -> ApplicationServices:
+    """Return the application service facade."""
 
-
-def get_archive_service(
-    container: ServiceRegistry = Depends(get_service_container),  # noqa: B008 - FastAPI DI
-) -> ArchiveService:
-    """Return the archive helper service."""
-
-    return container.archive
-
-
-def get_backup_service(
-    container: ServiceRegistry = Depends(get_service_container),  # noqa: B008 - FastAPI DI
-) -> BackupService:
-    """Return the backup service instance."""
-
-    return container.backups
+    return container.application

--- a/backend/services/service_registry.py
+++ b/backend/services/service_registry.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
+from typing import Optional
+
 from .adapters import AdapterService
 from .analytics import AnalyticsService
 from .archive import ArchiveService, BackupService
@@ -15,6 +18,80 @@ from .system import SystemService
 from .websocket import WebSocketService
 
 
+@dataclass(frozen=True)
+class CoreServices:
+    """Type-safe facade exposing core tier services."""
+
+    _registry: CoreServiceRegistry
+
+    @property
+    def storage(self) -> StorageService:
+        """Return the shared storage service."""
+
+        return self._registry.storage
+
+
+@dataclass(frozen=True)
+class DomainServices:
+    """Facade exposing domain service dependencies."""
+
+    _registry: DomainServiceRegistry
+
+    @property
+    def adapters(self) -> AdapterService:
+        return self._registry.adapters
+
+    @property
+    def compose(self) -> ComposeService:
+        return self._registry.compose
+
+    @property
+    def generation(self) -> GenerationService:
+        return self._registry.generation
+
+    @property
+    def analytics(self) -> AnalyticsService:
+        return self._registry.analytics
+
+    @property
+    def recommendations(self) -> RecommendationService:
+        return self._registry.recommendations
+
+
+@dataclass(frozen=True)
+class ApplicationServices:
+    """Facade exposing application tier services."""
+
+    _registry: InfrastructureServiceRegistry
+    _generation_coordinator_override: Optional[GenerationCoordinator] = None
+
+    @property
+    def archive(self) -> ArchiveService:
+        return self._registry.archive
+
+    @property
+    def backups(self) -> BackupService:
+        return self._registry.backups
+
+    @property
+    def deliveries(self) -> DeliveryService:
+        return self._registry.deliveries
+
+    @property
+    def generation_coordinator(self) -> GenerationCoordinator:
+        if self._generation_coordinator_override is not None:
+            return self._generation_coordinator_override
+        return self._registry.generation_coordinator
+
+    @property
+    def websocket(self) -> WebSocketService:
+        return self._registry.websocket
+
+    @property
+    def system(self) -> SystemService:
+        return self._registry.system
+
+
 class ServiceRegistry:
     """Facade exposing lazily constructed services from dedicated registries."""
 
@@ -24,81 +101,96 @@ class ServiceRegistry:
         domain: DomainServiceRegistry,
         infrastructure: InfrastructureServiceRegistry,
     ) -> None:
-        self._core = core
-        self._domain = domain
-        self._infrastructure = infrastructure
+        self._core_registry = core
+        self._domain_registry = domain
+        self._infrastructure_registry = infrastructure
+
+        self._core_services = CoreServices(core)
+        self._domain_services = DomainServices(domain)
+        self._application_services = ApplicationServices(infrastructure)
 
     @property
-    def core(self) -> CoreServiceRegistry:
-        """Return the underlying core registry."""
+    def core(self) -> CoreServices:
+        """Return the core service facade."""
 
-        return self._core
-
-    @property
-    def domain(self) -> DomainServiceRegistry:
-        """Return the underlying domain registry."""
-
-        return self._domain
+        return self._core_services
 
     @property
-    def infrastructure(self) -> InfrastructureServiceRegistry:
-        """Return the underlying infrastructure registry."""
+    def domain(self) -> DomainServices:
+        """Return the domain service facade."""
 
-        return self._infrastructure
+        return self._domain_services
+
+    @property
+    def application(self) -> ApplicationServices:
+        """Return the application service facade."""
+
+        return self._application_services
+
+    @property
+    def infrastructure(self) -> ApplicationServices:
+        """Backward compatible alias for application services."""
+
+        return self._application_services
 
     @property
     def db_session(self):
         """Expose the database session associated with the registries."""
 
-        return self._core.db_session
+        return self._core_registry.db_session
 
     @property
     def storage(self) -> StorageService:
-        return self._core.storage
+        return self.core.storage
 
     @property
     def adapters(self) -> AdapterService:
-        return self._domain.adapters
+        return self.domain.adapters
 
     @property
     def archive(self) -> ArchiveService:
-        return self._infrastructure.archive
+        return self.application.archive
 
     @property
     def backups(self) -> BackupService:
-        return self._infrastructure.backups
+        return self.application.backups
 
     @property
     def deliveries(self) -> DeliveryService:
-        return self._infrastructure.deliveries
+        return self.application.deliveries
 
     @property
     def compose(self) -> ComposeService:
-        return self._domain.compose
+        return self.domain.compose
 
     @property
     def generation(self) -> GenerationService:
-        return self._domain.generation
+        return self.domain.generation
 
     @property
     def generation_coordinator(self) -> GenerationCoordinator:
-        return self._infrastructure.generation_coordinator
+        return self.application.generation_coordinator
 
     @property
     def websocket(self) -> WebSocketService:
-        return self._infrastructure.websocket
+        return self.application.websocket
 
     @property
     def system(self) -> SystemService:
-        return self._infrastructure.system
+        return self.application.system
 
     @property
     def analytics(self) -> AnalyticsService:
-        return self._domain.analytics
+        return self.domain.analytics
 
     @property
     def recommendations(self) -> RecommendationService:
-        return self._domain.recommendations
+        return self.domain.recommendations
 
 
-__all__ = ["ServiceRegistry"]
+__all__ = [
+    "ApplicationServices",
+    "CoreServices",
+    "DomainServices",
+    "ServiceRegistry",
+]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -56,11 +56,6 @@ def mock_storage_fixture(monkeypatch) -> MagicMock:
     builder = get_service_container_builder()
 
     monkeypatch.setattr(builder, "_storage_provider", lambda: mock_storage_service)
-
-    def mock_storage_property(self):
-        return mock_storage_service
-
-    monkeypatch.setattr(ServiceContainer, "storage", property(mock_storage_property))
     
     mock.storage_service = mock_storage_service
     return mock
@@ -109,7 +104,7 @@ def adapter_service(db_session: Session, mock_storage) -> AdapterService:
         recommendation_gpu_available=False,
         storage_provider=lambda: mock_storage.storage_service,
     )
-    return container.adapters
+    return container.domain.adapters
 
 
 @pytest.fixture
@@ -123,7 +118,7 @@ def delivery_service(db_session: Session, mock_storage) -> DeliveryService:
         recommendation_gpu_available=False,
         storage_provider=lambda: mock_storage.storage_service,
     )
-    return container.deliveries
+    return container.application.deliveries
 
 
 @pytest.fixture

--- a/tests/test_queue_configuration.py
+++ b/tests/test_queue_configuration.py
@@ -35,7 +35,7 @@ def test_queue_factory_shared_backend_with_redis(db_session) -> None:
             analytics_repository=AnalyticsRepository(db_session),
             recommendation_gpu_available=False,
         )
-        deliveries_service = container.deliveries
+        deliveries_service = container.application.deliveries
 
         assert deliveries_service.queue_orchestrator is orchestrator
         assert context.queue_orchestrator is orchestrator
@@ -72,7 +72,7 @@ def test_queue_factory_shared_backend_without_redis(db_session) -> None:
             analytics_repository=AnalyticsRepository(db_session),
             recommendation_gpu_available=False,
         )
-        deliveries_service = container.deliveries
+        deliveries_service = container.application.deliveries
 
         assert deliveries_service.queue_orchestrator is orchestrator
         assert context.queue_orchestrator is orchestrator


### PR DESCRIPTION
## Summary
- add CoreServices, DomainServices, and ApplicationServices facades and compose ServiceContainer around the aggregated registries
- rework API dependencies to consume the new facades and drop legacy helper functions
- update importer and tests to build services through the container and refreshed fixtures

## Testing
- pytest tests

------
https://chatgpt.com/codex/tasks/task_e_68d296ceac748329ad0ecdc74ea06dba