### PR TITLE
Refactor service providers into typed domain modules

### DIFF
--- a/backend/services/core_container.py
+++ b/backend/services/core_container.py
@@ -6,7 +6,7 @@ from sqlmodel import Session
 
 from .analytics_repository import AnalyticsRepository
 from .delivery_repository import DeliveryJobRepository
-from .providers import make_storage_service
+from .providers.storage import StorageServiceFactory, make_storage_service
 from .storage import StorageService
 
 
@@ -17,7 +17,7 @@ class CoreServiceRegistry:
         self,
         db_session: Optional[Session],
         *,
-        storage_provider: Callable[[], StorageService] = make_storage_service,
+        storage_provider: StorageServiceFactory = make_storage_service,
         delivery_repository: Optional[DeliveryJobRepository] = None,
         analytics_repository: Optional[AnalyticsRepository] = None,
     ) -> None:

--- a/backend/services/domain_container.py
+++ b/backend/services/domain_container.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Callable, Optional
+from typing import Optional
 
 from sqlmodel import Session
 
@@ -10,13 +10,18 @@ from .analytics_repository import AnalyticsRepository
 from .composition import ComposeService
 from .core_container import CoreServiceRegistry
 from .generation import GenerationService
-from .providers import (
-    make_adapter_service,
-    make_analytics_service,
+from .providers.analytics import AnalyticsServiceFactory, make_analytics_service
+from .providers.generation import (
+    ComposeServiceFactory,
+    GenerationServiceFactory,
     make_compose_service,
     make_generation_service,
+)
+from .providers.recommendations import (
+    RecommendationServiceFactory,
     make_recommendation_service,
 )
+from .providers.storage import AdapterServiceFactory, make_adapter_service
 from .recommendations import RecommendationService
 
 
@@ -29,11 +34,11 @@ class DomainServiceRegistry:
         *,
         db_session: Optional[Session],
         analytics_repository: Optional[AnalyticsRepository],
-        adapter_provider: Callable[..., AdapterService] = make_adapter_service,
-        compose_provider: Callable[[], ComposeService] = make_compose_service,
-        generation_provider: Callable[[], GenerationService] = make_generation_service,
-        analytics_provider: Callable[..., AnalyticsService] = make_analytics_service,
-        recommendation_provider: Callable[..., RecommendationService] = make_recommendation_service,
+        adapter_provider: AdapterServiceFactory = make_adapter_service,
+        compose_provider: ComposeServiceFactory = make_compose_service,
+        generation_provider: GenerationServiceFactory = make_generation_service,
+        analytics_provider: AnalyticsServiceFactory = make_analytics_service,
+        recommendation_provider: RecommendationServiceFactory = make_recommendation_service,
         recommendation_gpu_available: Optional[bool] = None,
     ) -> None:
         self._core = core

--- a/backend/services/infra_container.py
+++ b/backend/services/infra_container.py
@@ -1,22 +1,26 @@
 from __future__ import annotations
 
-from typing import Callable, Optional
+from typing import Optional
 
 from .archive import ArchiveService, BackupService
 from .core_container import CoreServiceRegistry
 from .deliveries import DeliveryService
 from .domain_container import DomainServiceRegistry
 from .generation import GenerationCoordinator
-from .providers import (
-    make_archive_service,
-    make_delivery_service,
+from .providers.archive import ArchiveServiceFactory, make_archive_service
+from .providers.deliveries import DeliveryServiceFactory, make_delivery_service
+from .providers.generation import (
+    GenerationCoordinatorFactory,
     make_generation_coordinator,
-    make_system_service,
-    make_websocket_service,
+)
+from .providers.system import SystemServiceFactory, make_system_service
+from .providers.websocket import (
+    WebSocketServiceFactory,
+    default_websocket_service_factory,
 )
 from .queue import QueueOrchestrator
 from .system import SystemService
-from .websocket import WebSocketService, websocket_service
+from .websocket import WebSocketService
 
 
 class InfrastructureServiceRegistry:
@@ -28,11 +32,11 @@ class InfrastructureServiceRegistry:
         domain: DomainServiceRegistry,
         *,
         queue_orchestrator: Optional[QueueOrchestrator],
-        archive_provider: Callable[..., ArchiveService] = make_archive_service,
-        delivery_provider: Callable[..., DeliveryService] = make_delivery_service,
-        generation_coordinator_provider: Callable[..., GenerationCoordinator] = make_generation_coordinator,
-        websocket_provider: Optional[Callable[[], WebSocketService]] = None,
-        system_provider: Callable[[DeliveryService], SystemService] = make_system_service,
+        archive_provider: ArchiveServiceFactory = make_archive_service,
+        delivery_provider: DeliveryServiceFactory = make_delivery_service,
+        generation_coordinator_provider: GenerationCoordinatorFactory = make_generation_coordinator,
+        websocket_provider: Optional[WebSocketServiceFactory] = None,
+        system_provider: SystemServiceFactory = make_system_service,
     ) -> None:
         self._core = core
         self._domain = domain
@@ -43,7 +47,7 @@ class InfrastructureServiceRegistry:
         self._websocket_provider = (
             websocket_provider
             if websocket_provider is not None
-            else (lambda: make_websocket_service(service=websocket_service))
+            else default_websocket_service_factory
         )
         self._system_provider = system_provider
 

--- a/backend/services/providers/__init__.py
+++ b/backend/services/providers/__init__.py
@@ -1,247 +1,66 @@
-"""Factory helpers for constructing service instances with explicit dependencies."""
+"""Typed service provider interfaces grouped by domain."""
 
-from __future__ import annotations
-
-from typing import Optional
-
-from sqlmodel import Session
-
-from backend.services.adapters import AdapterService
-from backend.services.analytics import AnalyticsService, InsightGenerator, TimeSeriesBuilder
-from backend.services.analytics_repository import AnalyticsRepository
-from backend.services.archive import ArchiveExportPlanner, ArchiveImportExecutor, ArchiveService
-from backend.services.composition import ComposeService
-from backend.services.deliveries import DeliveryService
-from backend.services.delivery_repository import DeliveryJobRepository
-from backend.services.generation import GenerationCoordinator, GenerationService
-from backend.services.queue import QueueOrchestrator
-from backend.services.recommendations import (
-    EmbeddingCoordinator,
-    EmbeddingManager,
-    EmbeddingStack,
-    FeedbackManager,
-    LoRAEmbeddingRepository,
-    PersistenceComponents,
-    RecommendationConfig,
-    RecommendationMetricsTracker,
-    RecommendationModelBootstrap,
-    RecommendationPersistenceManager,
-    RecommendationPersistenceService,
-    RecommendationRepository,
-    RecommendationService,
-    RecommendationServiceBuilder,
-    SimilarLoraUseCase,
-    StatsReporter,
-    PromptRecommendationUseCase,
-    UseCaseBundle,
-    build_embedding_stack,
-    build_persistence_components,
-    build_use_cases,
+from .analytics import (
+    AnalyticsProviders,
+    AnalyticsServiceFactory,
+    make_analytics_service,
 )
-from backend.services.storage import StorageBackend, StorageService, get_storage_backend
-from backend.services.system import SystemService
-from backend.services.websocket import WebSocketService
-
-
-def make_storage_service(*, backend: Optional[StorageBackend] = None) -> StorageService:
-    """Create a :class:`StorageService` using the provided backend."""
-
-    backend = backend or get_storage_backend()
-    return StorageService(backend)
-
-
-def make_adapter_service(
-    *,
-    db_session: Session,
-    storage_service: StorageService,
-    storage_backend: Optional[StorageBackend] = None,
-) -> AdapterService:
-    """Create an :class:`AdapterService` with explicit collaborators."""
-
-    backend = storage_backend or storage_service.backend
-    return AdapterService(db_session, storage_backend=backend)
-
-
-def make_archive_service(
-    adapter_service: AdapterService,
-    storage_service: StorageService,
-    *,
-    planner: Optional[ArchiveExportPlanner] = None,
-    executor: Optional[ArchiveImportExecutor] = None,
-    chunk_size: int = 64 * 1024,
-    spooled_file_max_size: int = 32 * 1024 * 1024,
-) -> ArchiveService:
-    """Create an :class:`ArchiveService` wired with planner and executor collaborators."""
-
-    return ArchiveService(
-        adapter_service,
-        storage_service,
-        planner=planner,
-        executor=executor,
-        chunk_size=chunk_size,
-        spooled_file_max_size=spooled_file_max_size,
-    )
-
-
-def make_delivery_service(
-    repository: DeliveryJobRepository,
-    *,
-    queue_orchestrator: QueueOrchestrator,
-) -> DeliveryService:
-    """Create a :class:`DeliveryService` with explicit repository and queue orchestrator."""
-
-    return DeliveryService(repository, queue_orchestrator=queue_orchestrator)
-
-
-def make_compose_service() -> ComposeService:
-    """Create a :class:`ComposeService`."""
-
-    return ComposeService()
-
-
-def make_generation_service() -> GenerationService:
-    """Create a :class:`GenerationService`."""
-
-    return GenerationService()
-
-
-def make_generation_coordinator(
-    delivery_service: DeliveryService,
-    websocket_service: WebSocketService,
-    generation_service: GenerationService,
-) -> GenerationCoordinator:
-    """Create a :class:`GenerationCoordinator` with its collaborators."""
-
-    return GenerationCoordinator(delivery_service, websocket_service, generation_service)
-
-
-def make_websocket_service(
-    *,
-    service: Optional[WebSocketService] = None,
-    connection_manager=None,
-    job_monitor=None,
-) -> WebSocketService:
-    """Create or return a :class:`WebSocketService` configured with explicit collaborators."""
-
-    if service is not None:
-        return service
-    return WebSocketService(connection_manager=connection_manager, job_monitor=job_monitor)
-
-
-def make_system_service(delivery_service: DeliveryService) -> SystemService:
-    """Create a :class:`SystemService` bound to the delivery service."""
-
-    return SystemService(delivery_service)
-
-
-def make_analytics_service(
-    db_session: Session,
-    *,
-    repository: AnalyticsRepository,
-    time_series_builder: Optional[TimeSeriesBuilder] = None,
-    insight_generator: Optional[InsightGenerator] = None,
-) -> AnalyticsService:
-    """Create an :class:`AnalyticsService` with explicit collaborators."""
-
-    return AnalyticsService(
-        db_session,
-        repository=repository,
-        time_series_builder=time_series_builder or TimeSeriesBuilder(),
-        insight_generator=insight_generator or InsightGenerator(),
-    )
-
-
-def make_recommendation_service(
-    db_session: Session,
-    *,
-    gpu_available: bool,
-    model_bootstrap: Optional[RecommendationModelBootstrap] = None,
-    embedding_repository: Optional[LoRAEmbeddingRepository] = None,
-    embedding_manager: Optional[EmbeddingManager] = None,
-    embedding_stack: Optional[EmbeddingStack] = None,
-    repository: Optional[RecommendationRepository] = None,
-    persistence_manager: Optional[RecommendationPersistenceManager] = None,
-    persistence_service: Optional[RecommendationPersistenceService] = None,
-    persistence_components: Optional[PersistenceComponents] = None,
-    metrics_tracker: Optional[RecommendationMetricsTracker] = None,
-    config: Optional[RecommendationConfig] = None,
-    similar_use_case: Optional[SimilarLoraUseCase] = None,
-    prompt_use_case: Optional[PromptRecommendationUseCase] = None,
-    use_case_bundle: Optional[UseCaseBundle] = None,
-    embedding_coordinator: Optional[EmbeddingCoordinator] = None,
-    feedback_manager: Optional[FeedbackManager] = None,
-    stats_reporter: Optional[StatsReporter] = None,
-    builder: Optional[RecommendationServiceBuilder] = None,
-) -> RecommendationService:
-    """Create a :class:`RecommendationService` wired with explicit collaborators."""
-
-    bootstrap = model_bootstrap or RecommendationModelBootstrap(gpu_enabled=gpu_available)
-    model_registry = bootstrap.get_model_registry()
-
-    repository = repository or RecommendationRepository(db_session)
-
-    if embedding_stack is None:
-        embedding_stack = build_embedding_stack(
-            db_session=db_session,
-            model_registry=model_registry,
-            embedding_repository=embedding_repository,
-            embedding_manager=embedding_manager,
-        )
-    embedding_repository = embedding_stack.repository
-    embedding_manager = embedding_stack.manager
-
-    if persistence_components is None:
-        persistence_components = build_persistence_components(
-            embedding_manager=embedding_manager,
-            model_registry=model_registry,
-            persistence_manager=persistence_manager,
-            persistence_service=persistence_service,
-            config=config,
-        )
-    persistence_manager = persistence_components.manager
-    persistence_service = persistence_components.service
-    config = persistence_components.config
-
-    metrics_tracker = metrics_tracker or RecommendationMetricsTracker()
-
-    if use_case_bundle is None:
-        use_case_bundle = build_use_cases(
-            repository=repository,
-            embedding_workflow=embedding_manager,
-            model_registry=model_registry,
-            metrics_tracker=metrics_tracker,
-            device=bootstrap.device,
-            similar_use_case=similar_use_case,
-            prompt_use_case=prompt_use_case,
-        )
-    similar_use_case = use_case_bundle.similar_lora
-    prompt_use_case = use_case_bundle.prompt_recommendation
-
-    embedding_coordinator = embedding_coordinator or EmbeddingCoordinator(
-        bootstrap=bootstrap,
-        embedding_workflow=embedding_manager,
-        persistence_service=persistence_service,
-    )
-    feedback_manager = feedback_manager or FeedbackManager(repository)
-    stats_reporter = stats_reporter or StatsReporter(
-        metrics_tracker=metrics_tracker,
-        repository=repository,
-    )
-
-    builder = builder or RecommendationServiceBuilder()
-    return (
-        builder.with_components(
-            embedding_coordinator=embedding_coordinator,
-            feedback_manager=feedback_manager,
-            stats_reporter=stats_reporter,
-            similar_lora_use_case=similar_use_case,
-            prompt_recommendation_use_case=prompt_use_case,
-            config=config,
-        ).build()
-    )
-
+from .archive import ArchiveProviders, ArchiveServiceFactory, make_archive_service
+from .deliveries import (
+    DeliveryProviders,
+    DeliveryServiceFactory,
+    make_delivery_service,
+)
+from .generation import (
+    ComposeServiceFactory,
+    GenerationCoordinatorFactory,
+    GenerationProviders,
+    GenerationServiceFactory,
+    make_compose_service,
+    make_generation_coordinator,
+    make_generation_service,
+)
+from .recommendations import (
+    RecommendationProviders,
+    RecommendationServiceFactory,
+    make_recommendation_service,
+)
+from .storage import (
+    AdapterServiceFactory,
+    StorageProviders,
+    StorageServiceFactory,
+    make_adapter_service,
+    make_storage_service,
+)
+from .system import SystemProviders, SystemServiceFactory, make_system_service
+from .websocket import (
+    WebSocketProviders,
+    WebSocketServiceFactory,
+    default_websocket_service_factory,
+    make_websocket_service,
+)
 
 __all__ = [
+    "AdapterServiceFactory",
+    "AnalyticsProviders",
+    "AnalyticsServiceFactory",
+    "ArchiveProviders",
+    "ArchiveServiceFactory",
+    "ComposeServiceFactory",
+    "DeliveryProviders",
+    "DeliveryServiceFactory",
+    "GenerationCoordinatorFactory",
+    "GenerationProviders",
+    "GenerationServiceFactory",
+    "RecommendationProviders",
+    "RecommendationServiceFactory",
+    "StorageProviders",
+    "StorageServiceFactory",
+    "SystemProviders",
+    "SystemServiceFactory",
+    "WebSocketProviders",
+    "WebSocketServiceFactory",
+    "default_websocket_service_factory",
     "make_adapter_service",
     "make_analytics_service",
     "make_archive_service",
@@ -254,3 +73,4 @@ __all__ = [
     "make_system_service",
     "make_websocket_service",
 ]
+

--- a/backend/services/providers/analytics.py
+++ b/backend/services/providers/analytics.py
@@ -1,0 +1,57 @@
+"""Analytics service provider factories and protocols."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional, Protocol
+
+from sqlmodel import Session
+
+from ..analytics import AnalyticsService, InsightGenerator, TimeSeriesBuilder
+from ..analytics_repository import AnalyticsRepository
+
+
+class AnalyticsServiceFactory(Protocol):
+    """Callable protocol for creating :class:`AnalyticsService` instances."""
+
+    def __call__(
+        self,
+        db_session: Session,
+        *,
+        repository: AnalyticsRepository,
+        time_series_builder: Optional[TimeSeriesBuilder] = None,
+        insight_generator: Optional[InsightGenerator] = None,
+    ) -> AnalyticsService:
+        ...
+
+
+def make_analytics_service(
+    db_session: Session,
+    *,
+    repository: AnalyticsRepository,
+    time_series_builder: Optional[TimeSeriesBuilder] = None,
+    insight_generator: Optional[InsightGenerator] = None,
+) -> AnalyticsService:
+    """Create an :class:`AnalyticsService` with explicit collaborators."""
+
+    return AnalyticsService(
+        db_session,
+        repository=repository,
+        time_series_builder=time_series_builder or TimeSeriesBuilder(),
+        insight_generator=insight_generator or InsightGenerator(),
+    )
+
+
+@dataclass(frozen=True)
+class AnalyticsProviders:
+    """Grouped analytics-related provider callables."""
+
+    analytics: AnalyticsServiceFactory = make_analytics_service
+
+
+__all__ = [
+    "AnalyticsProviders",
+    "AnalyticsServiceFactory",
+    "make_analytics_service",
+]
+

--- a/backend/services/providers/archive.py
+++ b/backend/services/providers/archive.py
@@ -1,0 +1,62 @@
+"""Archive service provider factories and protocols."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional, Protocol
+
+from ..adapters import AdapterService
+from ..archive import ArchiveExportPlanner, ArchiveImportExecutor, ArchiveService
+from ..storage import StorageService
+
+
+class ArchiveServiceFactory(Protocol):
+    """Callable protocol for creating :class:`ArchiveService` instances."""
+
+    def __call__(
+        self,
+        adapter_service: AdapterService,
+        storage_service: StorageService,
+        *,
+        planner: Optional[ArchiveExportPlanner] = None,
+        executor: Optional[ArchiveImportExecutor] = None,
+        chunk_size: int = 64 * 1024,
+        spooled_file_max_size: int = 32 * 1024 * 1024,
+    ) -> ArchiveService:
+        ...
+
+
+def make_archive_service(
+    adapter_service: AdapterService,
+    storage_service: StorageService,
+    *,
+    planner: Optional[ArchiveExportPlanner] = None,
+    executor: Optional[ArchiveImportExecutor] = None,
+    chunk_size: int = 64 * 1024,
+    spooled_file_max_size: int = 32 * 1024 * 1024,
+) -> ArchiveService:
+    """Create an :class:`ArchiveService` wired with planner and executor collaborators."""
+
+    return ArchiveService(
+        adapter_service,
+        storage_service,
+        planner=planner,
+        executor=executor,
+        chunk_size=chunk_size,
+        spooled_file_max_size=spooled_file_max_size,
+    )
+
+
+@dataclass(frozen=True)
+class ArchiveProviders:
+    """Grouped archive-related provider callables."""
+
+    archive: ArchiveServiceFactory = make_archive_service
+
+
+__all__ = [
+    "ArchiveProviders",
+    "ArchiveServiceFactory",
+    "make_archive_service",
+]
+

--- a/backend/services/providers/deliveries.py
+++ b/backend/services/providers/deliveries.py
@@ -1,0 +1,47 @@
+"""Delivery service provider factories and protocols."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol
+
+from ..deliveries import DeliveryService
+from ..delivery_repository import DeliveryJobRepository
+from ..queue import QueueOrchestrator
+
+
+class DeliveryServiceFactory(Protocol):
+    """Callable protocol for creating :class:`DeliveryService` instances."""
+
+    def __call__(
+        self,
+        repository: DeliveryJobRepository,
+        *,
+        queue_orchestrator: QueueOrchestrator,
+    ) -> DeliveryService:
+        ...
+
+
+def make_delivery_service(
+    repository: DeliveryJobRepository,
+    *,
+    queue_orchestrator: QueueOrchestrator,
+) -> DeliveryService:
+    """Create a :class:`DeliveryService` with explicit repository and queue orchestrator."""
+
+    return DeliveryService(repository, queue_orchestrator=queue_orchestrator)
+
+
+@dataclass(frozen=True)
+class DeliveryProviders:
+    """Grouped delivery-related provider callables."""
+
+    delivery: DeliveryServiceFactory = make_delivery_service
+
+
+__all__ = [
+    "DeliveryProviders",
+    "DeliveryServiceFactory",
+    "make_delivery_service",
+]
+

--- a/backend/services/providers/generation.py
+++ b/backend/services/providers/generation.py
@@ -1,0 +1,80 @@
+"""Generation workflow provider factories and protocols."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol
+
+from ..composition import ComposeService
+from ..deliveries import DeliveryService
+from ..generation import GenerationCoordinator, GenerationService
+from ..websocket import WebSocketService
+
+
+class ComposeServiceFactory(Protocol):
+    """Callable protocol for creating :class:`ComposeService` instances."""
+
+    def __call__(self) -> ComposeService:
+        ...
+
+
+class GenerationServiceFactory(Protocol):
+    """Callable protocol for creating :class:`GenerationService` instances."""
+
+    def __call__(self) -> GenerationService:
+        ...
+
+
+class GenerationCoordinatorFactory(Protocol):
+    """Callable protocol for creating :class:`GenerationCoordinator` instances."""
+
+    def __call__(
+        self,
+        delivery_service: DeliveryService,
+        websocket_service: WebSocketService,
+        generation_service: GenerationService,
+    ) -> GenerationCoordinator:
+        ...
+
+
+def make_compose_service() -> ComposeService:
+    """Create a :class:`ComposeService`."""
+
+    return ComposeService()
+
+
+def make_generation_service() -> GenerationService:
+    """Create a :class:`GenerationService`."""
+
+    return GenerationService()
+
+
+def make_generation_coordinator(
+    delivery_service: DeliveryService,
+    websocket_service: WebSocketService,
+    generation_service: GenerationService,
+) -> GenerationCoordinator:
+    """Create a :class:`GenerationCoordinator` with its collaborators."""
+
+    return GenerationCoordinator(delivery_service, websocket_service, generation_service)
+
+
+@dataclass(frozen=True)
+class GenerationProviders:
+    """Grouped generation-related provider callables."""
+
+    compose: ComposeServiceFactory = make_compose_service
+    generation: GenerationServiceFactory = make_generation_service
+    coordinator: GenerationCoordinatorFactory = make_generation_coordinator
+
+
+__all__ = [
+    "ComposeServiceFactory",
+    "GenerationCoordinatorFactory",
+    "GenerationProviders",
+    "GenerationServiceFactory",
+    "make_compose_service",
+    "make_generation_coordinator",
+    "make_generation_service",
+]
+

--- a/backend/services/providers/recommendations.py
+++ b/backend/services/providers/recommendations.py
@@ -1,0 +1,166 @@
+"""Recommendation service provider factories and protocols."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional, Protocol
+
+from sqlmodel import Session
+
+from ..recommendations import (
+    EmbeddingCoordinator,
+    EmbeddingManager,
+    EmbeddingStack,
+    FeedbackManager,
+    LoRAEmbeddingRepository,
+    PersistenceComponents,
+    RecommendationConfig,
+    RecommendationMetricsTracker,
+    RecommendationModelBootstrap,
+    RecommendationPersistenceManager,
+    RecommendationPersistenceService,
+    RecommendationRepository,
+    RecommendationService,
+    RecommendationServiceBuilder,
+    SimilarLoraUseCase,
+    StatsReporter,
+    PromptRecommendationUseCase,
+    UseCaseBundle,
+    build_embedding_stack,
+    build_persistence_components,
+    build_use_cases,
+)
+
+
+class RecommendationServiceFactory(Protocol):
+    """Callable protocol for creating :class:`RecommendationService` instances."""
+
+    def __call__(
+        self,
+        db_session: Session,
+        *,
+        gpu_available: bool,
+        model_bootstrap: Optional[RecommendationModelBootstrap] = None,
+        embedding_repository: Optional[LoRAEmbeddingRepository] = None,
+        embedding_manager: Optional[EmbeddingManager] = None,
+        embedding_stack: Optional[EmbeddingStack] = None,
+        repository: Optional[RecommendationRepository] = None,
+        persistence_manager: Optional[RecommendationPersistenceManager] = None,
+        persistence_service: Optional[RecommendationPersistenceService] = None,
+        persistence_components: Optional[PersistenceComponents] = None,
+        metrics_tracker: Optional[RecommendationMetricsTracker] = None,
+        config: Optional[RecommendationConfig] = None,
+        similar_use_case: Optional[SimilarLoraUseCase] = None,
+        prompt_use_case: Optional[PromptRecommendationUseCase] = None,
+        use_case_bundle: Optional[UseCaseBundle] = None,
+        embedding_coordinator: Optional[EmbeddingCoordinator] = None,
+        feedback_manager: Optional[FeedbackManager] = None,
+        stats_reporter: Optional[StatsReporter] = None,
+        builder: Optional[RecommendationServiceBuilder] = None,
+    ) -> RecommendationService:
+        ...
+
+
+def make_recommendation_service(
+    db_session: Session,
+    *,
+    gpu_available: bool,
+    model_bootstrap: Optional[RecommendationModelBootstrap] = None,
+    embedding_repository: Optional[LoRAEmbeddingRepository] = None,
+    embedding_manager: Optional[EmbeddingManager] = None,
+    embedding_stack: Optional[EmbeddingStack] = None,
+    repository: Optional[RecommendationRepository] = None,
+    persistence_manager: Optional[RecommendationPersistenceManager] = None,
+    persistence_service: Optional[RecommendationPersistenceService] = None,
+    persistence_components: Optional[PersistenceComponents] = None,
+    metrics_tracker: Optional[RecommendationMetricsTracker] = None,
+    config: Optional[RecommendationConfig] = None,
+    similar_use_case: Optional[SimilarLoraUseCase] = None,
+    prompt_use_case: Optional[PromptRecommendationUseCase] = None,
+    use_case_bundle: Optional[UseCaseBundle] = None,
+    embedding_coordinator: Optional[EmbeddingCoordinator] = None,
+    feedback_manager: Optional[FeedbackManager] = None,
+    stats_reporter: Optional[StatsReporter] = None,
+    builder: Optional[RecommendationServiceBuilder] = None,
+) -> RecommendationService:
+    """Create a :class:`RecommendationService` wired with explicit collaborators."""
+
+    bootstrap = model_bootstrap or RecommendationModelBootstrap(gpu_enabled=gpu_available)
+    model_registry = bootstrap.get_model_registry()
+
+    repository = repository or RecommendationRepository(db_session)
+
+    if embedding_stack is None:
+        embedding_stack = build_embedding_stack(
+            db_session=db_session,
+            model_registry=model_registry,
+            embedding_repository=embedding_repository,
+            embedding_manager=embedding_manager,
+        )
+    embedding_repository = embedding_stack.repository
+    embedding_manager = embedding_stack.manager
+
+    if persistence_components is None:
+        persistence_components = build_persistence_components(
+            embedding_manager=embedding_manager,
+            model_registry=model_registry,
+            persistence_manager=persistence_manager,
+            persistence_service=persistence_service,
+            config=config,
+        )
+    persistence_manager = persistence_components.manager
+    persistence_service = persistence_components.service
+    config = persistence_components.config
+
+    metrics_tracker = metrics_tracker or RecommendationMetricsTracker()
+
+    if use_case_bundle is None:
+        use_case_bundle = build_use_cases(
+            repository=repository,
+            embedding_workflow=embedding_manager,
+            model_registry=model_registry,
+            metrics_tracker=metrics_tracker,
+            device=bootstrap.device,
+            similar_use_case=similar_use_case,
+            prompt_use_case=prompt_use_case,
+        )
+    similar_use_case = use_case_bundle.similar_lora
+    prompt_use_case = use_case_bundle.prompt_recommendation
+
+    embedding_coordinator = embedding_coordinator or EmbeddingCoordinator(
+        bootstrap=bootstrap,
+        embedding_workflow=embedding_manager,
+        persistence_service=persistence_service,
+    )
+    feedback_manager = feedback_manager or FeedbackManager(repository)
+    stats_reporter = stats_reporter or StatsReporter(
+        metrics_tracker=metrics_tracker,
+        repository=repository,
+    )
+
+    builder = builder or RecommendationServiceBuilder()
+    return (
+        builder.with_components(
+            embedding_coordinator=embedding_coordinator,
+            feedback_manager=feedback_manager,
+            stats_reporter=stats_reporter,
+            similar_lora_use_case=similar_use_case,
+            prompt_recommendation_use_case=prompt_use_case,
+            config=config,
+        ).build()
+    )
+
+
+@dataclass(frozen=True)
+class RecommendationProviders:
+    """Grouped recommendation-related provider callables."""
+
+    recommendation: RecommendationServiceFactory = make_recommendation_service
+
+
+__all__ = [
+    "RecommendationProviders",
+    "RecommendationServiceFactory",
+    "make_recommendation_service",
+]
+

--- a/backend/services/providers/storage.py
+++ b/backend/services/providers/storage.py
@@ -1,0 +1,68 @@
+"""Storage-related provider factories and type-safe interfaces."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional, Protocol
+
+from sqlmodel import Session
+
+from ..adapters import AdapterService
+from ..storage import StorageBackend, StorageService, get_storage_backend
+
+
+class StorageServiceFactory(Protocol):
+    """Callable protocol for creating :class:`StorageService` instances."""
+
+    def __call__(self, *, backend: Optional[StorageBackend] = None) -> StorageService:
+        ...
+
+
+class AdapterServiceFactory(Protocol):
+    """Callable protocol for creating :class:`AdapterService` instances."""
+
+    def __call__(
+        self,
+        *,
+        db_session: Session,
+        storage_service: StorageService,
+        storage_backend: Optional[StorageBackend] = None,
+    ) -> AdapterService:
+        ...
+
+
+def make_storage_service(*, backend: Optional[StorageBackend] = None) -> StorageService:
+    """Create a :class:`StorageService` using the provided backend."""
+
+    backend = backend or get_storage_backend()
+    return StorageService(backend)
+
+
+def make_adapter_service(
+    *,
+    db_session: Session,
+    storage_service: StorageService,
+    storage_backend: Optional[StorageBackend] = None,
+) -> AdapterService:
+    """Create an :class:`AdapterService` with explicit collaborators."""
+
+    backend = storage_backend or storage_service.backend
+    return AdapterService(db_session, storage_backend=backend)
+
+
+@dataclass(frozen=True)
+class StorageProviders:
+    """Grouped storage-related provider callables."""
+
+    storage: StorageServiceFactory = make_storage_service
+    adapter: AdapterServiceFactory = make_adapter_service
+
+
+__all__ = [
+    "AdapterServiceFactory",
+    "StorageProviders",
+    "StorageServiceFactory",
+    "make_adapter_service",
+    "make_storage_service",
+]
+

--- a/backend/services/providers/system.py
+++ b/backend/services/providers/system.py
@@ -1,0 +1,37 @@
+"""System service provider factories and protocols."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol
+
+from ..deliveries import DeliveryService
+from ..system import SystemService
+
+
+class SystemServiceFactory(Protocol):
+    """Callable protocol for creating :class:`SystemService` instances."""
+
+    def __call__(self, delivery_service: DeliveryService) -> SystemService:
+        ...
+
+
+def make_system_service(delivery_service: DeliveryService) -> SystemService:
+    """Create a :class:`SystemService` bound to the delivery service."""
+
+    return SystemService(delivery_service)
+
+
+@dataclass(frozen=True)
+class SystemProviders:
+    """Grouped system-related provider callables."""
+
+    system: SystemServiceFactory = make_system_service
+
+
+__all__ = [
+    "SystemProviders",
+    "SystemServiceFactory",
+    "make_system_service",
+]
+

--- a/backend/services/providers/websocket.py
+++ b/backend/services/providers/websocket.py
@@ -1,0 +1,50 @@
+"""WebSocket service provider factories and protocols."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional, Protocol
+
+from ..websocket import WebSocketService, websocket_service
+
+
+class WebSocketServiceFactory(Protocol):
+    """Callable protocol for producing :class:`WebSocketService` instances."""
+
+    def __call__(self) -> WebSocketService:
+        ...
+
+
+def make_websocket_service(
+    *,
+    service: Optional[WebSocketService] = None,
+    connection_manager=None,
+    job_monitor=None,
+) -> WebSocketService:
+    """Create or return a :class:`WebSocketService` configured with explicit collaborators."""
+
+    if service is not None:
+        return service
+    return WebSocketService(connection_manager=connection_manager, job_monitor=job_monitor)
+
+
+def default_websocket_service_factory() -> WebSocketService:
+    """Return the application-wide WebSocket service instance."""
+
+    return make_websocket_service(service=websocket_service)
+
+
+@dataclass(frozen=True)
+class WebSocketProviders:
+    """Grouped websocket-related provider callables."""
+
+    websocket: WebSocketServiceFactory = default_websocket_service_factory
+
+
+__all__ = [
+    "WebSocketProviders",
+    "WebSocketServiceFactory",
+    "default_websocket_service_factory",
+    "make_websocket_service",
+]
+

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 """Shared fixtures for the test suite."""
 
 from contextlib import contextmanager
+from dataclasses import replace
 from unittest.mock import MagicMock
 
 import pytest
@@ -18,7 +19,7 @@ from backend.services.composition import ComposeService
 from backend.services.deliveries import DeliveryService
 from backend.services.analytics_repository import AnalyticsRepository
 from backend.services.delivery_repository import DeliveryJobRepository
-from backend.services.providers import make_compose_service
+from backend.services.providers.generation import make_compose_service
 from backend.services.queue import create_queue_orchestrator
 
 
@@ -55,7 +56,11 @@ def mock_storage_fixture(monkeypatch) -> MagicMock:
 
     builder = get_service_container_builder()
 
-    monkeypatch.setattr(builder, "_storage_provider", lambda: mock_storage_service)
+    monkeypatch.setattr(
+        builder,
+        "_storage",
+        replace(builder._storage, storage=lambda: mock_storage_service),
+    )
     
     mock.storage_service = mock_storage_service
     return mock

--- a/tests/test_service_providers.py
+++ b/tests/test_service_providers.py
@@ -7,19 +7,18 @@ from backend.services.composition import ComposeService
 from backend.services.deliveries import DeliveryService
 from backend.services.delivery_repository import DeliveryJobRepository
 from backend.services.generation import GenerationCoordinator, GenerationService
-from backend.services.providers import (
-    make_adapter_service,
-    make_analytics_service,
-    make_archive_service,
+from backend.services.providers.analytics import make_analytics_service
+from backend.services.providers.archive import make_archive_service
+from backend.services.providers.deliveries import make_delivery_service
+from backend.services.providers.generation import (
     make_compose_service,
-    make_delivery_service,
     make_generation_coordinator,
     make_generation_service,
-    make_recommendation_service,
-    make_storage_service,
-    make_system_service,
-    make_websocket_service,
 )
+from backend.services.providers.recommendations import make_recommendation_service
+from backend.services.providers.storage import make_adapter_service, make_storage_service
+from backend.services.providers.system import make_system_service
+from backend.services.providers.websocket import make_websocket_service
 from backend.services.queue import QueueOrchestrator
 from backend.services.recommendations import (
     EmbeddingStack,


### PR DESCRIPTION
## Summary
- split the service provider helpers into domain-specific modules with typed factory protocols
- reshape ServiceContainerBuilder and ServiceContainer to consume grouped provider dataclasses
- update tests and fixtures to reference the new modules and wiring

## Testing
- pytest tests/test_service_providers.py tests/test_services.py

------
https://chatgpt.com/codex/tasks/task_e_68d29d26e3a883299342ed801d1311a9