### PR TITLE
Broadcast compose SDNext jobs for monitoring

### DIFF
--- a/backend/api/v1/compose.py
+++ b/backend/api/v1/compose.py
@@ -51,6 +51,10 @@ async def compose(
                 return_format=sdnext_config.return_format,
                 background_tasks=background_tasks,
             )
+            await application.generation_coordinator.broadcast_job_started(
+                job.id,
+                generation_params,
+            )
         else:
             job = application.deliveries.schedule_job(
                 composition.prompt,


### PR DESCRIPTION
## Summary
- start WebSocket monitoring when the compose endpoint schedules SDNext generation jobs
- extend the compose SDNext test to confirm the broadcast helper is invoked

## Testing
- pytest tests/test_generation_jobs.py

------
https://chatgpt.com/codex/tasks/task_e_68d2b7e9fa78832985e0f3730d973575