### PR TITLE
Refactor import/export workflows into container architecture

### DIFF
--- a/app/frontend/src/components/ImportExport.vue
+++ b/app/frontend/src/components/ImportExport.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="import-export-container" v-if="isInitialized">
+  <div v-if="isInitialized" class="import-export-container">
     <div class="page-header">
       <div class="flex justify-between items-center">
         <div>
@@ -8,14 +8,14 @@
         </div>
         <div class="header-actions">
           <div class="flex items-center space-x-3">
-            <button @click="onQuickExportAll" class="btn btn-primary btn-sm">
+            <button @click="$emit('quickExportAll')" class="btn btn-primary btn-sm">
               <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 10v6m0 0l-4-4m4 4l4-4m6-2a9 9 0 11-18 0 9 9 0 0118 0z"></path>
               </svg>
               Quick Export All
             </button>
 
-            <button @click="viewHistory" class="btn btn-secondary btn-sm">
+            <button @click="$emit('viewHistory')" class="btn btn-secondary btn-sm">
               <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"></path>
               </svg>
@@ -31,7 +31,7 @@
         <div class="border-b border-gray-200">
           <nav class="-mb-px flex space-x-8">
             <button
-              @click="activeTab = 'export'"
+              @click="onTabChange('export')"
               :class="activeTab === 'export' ? 'tab-button active' : 'tab-button'"
             >
               <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -41,7 +41,7 @@
             </button>
 
             <button
-              @click="activeTab = 'import'"
+              @click="onTabChange('import')"
               :class="activeTab === 'import' ? 'tab-button active' : 'tab-button'"
             >
               <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -51,7 +51,7 @@
             </button>
 
             <button
-              @click="activeTab = 'backup'"
+              @click="onTabChange('backup')"
               :class="activeTab === 'backup' ? 'tab-button active' : 'tab-button'"
             >
               <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -61,7 +61,7 @@
             </button>
 
             <button
-              @click="activeTab = 'migration'"
+              @click="onTabChange('migration')"
               :class="activeTab === 'migration' ? 'tab-button active' : 'tab-button'"
             >
               <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -81,10 +81,10 @@
           :estimated-size="estimatedSize"
           :estimated-time="estimatedTime"
           :is-exporting="isExporting"
-          @update-config="handleExportConfigUpdate"
-          @validate="validateExport"
-          @preview="previewExport"
-          @start="() => startExport()"
+          @update-config="onExportConfigUpdate"
+          @validate="$emit('validateExport')"
+          @preview="$emit('previewExport')"
+          @start="$emit('startExport')"
         />
 
         <ImportProcessingPanel
@@ -96,12 +96,12 @@
           :is-importing="isImporting"
           :format-file-size="formatFileSize"
           :get-status-classes="getStatusClasses"
-          @update-config="handleImportConfigUpdate"
-          @add-files="onImportFilesAdded"
-          @remove-file="onImportFileRemoved"
-          @analyze="() => analyzeFiles()"
-          @validate="validateImport"
-          @start="() => startImport()"
+          @update-config="onImportConfigUpdate"
+          @add-files="$emit('addImportFiles', $event)"
+          @remove-file="$emit('removeImportFile', $event)"
+          @analyze="$emit('analyzeFiles')"
+          @validate="$emit('validateImport')"
+          @start="$emit('startImport')"
         />
 
         <BackupManagementPanel
@@ -109,81 +109,34 @@
           :history="backupHistory"
           :format-file-size="formatFileSize"
           :format-date="formatDate"
-          @create-full-backup="() => createFullBackup()"
-          @create-quick-backup="() => createQuickBackup()"
-          @schedule-backup="scheduleBackup"
-          @download-backup="downloadBackup"
-          @restore-backup="restoreBackup"
-          @delete-backup="deleteBackup"
+          @create-full-backup="$emit('createFullBackup')"
+          @create-quick-backup="$emit('createQuickBackup')"
+          @schedule-backup="$emit('scheduleBackup')"
+          @download-backup="$emit('downloadBackup', $event)"
+          @restore-backup="$emit('restoreBackup', $event)"
+          @delete-backup="$emit('deleteBackup', $event)"
         />
 
         <MigrationWorkflowPanel
           v-show="activeTab === 'migration'"
           :config="migrationConfig"
-          @update-config="handleMigrationConfigUpdate"
-          @start-version-migration="startVersionMigration"
-          @start-platform-migration="startPlatformMigration"
+          @update-config="onMigrationConfigUpdate"
+          @start-version-migration="$emit('startVersionMigration')"
+          @start-platform-migration="$emit('startPlatformMigration')"
         />
       </div>
     </div>
 
-    <div
-      v-show="showProgress"
-      class="fixed inset-0 z-50 overflow-y-auto transition-opacity duration-300"
-      :class="showProgress ? 'opacity-100' : 'opacity-0'"
-      role="dialog"
-      aria-modal="true"
-      :aria-busy="showProgress"
-      aria-labelledby="progress-title"
-    >
-      <div class="flex items-center justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:block sm:p-0">
-        <div class="fixed inset-0 bg-gray-500 bg-opacity-75"></div>
+    <ImportExportProgressModal
+      :show="showProgress"
+      :title="progressTitle"
+      :value="progressValue"
+      :current-step="currentStep"
+      :messages="progressMessages"
+      @cancel="$emit('cancelOperation')"
+    />
 
-        <div class="inline-block align-bottom bg-white rounded-lg text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-lg sm:w-full">
-          <div class="bg-white px-4 pt-5 pb-4 sm:p-6 sm:pb-4">
-            <h3 id="progress-title" class="text-lg leading-6 font-medium text-gray-900 mb-4">{{ progressTitle }}</h3>
-
-            <div class="space-y-4">
-              <div>
-                <div class="flex justify-between text-sm mb-1">
-                  <span>{{ currentStep }}</span>
-                  <span>{{ progressValue }}%</span>
-                </div>
-                <div class="w-full bg-gray-200 rounded-full h-2">
-                  <div
-                    class="bg-blue-600 h-2 rounded-full transition-all duration-500"
-                    :style="`width: ${progressValue}%`"
-                  ></div>
-                </div>
-              </div>
-
-              <div class="max-h-40 overflow-y-auto text-xs font-mono bg-gray-100 p-3 rounded">
-                <div v-for="message in progressMessages" :key="message.id">
-                  {{ message.text }}
-                </div>
-              </div>
-            </div>
-          </div>
-          <div class="bg-gray-50 px-4 py-3 sm:px-6 sm:flex sm:flex-row-reverse">
-            <button
-              @click="cancelOperation"
-              type="button"
-              class="w-full inline-flex justify-center rounded-md border border-gray-300 shadow-sm px-4 py-2 bg-white text-base font-medium text-gray-700 hover:bg-gray-50 sm:ml-3 sm:w-auto sm:text-sm"
-            >
-              Cancel
-            </button>
-          </div>
-        </div>
-      </div>
-    </div>
-
-    <div
-      v-show="showToast"
-      class="fixed top-4 right-4 z-50 px-4 py-2 rounded-lg shadow-lg transition-all duration-300"
-      :class="toastClasses"
-    >
-      {{ toastMessage }}
-    </div>
+    <ImportExportToast :show="showToast" :message="toastMessage" :type="toastType" />
   </div>
 
   <div v-else class="py-12 text-center text-gray-500">
@@ -196,231 +149,92 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted, ref } from 'vue';
-
 import BackupManagementPanel from './import-export/BackupManagementPanel.vue';
 import ExportConfigurationPanel from './import-export/ExportConfigurationPanel.vue';
 import ImportProcessingPanel from './import-export/ImportProcessingPanel.vue';
 import MigrationWorkflowPanel from './import-export/MigrationWorkflowPanel.vue';
+import ImportExportProgressModal from './import-export/ImportExportProgressModal.vue';
+import ImportExportToast from './import-export/ImportExportToast.vue';
 
-import { useBackupWorkflow } from '@/composables/useBackupWorkflow';
-import { useExportWorkflow, type ExportConfig, type ProgressUpdate } from '@/composables/useExportWorkflow';
-import { useImportWorkflow, type ImportConfig } from '@/composables/useImportWorkflow';
-import { useMigrationWorkflow, type MigrationConfig } from '@/composables/useMigrationWorkflow';
-import { formatDateTime, formatFileSize as formatBytes } from '@/utils/format';
+import type { NotifyType, ExportConfig } from '@/composables/useExportWorkflow';
+import type { ImportConfig, ImportPreviewItem } from '@/composables/useImportWorkflow';
+import type { MigrationConfig } from '@/composables/useMigrationWorkflow';
+import type { BackupEntry } from '@/composables/useBackupWorkflow';
 
-type OperationType = 'export' | 'import' | 'migration';
+export type ActiveTab = 'export' | 'import' | 'backup' | 'migration';
 
-const isInitialized = ref(false);
-const activeTab = ref<'export' | 'import' | 'backup' | 'migration'>('export');
-
-const showProgress = ref(false);
-const progressValue = ref(0);
-const currentStep = ref('');
-const progressMessages = ref<Array<{ id: number; text: string }>>([]);
-const currentOperation = ref<OperationType | null>(null);
-
-const showToast = ref(false);
-const toastMessage = ref('');
-const toastType = ref<'success' | 'error' | 'warning' | 'info'>('info');
-let toastTimeout: ReturnType<typeof setTimeout> | undefined;
-
-const progressTitle = computed(() => {
-  switch (currentOperation.value) {
-    case 'export':
-      return 'Export Progress';
-    case 'import':
-      return 'Import Progress';
-    case 'migration':
-      return 'Migration Progress';
-    default:
-      return 'Progress';
-  }
-});
-
-const toastClasses = computed(() => {
-  const baseClasses = 'px-4 py-2 rounded-lg shadow-lg';
-  switch (toastType.value) {
-    case 'success':
-      return `${baseClasses} bg-green-500 text-white`;
-    case 'error':
-      return `${baseClasses} bg-red-500 text-white`;
-    case 'warning':
-      return `${baseClasses} bg-yellow-500 text-white`;
-    default:
-      return `${baseClasses} bg-blue-500 text-white`;
-  }
-});
-
-const notify: Parameters<typeof useExportWorkflow>[0]['notify'] = (message, type = 'info') => {
-  toastMessage.value = message;
-  toastType.value = type;
-  showToast.value = true;
-  if (toastTimeout) {
-    clearTimeout(toastTimeout);
-  }
-  toastTimeout = setTimeout(() => {
-    showToast.value = false;
-  }, 3000);
-};
-
-const resetProgress = () => {
-  progressValue.value = 0;
-  currentStep.value = '';
-  progressMessages.value = [];
-};
-
-const beginProgress = (operation: OperationType) => {
-  currentOperation.value = operation;
-  resetProgress();
-  showProgress.value = true;
-};
-
-const updateProgress = (update: ProgressUpdate) => {
-  if (typeof update.value === 'number') {
-    progressValue.value = update.value;
-  }
-  if (typeof update.step === 'string') {
-    currentStep.value = update.step;
-  }
-  if (update.message) {
-    progressMessages.value = [
-      ...progressMessages.value,
-      {
-        id: Date.now() + Math.random(),
-        text: `[${new Date().toLocaleTimeString()}] ${update.message}`
-      }
-    ];
-  }
-};
-
-const endProgress = () => {
-  showProgress.value = false;
-  currentOperation.value = null;
-};
-
-const exportWorkflow = useExportWorkflow({
-  notify,
-  progress: {
-    begin: () => beginProgress('export'),
-    update: updateProgress,
-    end: endProgress
-  }
-});
-
-const importWorkflow = useImportWorkflow({
-  notify,
-  progress: {
-    begin: () => beginProgress('import'),
-    update: updateProgress,
-    end: endProgress
-  }
-});
-
-const backupWorkflow = useBackupWorkflow({ notify });
-const migrationWorkflow = useMigrationWorkflow({ notify });
-
-const exportConfig = exportWorkflow.exportConfig;
-const canExport = exportWorkflow.canExport;
-const estimatedSize = exportWorkflow.estimatedSize;
-const estimatedTime = exportWorkflow.estimatedTime;
-const isExporting = exportWorkflow.isExporting;
-
-const importConfig = importWorkflow.importConfig;
-const importFiles = importWorkflow.importFiles;
-const importPreview = importWorkflow.importPreview;
-const hasEncryptedFiles = importWorkflow.hasEncryptedFiles;
-const isImporting = importWorkflow.isImporting;
-
-const backupHistory = backupWorkflow.backupHistory;
-const migrationConfig = migrationWorkflow.migrationConfig;
-
-const formatFileSize = (bytes: number) => formatBytes(typeof bytes === 'number' ? bytes : 0);
-const formatDate = (dateString: string) => formatDateTime(dateString, {
-  year: 'numeric',
-  month: 'short',
-  day: 'numeric',
-  hour: '2-digit',
-  minute: '2-digit'
-});
-
-const getStatusClasses = (status: string) => {
-  const statusClasses: Record<string, string> = {
-    new: 'bg-green-100 text-green-800',
-    conflict: 'bg-yellow-100 text-yellow-800',
-    existing: 'bg-gray-100 text-gray-800',
-    error: 'bg-red-100 text-red-800'
-  };
-  return statusClasses[status] ?? 'bg-gray-100 text-gray-800';
-};
-
-function handleExportConfigUpdate<K extends keyof ExportConfig>(key: K, value: ExportConfig[K]) {
-  exportWorkflow.updateConfig(key, value);
+interface ProgressMessage {
+  id: number | string;
+  text: string;
 }
 
-function handleImportConfigUpdate<K extends keyof ImportConfig>(key: K, value: ImportConfig[K]) {
-  importWorkflow.updateConfig(key, value);
-}
+defineProps<{
+  isInitialized: boolean;
+  activeTab: ActiveTab;
+  exportConfig: ExportConfig;
+  canExport: boolean;
+  estimatedSize: string;
+  estimatedTime: string;
+  isExporting: boolean;
+  importConfig: ImportConfig;
+  importFiles: readonly File[];
+  importPreview: readonly ImportPreviewItem[];
+  hasEncryptedFiles: boolean;
+  isImporting: boolean;
+  backupHistory: readonly BackupEntry[];
+  migrationConfig: MigrationConfig;
+  showProgress: boolean;
+  progressTitle: string;
+  progressValue: number;
+  currentStep: string;
+  progressMessages: readonly ProgressMessage[];
+  showToast: boolean;
+  toastMessage: string;
+  toastType: NotifyType;
+  formatFileSize: (bytes: number) => string;
+  formatDate: (input: string) => string;
+  getStatusClasses: (status: string) => string;
+}>();
 
-function handleMigrationConfigUpdate<K extends keyof MigrationConfig>(key: K, value: MigrationConfig[K]) {
-  migrationWorkflow.updateConfig(key, value);
-}
+const emit = defineEmits<{
+  (e: 'update:activeTab', value: ActiveTab): void;
+  (e: 'quickExportAll'): void;
+  (e: 'viewHistory'): void;
+  <K extends keyof ExportConfig>(e: 'updateExportConfig', key: K, value: ExportConfig[K]): void;
+  (e: 'validateExport'): void;
+  (e: 'previewExport'): void;
+  (e: 'startExport'): void;
+  <K extends keyof ImportConfig>(e: 'updateImportConfig', key: K, value: ImportConfig[K]): void;
+  (e: 'addImportFiles', files: readonly File[]): void;
+  (e: 'removeImportFile', file: File): void;
+  (e: 'analyzeFiles'): void;
+  (e: 'validateImport'): void;
+  (e: 'startImport'): void;
+  (e: 'createFullBackup'): void;
+  (e: 'createQuickBackup'): void;
+  (e: 'scheduleBackup'): void;
+  (e: 'downloadBackup', backupId: string): void;
+  (e: 'restoreBackup', backupId: string): void;
+  (e: 'deleteBackup', backupId: string): void;
+  <K extends keyof MigrationConfig>(e: 'updateMigrationConfig', key: K, value: MigrationConfig[K]): void;
+  (e: 'startVersionMigration'): void;
+  (e: 'startPlatformMigration'): void;
+  (e: 'cancelOperation'): void;
+}>();
 
-const onImportFilesAdded = (files: readonly File[]) => {
-  importWorkflow.addFiles([...files]);
+const onTabChange = (tab: ActiveTab) => {
+  emit('update:activeTab', tab);
 };
 
-const onImportFileRemoved = (file: File) => {
-  importWorkflow.removeFile(file);
+const onExportConfigUpdate = <K extends keyof ExportConfig>(key: K, value: ExportConfig[K]) => {
+  emit('updateExportConfig', key, value);
 };
 
-const startExport = () => {
-  void exportWorkflow.startExport();
+const onImportConfigUpdate = <K extends keyof ImportConfig>(key: K, value: ImportConfig[K]) => {
+  emit('updateImportConfig', key, value);
 };
 
-const startImport = () => {
-  void importWorkflow.startImport();
+const onMigrationConfigUpdate = <K extends keyof MigrationConfig>(key: K, value: MigrationConfig[K]) => {
+  emit('updateMigrationConfig', key, value);
 };
-
-const analyzeFiles = () => {
-  void importWorkflow.analyzeFiles();
-};
-
-const validateExport = () => exportWorkflow.validateExport();
-const previewExport = () => exportWorkflow.previewExport();
-const validateImport = () => importWorkflow.validateImport();
-const createFullBackup = () => backupWorkflow.createFullBackup();
-const createQuickBackup = () => backupWorkflow.createQuickBackup();
-const scheduleBackup = () => backupWorkflow.scheduleBackup();
-const downloadBackup = (backupId: string) => backupWorkflow.downloadBackup(backupId);
-const restoreBackup = (backupId: string) => backupWorkflow.restoreBackup(backupId);
-const deleteBackup = (backupId: string) => backupWorkflow.deleteBackup(backupId);
-const startVersionMigration = () => migrationWorkflow.startVersionMigration();
-const startPlatformMigration = () => migrationWorkflow.startPlatformMigration();
-
-const onQuickExportAll = () => {
-  void exportWorkflow.quickExportAll();
-};
-
-const viewHistory = () => {
-  activeTab.value = 'backup';
-};
-
-const cancelOperation = () => {
-  if (currentOperation.value === 'export') {
-    exportWorkflow.cancelExport();
-  } else if (currentOperation.value === 'import') {
-    importWorkflow.cancelImport();
-  }
-  endProgress();
-  notify('Operation cancelled', 'warning');
-};
-
-onMounted(async () => {
-  await Promise.all([
-    exportWorkflow.initialize(),
-    backupWorkflow.initialize()
-  ]);
-  isInitialized.value = true;
-});
 </script>

--- a/app/frontend/src/components/import-export/ImportExportContainer.vue
+++ b/app/frontend/src/components/import-export/ImportExportContainer.vue
@@ -1,0 +1,308 @@
+<template>
+  <ImportExport
+    :is-initialized="isInitialized"
+    :active-tab="activeTab"
+    :export-config="exportConfig"
+    :can-export="canExport"
+    :estimated-size="estimatedSize"
+    :estimated-time="estimatedTime"
+    :is-exporting="isExporting"
+    :import-config="importConfig"
+    :import-files="importFiles"
+    :import-preview="importPreview"
+    :has-encrypted-files="hasEncryptedFiles"
+    :is-importing="isImporting"
+    :backup-history="backupHistory"
+    :migration-config="migrationConfig"
+    :show-progress="showProgress"
+    :progress-title="progressTitle"
+    :progress-value="progressValue"
+    :current-step="currentStep"
+    :progress-messages="progressMessages"
+    :show-toast="showToast"
+    :toast-message="toastMessage"
+    :toast-type="toastType"
+    :format-file-size="formatFileSize"
+    :format-date="formatDate"
+    :get-status-classes="getStatusClasses"
+    @update:active-tab="value => (activeTab.value = value)"
+    @quick-export-all="handleQuickExportAll"
+    @view-history="handleViewHistory"
+    @update-export-config="handleExportConfigUpdate"
+    @validate-export="handleValidateExport"
+    @preview-export="handlePreviewExport"
+    @start-export="handleStartExport"
+    @update-import-config="handleImportConfigUpdate"
+    @add-import-files="handleImportFilesAdded"
+    @remove-import-file="handleImportFileRemoved"
+    @analyze-files="handleAnalyzeFiles"
+    @validate-import="handleValidateImport"
+    @start-import="handleStartImport"
+    @create-full-backup="handleCreateFullBackup"
+    @create-quick-backup="handleCreateQuickBackup"
+    @schedule-backup="handleScheduleBackup"
+    @download-backup="handleDownloadBackup"
+    @restore-backup="handleRestoreBackup"
+    @delete-backup="handleDeleteBackup"
+    @update-migration-config="handleMigrationConfigUpdate"
+    @start-version-migration="handleStartVersionMigration"
+    @start-platform-migration="handleStartPlatformMigration"
+    @cancel-operation="handleCancelOperation"
+  />
+</template>
+
+<script setup lang="ts">
+import { computed, onBeforeUnmount, onMounted, ref } from 'vue';
+
+import ImportExport, { type ActiveTab } from '../ImportExport.vue';
+
+import { useBackupWorkflow } from '@/composables/useBackupWorkflow';
+import {
+  useExportWorkflow,
+  type ExportConfig,
+  type NotifyType,
+  type ProgressUpdate
+} from '@/composables/useExportWorkflow';
+import { useImportWorkflow, type ImportConfig } from '@/composables/useImportWorkflow';
+import { useMigrationWorkflow, type MigrationConfig } from '@/composables/useMigrationWorkflow';
+import { formatDateTime, formatFileSize as formatBytes } from '@/utils/format';
+
+type OperationType = 'export' | 'import' | 'migration';
+
+type ProgressMessage = { id: number | string; text: string };
+
+const isInitialized = ref(false);
+const activeTab = ref<ActiveTab>('export');
+
+const showProgress = ref(false);
+const progressValue = ref(0);
+const currentStep = ref('');
+const progressMessages = ref<ProgressMessage[]>([]);
+const currentOperation = ref<OperationType | null>(null);
+
+const showToast = ref(false);
+const toastMessage = ref('');
+const toastType = ref<NotifyType>('info');
+let toastTimeout: ReturnType<typeof setTimeout> | undefined;
+
+const progressTitle = computed(() => {
+  switch (currentOperation.value) {
+    case 'export':
+      return 'Export Progress';
+    case 'import':
+      return 'Import Progress';
+    case 'migration':
+      return 'Migration Progress';
+    default:
+      return 'Progress';
+  }
+});
+
+const notify: Parameters<typeof useExportWorkflow>[0]['notify'] = (message, type = 'info') => {
+  toastMessage.value = message;
+  toastType.value = type;
+  showToast.value = true;
+  if (toastTimeout) {
+    clearTimeout(toastTimeout);
+  }
+  toastTimeout = setTimeout(() => {
+    showToast.value = false;
+  }, 3000);
+};
+
+const resetProgress = () => {
+  progressValue.value = 0;
+  currentStep.value = '';
+  progressMessages.value = [];
+};
+
+const beginProgress = (operation: OperationType) => {
+  currentOperation.value = operation;
+  resetProgress();
+  showProgress.value = true;
+};
+
+const updateProgress = (update: ProgressUpdate) => {
+  if (typeof update.value === 'number') {
+    progressValue.value = update.value;
+  }
+  if (typeof update.step === 'string') {
+    currentStep.value = update.step;
+  }
+  if (update.message) {
+    progressMessages.value = [
+      ...progressMessages.value,
+      {
+        id: Date.now() + Math.random(),
+        text: `[${new Date().toLocaleTimeString()}] ${update.message}`
+      }
+    ];
+  }
+};
+
+const endProgress = () => {
+  showProgress.value = false;
+  currentOperation.value = null;
+};
+
+const exportWorkflow = useExportWorkflow({
+  notify,
+  progress: {
+    begin: () => beginProgress('export'),
+    update: updateProgress,
+    end: endProgress
+  }
+});
+
+const importWorkflow = useImportWorkflow({
+  notify,
+  progress: {
+    begin: () => beginProgress('import'),
+    update: updateProgress,
+    end: endProgress
+  }
+});
+
+const backupWorkflow = useBackupWorkflow({ notify });
+const migrationWorkflow = useMigrationWorkflow({ notify });
+
+const exportConfig = exportWorkflow.exportConfig;
+const canExport = exportWorkflow.canExport;
+const estimatedSize = exportWorkflow.estimatedSize;
+const estimatedTime = exportWorkflow.estimatedTime;
+const isExporting = exportWorkflow.isExporting;
+
+const importConfig = importWorkflow.importConfig;
+const importFiles = importWorkflow.importFiles;
+const importPreview = importWorkflow.importPreview;
+const hasEncryptedFiles = importWorkflow.hasEncryptedFiles;
+const isImporting = importWorkflow.isImporting;
+
+const backupHistory = backupWorkflow.backupHistory;
+const migrationConfig = migrationWorkflow.migrationConfig;
+
+const formatFileSize = (bytes: number) => formatBytes(typeof bytes === 'number' ? bytes : 0);
+const formatDate = (dateString: string) =>
+  formatDateTime(dateString, {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit'
+  });
+
+const getStatusClasses = (status: string) => {
+  const statusClasses: Record<string, string> = {
+    new: 'bg-green-100 text-green-800',
+    conflict: 'bg-yellow-100 text-yellow-800',
+    existing: 'bg-gray-100 text-gray-800',
+    error: 'bg-red-100 text-red-800'
+  };
+  return statusClasses[status] ?? 'bg-gray-100 text-gray-800';
+};
+
+const handleExportConfigUpdate = <K extends keyof ExportConfig>(key: K, value: ExportConfig[K]) => {
+  exportWorkflow.updateConfig(key, value);
+};
+
+const handleImportConfigUpdate = <K extends keyof ImportConfig>(key: K, value: ImportConfig[K]) => {
+  importWorkflow.updateConfig(key, value);
+};
+
+const handleMigrationConfigUpdate = <K extends keyof MigrationConfig>(key: K, value: MigrationConfig[K]) => {
+  migrationWorkflow.updateConfig(key, value);
+};
+
+const handleImportFilesAdded = (files: readonly File[]) => {
+  importWorkflow.addFiles([...files]);
+};
+
+const handleImportFileRemoved = (file: File) => {
+  importWorkflow.removeFile(file);
+};
+
+const handleStartExport = () => {
+  void exportWorkflow.startExport();
+};
+
+const handleStartImport = () => {
+  void importWorkflow.startImport();
+};
+
+const handleAnalyzeFiles = () => {
+  void importWorkflow.analyzeFiles();
+};
+
+const handleValidateExport = () => {
+  exportWorkflow.validateExport();
+};
+
+const handlePreviewExport = () => {
+  exportWorkflow.previewExport();
+};
+
+const handleValidateImport = () => {
+  importWorkflow.validateImport();
+};
+
+const handleCreateFullBackup = () => {
+  void backupWorkflow.createFullBackup();
+};
+
+const handleCreateQuickBackup = () => {
+  void backupWorkflow.createQuickBackup();
+};
+
+const handleScheduleBackup = () => {
+  backupWorkflow.scheduleBackup();
+};
+
+const handleDownloadBackup = (backupId: string) => {
+  backupWorkflow.downloadBackup(backupId);
+};
+
+const handleRestoreBackup = (backupId: string) => {
+  backupWorkflow.restoreBackup(backupId);
+};
+
+const handleDeleteBackup = (backupId: string) => {
+  backupWorkflow.deleteBackup(backupId);
+};
+
+const handleStartVersionMigration = () => {
+  migrationWorkflow.startVersionMigration();
+};
+
+const handleStartPlatformMigration = () => {
+  migrationWorkflow.startPlatformMigration();
+};
+
+const handleQuickExportAll = () => {
+  void exportWorkflow.quickExportAll();
+};
+
+const handleViewHistory = () => {
+  activeTab.value = 'backup';
+};
+
+const handleCancelOperation = () => {
+  if (currentOperation.value === 'export') {
+    exportWorkflow.cancelExport();
+  } else if (currentOperation.value === 'import') {
+    importWorkflow.cancelImport();
+  }
+  endProgress();
+  notify('Operation cancelled', 'warning');
+};
+
+onMounted(async () => {
+  await Promise.all([exportWorkflow.initialize(), backupWorkflow.initialize()]);
+  isInitialized.value = true;
+});
+
+onBeforeUnmount(() => {
+  if (toastTimeout) {
+    clearTimeout(toastTimeout);
+  }
+});
+</script>

--- a/app/frontend/src/components/import-export/ImportExportProgressModal.vue
+++ b/app/frontend/src/components/import-export/ImportExportProgressModal.vue
@@ -1,0 +1,66 @@
+<template>
+  <div
+    v-if="show"
+    class="fixed inset-0 z-50 overflow-y-auto transition-opacity duration-300"
+    role="dialog"
+    aria-modal="true"
+    :aria-busy="show"
+    aria-labelledby="progress-title"
+  >
+    <div class="flex items-center justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:block sm:p-0">
+      <div class="fixed inset-0 bg-gray-500 bg-opacity-75"></div>
+
+      <div class="inline-block align-bottom bg-white rounded-lg text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-lg sm:w-full">
+        <div class="bg-white px-4 pt-5 pb-4 sm:p-6 sm:pb-4">
+          <h3 id="progress-title" class="text-lg leading-6 font-medium text-gray-900 mb-4">{{ title }}</h3>
+
+          <div class="space-y-4">
+            <div>
+              <div class="flex justify-between text-sm mb-1">
+                <span>{{ currentStep }}</span>
+                <span>{{ value }}%</span>
+              </div>
+              <div class="w-full bg-gray-200 rounded-full h-2">
+                <div class="bg-blue-600 h-2 rounded-full transition-all duration-500" :style="`width: ${value}%`"></div>
+              </div>
+            </div>
+
+            <div class="max-h-40 overflow-y-auto text-xs font-mono bg-gray-100 p-3 rounded">
+              <div v-for="message in messages" :key="message.id">
+                {{ message.text }}
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="bg-gray-50 px-4 py-3 sm:px-6 sm:flex sm:flex-row-reverse">
+          <button
+            @click="$emit('cancel')"
+            type="button"
+            class="w-full inline-flex justify-center rounded-md border border-gray-300 shadow-sm px-4 py-2 bg-white text-base font-medium text-gray-700 hover:bg-gray-50 sm:ml-3 sm:w-auto sm:text-sm"
+          >
+            Cancel
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+interface ProgressMessage {
+  id: number | string;
+  text: string;
+}
+
+defineProps<{
+  show: boolean;
+  title: string;
+  value: number;
+  currentStep: string;
+  messages: readonly ProgressMessage[];
+}>();
+
+defineEmits<{
+  (e: 'cancel'): void;
+}>();
+</script>

--- a/app/frontend/src/components/import-export/ImportExportToast.vue
+++ b/app/frontend/src/components/import-export/ImportExportToast.vue
@@ -1,0 +1,37 @@
+<template>
+  <div
+    v-if="show"
+    class="fixed top-4 right-4 z-50 px-4 py-2 rounded-lg shadow-lg transition-all duration-300"
+    :class="toastClass"
+    role="status"
+    aria-live="polite"
+  >
+    {{ message }}
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue';
+
+type ToastType = 'success' | 'error' | 'warning' | 'info';
+
+const props = defineProps<{
+  show: boolean;
+  message: string;
+  type: ToastType;
+}>();
+
+const toastClass = computed(() => {
+  const baseClasses = 'text-white';
+  switch (props.type) {
+    case 'success':
+      return `${baseClasses} bg-green-500`;
+    case 'error':
+      return `${baseClasses} bg-red-500`;
+    case 'warning':
+      return `${baseClasses} bg-yellow-500`;
+    default:
+      return `${baseClasses} bg-blue-500`;
+  }
+});
+</script>

--- a/app/frontend/src/views/AdminView.vue
+++ b/app/frontend/src/views/AdminView.vue
@@ -16,7 +16,7 @@
     </div>
     <div class="grid gap-6 xl:grid-cols-2">
       <JobQueue :show-clear-completed="true" />
-      <ImportExport />
+      <ImportExportContainer />
     </div>
     <div class="grid gap-6 xl:grid-cols-2">
       <PerformanceAnalytics :show-page-header="false" :show-system-status="false" />
@@ -28,7 +28,7 @@
 <script setup lang="ts">
 import { RouterLink } from 'vue-router';
 
-import ImportExport from '@/components/ImportExport.vue';
+import ImportExportContainer from '@/components/import-export/ImportExportContainer.vue';
 import JobQueue from '@/components/JobQueue.vue';
 import PageHeader from '@/components/PageHeader.vue';
 import PerformanceAnalytics from '@/views/analytics/PerformanceAnalyticsPage.vue';

--- a/app/frontend/src/views/DashboardView.vue
+++ b/app/frontend/src/views/DashboardView.vue
@@ -37,7 +37,7 @@
     </section>
 
     <section class="grid gap-6 xl:grid-cols-2">
-      <ImportExport />
+      <ImportExportContainer />
       <HelloWorld />
     </section>
   </div>
@@ -49,7 +49,7 @@ import { RouterLink } from 'vue-router';
 import GenerationHistory from '@/components/GenerationHistory.vue';
 import GenerationStudio from '@/components/GenerationStudio.vue';
 import HelloWorld from '@/components/HelloWorld.vue';
-import ImportExport from '@/components/ImportExport.vue';
+import ImportExportContainer from '@/components/import-export/ImportExportContainer.vue';
 import JobQueue from '@/components/JobQueue.vue';
 import LoraGallery from '@/components/LoraGallery.vue';
 import PageHeader from '@/components/PageHeader.vue';

--- a/app/frontend/src/views/ImportExportView.vue
+++ b/app/frontend/src/views/ImportExportView.vue
@@ -10,7 +10,7 @@
         </RouterLink>
       </template>
     </PageHeader>
-    <ImportExport />
+    <ImportExportContainer />
     <div class="grid gap-6 xl:grid-cols-2">
       <JobQueue :show-clear-completed="true" />
       <SystemStatusPanel />
@@ -19,10 +19,14 @@
 </template>
 
 <script setup lang="ts">
+import { defineAsyncComponent } from 'vue';
 import { RouterLink } from 'vue-router';
 
-import ImportExport from '@/components/ImportExport.vue';
 import JobQueue from '@/components/JobQueue.vue';
 import PageHeader from '@/components/PageHeader.vue';
 import SystemStatusPanel from '@/components/SystemStatusPanel.vue';
+
+const ImportExportContainer = defineAsyncComponent(() =>
+  import('@/components/import-export/ImportExportContainer.vue')
+);
 </script>


### PR DESCRIPTION
## Summary
- introduce an ImportExport container component that owns workflow state, orchestrates progress notifications, and feeds the presentation layer
- trim ImportExport.vue into a presentational shell backed by reusable progress modal and toast components
- update admin, dashboard, and import/export views plus unit tests to consume the new container setup

## Testing
- npm run test:unit

------
https://chatgpt.com/codex/tasks/task_e_68d2a156f3bc8329a65f3df48d8f43d5