### PR TITLE
Refactor generation history container into composables

### DIFF
--- a/app/frontend/src/components/HistoryActionToolbar.vue
+++ b/app/frontend/src/components/HistoryActionToolbar.vue
@@ -1,0 +1,106 @@
+<template>
+  <div class="page-header">
+    <div class="flex justify-between items-center">
+      <div>
+        <h1 class="page-title">Generation History</h1>
+        <p class="page-subtitle">View and manage your generated images</p>
+      </div>
+      <div class="header-actions">
+        <div class="flex items-center space-x-3">
+          <div class="view-mode-toggle">
+            <button
+              type="button"
+              @click="setViewMode('grid')"
+              :class="viewMode === 'grid' ? 'view-mode-btn active' : 'view-mode-btn'"
+            >
+              <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                  d="M4 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2V6zM14 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2V6zM4 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2v-2zM14 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2v-2z"
+                />
+              </svg>
+            </button>
+            <button
+              type="button"
+              @click="setViewMode('list')"
+              :class="viewMode === 'list' ? 'view-mode-btn active' : 'view-mode-btn'"
+            >
+              <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 10h16M4 14h16M4 18h16" />
+              </svg>
+            </button>
+          </div>
+
+          <select :value="sortBy" @change="onSortChange" class="form-input text-sm">
+            <option value="created_at">Newest First</option>
+            <option value="created_at_asc">Oldest First</option>
+            <option value="prompt">By Prompt</option>
+            <option value="rating">By Rating</option>
+          </select>
+
+          <button
+            type="button"
+            @click="$emit('delete-selected')"
+            class="btn btn-danger btn-sm"
+            :disabled="selectedCount === 0"
+          >
+            <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
+              />
+            </svg>
+            Delete ({{ selectedCount }})
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import type { HistorySortOption } from '@/composables/useGenerationHistory';
+
+export type HistoryViewMode = 'grid' | 'list';
+
+const props = defineProps<{
+  viewMode: HistoryViewMode;
+  sortBy: HistorySortOption;
+  selectedCount: number;
+}>();
+
+const emit = defineEmits<{
+  (event: 'update:viewMode', value: HistoryViewMode): void;
+  (event: 'update:sortBy', value: HistorySortOption): void;
+  (event: 'sort-change'): void;
+  (event: 'delete-selected'): void;
+}>();
+
+const setViewMode = (mode: HistoryViewMode): void => {
+  if (props.viewMode === mode) {
+    return;
+  }
+
+  emit('update:viewMode', mode);
+};
+
+const onSortChange = (event: Event): void => {
+  const target = event.target as HTMLSelectElement | null;
+  if (!target) {
+    return;
+  }
+
+  const value = target.value as HistorySortOption;
+  if (value === props.sortBy) {
+    emit('sort-change');
+    return;
+  }
+
+  emit('update:sortBy', value);
+  emit('sort-change');
+};
+</script>

--- a/app/frontend/src/components/HistoryModalLauncher.vue
+++ b/app/frontend/src/components/HistoryModalLauncher.vue
@@ -1,0 +1,34 @@
+<template>
+  <HistoryModal
+    :visible="visible"
+    :result="result"
+    :formatted-date="formattedDate"
+    @close="emit('close')"
+    @reuse="emit('reuse', $event)"
+    @download="emit('download', $event)"
+    @delete="emit('delete', $event)"
+  />
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue';
+
+import type { GenerationHistoryResult } from '@/types';
+
+import HistoryModal from './HistoryModal.vue';
+
+const props = defineProps<{
+  visible: boolean;
+  result: GenerationHistoryResult | null;
+  formatDate: (date: string) => string;
+}>();
+
+const emit = defineEmits<{
+  (event: 'close'): void;
+  (event: 'reuse', result: GenerationHistoryResult): void;
+  (event: 'download', result: GenerationHistoryResult): void;
+  (event: 'delete', resultId: GenerationHistoryResult['id']): void;
+}>();
+
+const formattedDate = computed(() => (props.result ? props.formatDate(props.result.created_at) : ''));
+</script>

--- a/app/frontend/src/components/HistoryStatsSummary.vue
+++ b/app/frontend/src/components/HistoryStatsSummary.vue
@@ -1,0 +1,42 @@
+<template>
+  <div class="grid grid-cols-1 md:grid-cols-4 gap-4 mb-6">
+    <div class="card">
+      <div class="card-body text-center">
+        <div class="text-2xl font-bold text-blue-600">{{ stats.total_results }}</div>
+        <div class="text-sm text-gray-600">Total Images</div>
+      </div>
+    </div>
+    <div class="card">
+      <div class="card-body text-center">
+        <div class="text-2xl font-bold text-green-600">{{ formattedAverageRating }}</div>
+        <div class="text-sm text-gray-600">Average Rating</div>
+      </div>
+    </div>
+    <div class="card">
+      <div class="card-body text-center">
+        <div class="text-2xl font-bold text-purple-600">{{ stats.total_favorites }}</div>
+        <div class="text-sm text-gray-600">Favorited</div>
+      </div>
+    </div>
+    <div class="card">
+      <div class="card-body text-center">
+        <div class="text-2xl font-bold text-orange-600">{{ formattedStorageUsed }}</div>
+        <div class="text-sm text-gray-600">Storage Used</div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue';
+
+import type { GenerationHistoryStats } from '@/types';
+import { formatFileSize } from '@/utils/format';
+
+const props = defineProps<{ stats: GenerationHistoryStats }>();
+
+const formattedAverageRating = computed(() => props.stats.avg_rating.toFixed(1));
+const formattedStorageUsed = computed(() =>
+  formatFileSize(Number.isFinite(props.stats.total_size) ? props.stats.total_size : 0),
+);
+</script>

--- a/app/frontend/src/composables/useHistorySelection.ts
+++ b/app/frontend/src/composables/useHistorySelection.ts
@@ -1,0 +1,60 @@
+import { computed, ref } from 'vue';
+
+import type { GenerationHistoryResult } from '@/types';
+
+export type HistorySelectionChangePayload = {
+  id: GenerationHistoryResult['id'];
+  selected: boolean;
+};
+
+const cloneSelection = (current: Set<GenerationHistoryResult['id']>): Set<GenerationHistoryResult['id']> =>
+  new Set(current);
+
+export const useHistorySelection = () => {
+  const selectedItems = ref<Set<GenerationHistoryResult['id']>>(new Set());
+
+  const selectedSet = computed(() => selectedItems.value);
+  const selectedCount = computed(() => selectedItems.value.size);
+  const selectedIds = computed(() => Array.from(selectedItems.value));
+
+  const withUpdatedSelection = (
+    updater: (next: Set<GenerationHistoryResult['id']>) => void,
+  ): void => {
+    const next = cloneSelection(selectedItems.value);
+    updater(next);
+    selectedItems.value = next;
+  };
+
+  const onSelectionChange = ({ id, selected }: HistorySelectionChangePayload): void => {
+    withUpdatedSelection((next) => {
+      if (selected) {
+        next.add(id);
+        return;
+      }
+
+      next.delete(id);
+    });
+  };
+
+  const clearSelection = (): void => {
+    selectedItems.value = new Set();
+  };
+
+  const setSelection = (ids: Iterable<GenerationHistoryResult['id']>): void => {
+    selectedItems.value = new Set(ids);
+  };
+
+  const isSelected = (id: GenerationHistoryResult['id']): boolean => selectedItems.value.has(id);
+
+  return {
+    selectedItems,
+    selectedSet,
+    selectedCount,
+    selectedIds,
+    withUpdatedSelection,
+    onSelectionChange,
+    clearSelection,
+    setSelection,
+    isSelected,
+  } as const;
+};

--- a/app/frontend/src/composables/useHistoryToast.ts
+++ b/app/frontend/src/composables/useHistoryToast.ts
@@ -1,0 +1,52 @@
+import { onUnmounted, ref } from 'vue';
+
+export type HistoryToastType = 'success' | 'error' | 'info' | 'warning';
+
+export interface UseHistoryToastOptions {
+  duration?: number;
+}
+
+export const useHistoryToast = ({ duration = 3000 }: UseHistoryToastOptions = {}) => {
+  const toastVisible = ref(false);
+  const toastMessage = ref('');
+  const toastType = ref<HistoryToastType>('success');
+
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+
+  const clearToastTimer = (): void => {
+    if (timeout) {
+      clearTimeout(timeout);
+      timeout = undefined;
+    }
+  };
+
+  const hideToast = (): void => {
+    toastVisible.value = false;
+  };
+
+  const showToastMessage = (message: string, type: HistoryToastType = 'success'): void => {
+    clearToastTimer();
+
+    toastMessage.value = message;
+    toastType.value = type;
+    toastVisible.value = true;
+
+    timeout = setTimeout(() => {
+      hideToast();
+      timeout = undefined;
+    }, duration);
+  };
+
+  onUnmounted(() => {
+    clearToastTimer();
+  });
+
+  return {
+    toastVisible,
+    toastMessage,
+    toastType,
+    showToastMessage,
+    hideToast,
+    clearToastTimer,
+  } as const;
+};

--- a/tests/vue/HistoryActionToolbar.spec.ts
+++ b/tests/vue/HistoryActionToolbar.spec.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+
+import HistoryActionToolbar from '../../app/frontend/src/components/HistoryActionToolbar.vue';
+
+describe('HistoryActionToolbar', () => {
+  it('emits update:viewMode when toggling view mode', async () => {
+    const wrapper = mount(HistoryActionToolbar, {
+      props: {
+        viewMode: 'grid',
+        sortBy: 'created_at',
+        selectedCount: 0,
+      },
+    });
+
+    await wrapper.findAll('button')[1].trigger('click');
+
+    expect(wrapper.emitted()['update:viewMode']).toBeTruthy();
+    expect(wrapper.emitted()['update:viewMode']?.[0]).toEqual(['list']);
+  });
+
+  it('emits sort updates and sort-change when selection changes', async () => {
+    const wrapper = mount(HistoryActionToolbar, {
+      props: {
+        viewMode: 'grid',
+        sortBy: 'created_at',
+        selectedCount: 0,
+      },
+    });
+
+    const select = wrapper.find('select');
+    await select.setValue('prompt');
+
+    expect(wrapper.emitted()['update:sortBy']).toBeTruthy();
+    expect(wrapper.emitted()['update:sortBy']?.[0]).toEqual(['prompt']);
+    expect(wrapper.emitted()['sort-change']).toBeTruthy();
+
+    await select.setValue('prompt');
+    expect(wrapper.emitted()['sort-change']).toHaveLength(2);
+  });
+
+  it('emits delete-selected when delete button is pressed', async () => {
+    const wrapper = mount(HistoryActionToolbar, {
+      props: {
+        viewMode: 'grid',
+        sortBy: 'created_at',
+        selectedCount: 3,
+      },
+    });
+
+    const deleteButton = wrapper.findAll('button').at(-1);
+    await deleteButton?.trigger('click');
+
+    expect(wrapper.emitted()['delete-selected']).toBeTruthy();
+  });
+});

--- a/tests/vue/useHistorySelection.spec.ts
+++ b/tests/vue/useHistorySelection.spec.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+
+import { useHistorySelection } from '../../app/frontend/src/composables/useHistorySelection';
+
+describe('useHistorySelection', () => {
+  it('adds and removes ids from the selection set', () => {
+    const selection = useHistorySelection();
+
+    selection.onSelectionChange({ id: 1, selected: true });
+    expect(selection.selectedCount.value).toBe(1);
+    expect(selection.selectedSet.value.has(1)).toBe(true);
+
+    selection.onSelectionChange({ id: 2, selected: true });
+    expect(selection.selectedCount.value).toBe(2);
+    expect(selection.selectedIds.value).toEqual([1, 2]);
+
+    selection.onSelectionChange({ id: 1, selected: false });
+    expect(selection.selectedCount.value).toBe(1);
+    expect(selection.isSelected(1)).toBe(false);
+    expect(selection.isSelected(2)).toBe(true);
+  });
+
+  it('clears and replaces selection using helpers', () => {
+    const selection = useHistorySelection();
+
+    selection.setSelection([3, 4, 5]);
+    expect(selection.selectedCount.value).toBe(3);
+
+    selection.clearSelection();
+    expect(selection.selectedCount.value).toBe(0);
+    expect(selection.selectedIds.value).toEqual([]);
+
+    selection.withUpdatedSelection((next) => {
+      next.add(6);
+      next.add(7);
+    });
+
+    expect(selection.selectedIds.value).toEqual([6, 7]);
+  });
+});

--- a/tests/vue/useHistoryToast.spec.ts
+++ b/tests/vue/useHistoryToast.spec.ts
@@ -1,0 +1,45 @@
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
+
+import { useHistoryToast } from '../../app/frontend/src/composables/useHistoryToast';
+
+describe('useHistoryToast', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.runAllTimers();
+    vi.useRealTimers();
+  });
+
+  it('shows toast message and hides after the configured duration', () => {
+    const toast = useHistoryToast({ duration: 1000 });
+
+    toast.showToastMessage('hello world', 'info');
+
+    expect(toast.toastVisible.value).toBe(true);
+    expect(toast.toastMessage.value).toBe('hello world');
+    expect(toast.toastType.value).toBe('info');
+
+    vi.advanceTimersByTime(1000);
+
+    expect(toast.toastVisible.value).toBe(false);
+  });
+
+  it('resets the timer when a new toast is shown', () => {
+    const toast = useHistoryToast({ duration: 1000 });
+
+    toast.showToastMessage('first', 'success');
+    vi.advanceTimersByTime(700);
+
+    toast.showToastMessage('second', 'error');
+    expect(toast.toastMessage.value).toBe('second');
+    expect(toast.toastType.value).toBe('error');
+
+    vi.advanceTimersByTime(900);
+    expect(toast.toastVisible.value).toBe(true);
+
+    vi.advanceTimersByTime(100);
+    expect(toast.toastVisible.value).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- extract selection and toast state from GenerationHistoryContainer into dedicated composables
- introduce HistoryActionToolbar, HistoryStatsSummary, and HistoryModalLauncher to simplify the container template
- add unit tests covering the new composables and toolbar behaviors

## Testing
- npm run test:unit

------
https://chatgpt.com/codex/tasks/task_e_68d2c59990a88329a71e22d8a339b61f