### PR TITLE
Fix frontend build validation type errors

### DIFF
--- a/app/frontend/src/components/import-export/ImportExportContainer.vue
+++ b/app/frontend/src/components/import-export/ImportExportContainer.vue
@@ -25,7 +25,7 @@
     :format-file-size="formatFileSize"
     :format-date="formatDate"
     :get-status-classes="getStatusClasses"
-    @update:active-tab="value => (activeTab.value = value)"
+    @update:active-tab="handleActiveTabChange"
     @quick-export-all="handleQuickExportAll"
     @view-history="handleViewHistory"
     @update-export-config="handleExportConfigUpdate"
@@ -147,6 +147,10 @@ const updateProgress = (update: ProgressUpdate) => {
 const endProgress = () => {
   showProgress.value = false;
   currentOperation.value = null;
+};
+
+const handleActiveTabChange = (value: ActiveTab) => {
+  activeTab.value = value;
 };
 
 const exportWorkflow = useExportWorkflow({

--- a/app/frontend/src/types/vue-virtual-scroller.d.ts
+++ b/app/frontend/src/types/vue-virtual-scroller.d.ts
@@ -1,0 +1,7 @@
+declare module 'vue-virtual-scroller' {
+  import type { DefineComponent } from 'vue';
+
+  export const RecycleScroller: DefineComponent<Record<string, unknown>, {}, any>;
+  export const DynamicScroller: DefineComponent<Record<string, unknown>, {}, any>;
+  export const DynamicScrollerItem: DefineComponent<Record<string, unknown>, {}, any>;
+}


### PR DESCRIPTION
## Summary
- replace the inline active tab update handler with a named function to avoid template ref unwrapping issues
- declare minimal vue-virtual-scroller module typings so RecycleScroller imports are type-safe

## Testing
- npm run type-check

------
https://chatgpt.com/codex/tasks/task_e_68d2bae384fc83299b31be393d81d78b