### PR TITLE
Run recommendation preload in background task

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,11 +1,18 @@
 """Tests for the HTTP API, using FastAPI's TestClient and pytest fixtures."""
+import asyncio
+import logging
 from pathlib import Path
+from threading import Event
 from unittest.mock import MagicMock
 
+import pytest
+from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
+import backend.main as backend_main
 from backend.core.dependencies import get_service_container
 from backend.main import app as backend_app
+from backend.main import lifespan
 from backend.schemas import SDNextGenerationResult
 from backend.services import ServiceContainer
 from backend.services.analytics_repository import AnalyticsRepository
@@ -62,6 +69,74 @@ def _create_active_adapter(client: TestClient, mock_storage: MagicMock) -> None:
     assert activate_response.status_code == 200
 
     return adapter_id
+
+
+@pytest.mark.anyio
+async def test_lifespan_preloads_recommendations_in_background(monkeypatch, caplog):
+    """The lifespan context should not block on recommendation preload."""
+
+    caplog.set_level(logging.INFO, logger="lora.recommendations.startup")
+
+    monkeypatch.setattr(backend_main, "setup_logging", lambda: None)
+    monkeypatch.setattr(backend_main, "init_db", lambda: None)
+    monkeypatch.setattr(
+        backend_main.settings,
+        "IMPORT_ON_STARTUP",
+        False,
+        raising=False,
+    )
+
+    start_event = Event()
+    finish_event = Event()
+
+    def _slow_preload():
+        start_event.set()
+        finish_event.wait(timeout=0.5)
+
+    monkeypatch.setattr(backend_main.RecommendationService, "preload_models", _slow_preload)
+
+    app = FastAPI(lifespan=lifespan)
+    ctx = app.router.lifespan_context(app)
+
+    try:
+        await asyncio.wait_for(ctx.__aenter__(), timeout=0.2)
+        assert start_event.wait(timeout=0.2)
+    finally:
+        finish_event.set()
+        await ctx.__aexit__(None, None, None)
+
+    assert "Recommendation model preload completed successfully" in caplog.text
+
+
+@pytest.mark.anyio
+async def test_lifespan_logs_recommendation_preload_failure(monkeypatch, caplog):
+    """Failures during recommendation preload should be logged but not block startup."""
+
+    caplog.set_level(logging.INFO, logger="lora.recommendations.startup")
+
+    monkeypatch.setattr(backend_main, "setup_logging", lambda: None)
+    monkeypatch.setattr(backend_main, "init_db", lambda: None)
+    monkeypatch.setattr(
+        backend_main.settings,
+        "IMPORT_ON_STARTUP",
+        False,
+        raising=False,
+    )
+
+    def _failing_preload():
+        raise RuntimeError("preload failed")
+
+    monkeypatch.setattr(backend_main.RecommendationService, "preload_models", _failing_preload)
+
+    app = FastAPI(lifespan=lifespan)
+    ctx = app.router.lifespan_context(app)
+
+    try:
+        await ctx.__aenter__()
+    finally:
+        await ctx.__aexit__(None, None, None)
+
+    assert "Recommendation model preload failed" in caplog.text
 
 
 def test_health(client: TestClient):


### PR DESCRIPTION
## Summary
- preload recommendation models in a background task during startup and log success/failure
- add lifespan tests that verify preload runs asynchronously and logs failures

## Testing
- pytest tests/test_main.py -k lifespan

------
https://chatgpt.com/codex/tasks/task_e_68d2bfd76f288329a7f41dd3f6bde454