### PR TITLE
Add recommendation model health reporting

### DIFF
--- a/backend/api/v1/recommendations.py
+++ b/backend/api/v1/recommendations.py
@@ -331,7 +331,7 @@ async def get_recommendation_health(
         health_status = {
             "status": "healthy",
             "checks": {
-                "models_loaded": True,  # TODO: Check if models are actually loaded
+                "models_loaded": recommendation_service.models_loaded(),
                 "embeddings_coverage": stats.embedding_coverage > 0.5,
                 "performance_acceptable": stats.avg_recommendation_time_ms < 5000,
                 "memory_usage_ok": stats.model_memory_usage_gb < 7.5,  # For 8GB VRAM

--- a/backend/services/recommendations/embedding_coordinator.py
+++ b/backend/services/recommendations/embedding_coordinator.py
@@ -102,3 +102,9 @@ class EmbeddingCoordinator:
         RecommendationModelBootstrap.preload_models_for_environment(
             gpu_enabled=gpu_enabled,
         )
+
+    @staticmethod
+    def models_loaded() -> bool:
+        """Return whether shared models have been initialised."""
+
+        return RecommendationModelBootstrap.models_loaded()

--- a/backend/services/recommendations/model_bootstrap.py
+++ b/backend/services/recommendations/model_bootstrap.py
@@ -92,3 +92,9 @@ class RecommendationModelBootstrap:
 
         return ("cuda" if gpu_enabled else "cpu", bool(gpu_enabled))
 
+    @classmethod
+    def models_loaded(cls) -> bool:
+        """Return whether shared models have been loaded for the process."""
+
+        return RecommendationModelRegistry.models_loaded()
+

--- a/backend/services/recommendations/model_registry.py
+++ b/backend/services/recommendations/model_registry.py
@@ -114,3 +114,13 @@ class RecommendationModelRegistry:
 
         effective_logger = logger or cls._shared_logger
         cls._ensure_shared_models_for_device(device, gpu_enabled, effective_logger)
+
+    @classmethod
+    def models_loaded(cls) -> bool:
+        """Return whether the shared models have been initialised."""
+
+        return (
+            cls._shared_semantic_embedder is not None
+            and cls._shared_feature_extractor is not None
+            and cls._shared_recommendation_engine is not None
+        )

--- a/backend/services/recommendations/service.py
+++ b/backend/services/recommendations/service.py
@@ -95,6 +95,12 @@ class RecommendationService:
 
         EmbeddingCoordinator.preload_models(gpu_enabled=gpu_enabled)
 
+    @staticmethod
+    def models_loaded() -> bool:
+        """Return whether required models have already been loaded."""
+
+        return EmbeddingCoordinator.models_loaded()
+
     # ------------------------------------------------------------------
     # Recommendation workflows
     # ------------------------------------------------------------------

--- a/tests/test_recommendations.py
+++ b/tests/test_recommendations.py
@@ -71,6 +71,47 @@ def repository(db_session):
     return RecommendationRepository(db_session)
 
 
+@pytest.fixture
+def model_registry(monkeypatch):
+    from backend.services.recommendations.model_registry import (
+        RecommendationModelRegistry,
+    )
+
+    monkeypatch.setattr(
+        RecommendationModelRegistry, "_shared_semantic_embedder", None
+    )
+    monkeypatch.setattr(
+        RecommendationModelRegistry, "_shared_feature_extractor", None
+    )
+    monkeypatch.setattr(
+        RecommendationModelRegistry, "_shared_recommendation_engine", None
+    )
+
+    return RecommendationModelRegistry
+
+
+class TestRecommendationModelStatus:
+    """Verify model loading status helpers."""
+
+    def test_models_loaded_false_when_registry_empty(self, model_registry):
+        assert RecommendationService.models_loaded() is False
+
+    def test_models_loaded_true_when_registry_populated(
+        self, model_registry, monkeypatch
+    ):
+        monkeypatch.setattr(
+            model_registry, "_shared_semantic_embedder", object()
+        )
+        monkeypatch.setattr(
+            model_registry, "_shared_feature_extractor", object()
+        )
+        monkeypatch.setattr(
+            model_registry, "_shared_recommendation_engine", object()
+        )
+
+        assert RecommendationService.models_loaded() is True
+
+
 class TestRecommendationPersistenceService:
     """Unit tests for the high level persistence helper."""
 


### PR DESCRIPTION
## Summary
- add helper chain to surface whether recommendation models are loaded
- report real model load state from the recommendation health endpoint
- cover loaded and unloaded scenarios with unit tests

## Testing
- pytest tests/test_recommendations.py::TestRecommendationModelStatus -q

------
https://chatgpt.com/codex/tasks/task_e_68d2bfdcb3088329a36a5e2d0c8ee934