### PR TITLE
Refactor import/export workflows into modular components

### DIFF
--- a/app/frontend/src/components/import-export/ExportConfigurationPanel.vue
+++ b/app/frontend/src/components/import-export/ExportConfigurationPanel.vue
@@ -1,303 +1,37 @@
 <template>
   <div class="space-y-6">
     <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
-      <div class="card">
-        <div class="card-header">
-          <h3 class="text-lg font-semibold">Select Data to Export</h3>
-        </div>
-        <div class="card-body space-y-4">
-          <div>
-            <label class="flex items-center">
-              <input
-                type="checkbox"
-                class="form-checkbox mr-3"
-                :checked="config.loras"
-                @change="onCheckboxChange('loras', $event)"
-              >
-              <div>
-                <div class="font-medium">LoRA Models</div>
-                <div class="text-sm text-gray-600">All LoRA files, metadata, and configurations</div>
-              </div>
-            </label>
-
-            <div
-              v-show="config.loras"
-              class="ml-6 mt-3 space-y-2 transition-all duration-200"
-            >
-              <label class="flex items-center">
-                <input
-                  type="checkbox"
-                  class="form-checkbox mr-2"
-                  :checked="config.lora_files"
-                  @change="onCheckboxChange('lora_files', $event)"
-                >
-                <span class="text-sm">Include model files</span>
-              </label>
-              <label class="flex items-center">
-                <input
-                  type="checkbox"
-                  class="form-checkbox mr-2"
-                  :checked="config.lora_metadata"
-                  @change="onCheckboxChange('lora_metadata', $event)"
-                >
-                <span class="text-sm">Include metadata only</span>
-              </label>
-              <label class="flex items-center">
-                <input
-                  type="checkbox"
-                  class="form-checkbox mr-2"
-                  :checked="config.lora_embeddings"
-                  @change="onCheckboxChange('lora_embeddings', $event)"
-                >
-                <span class="text-sm">Include embeddings</span>
-              </label>
-            </div>
-          </div>
-
-          <div>
-            <label class="flex items-center">
-              <input
-                type="checkbox"
-                class="form-checkbox mr-3"
-                :checked="config.generations"
-                @change="onCheckboxChange('generations', $event)"
-              >
-              <div>
-                <div class="font-medium">Generation Results</div>
-                <div class="text-sm text-gray-600">Generated images and their parameters</div>
-              </div>
-            </label>
-
-            <div
-              v-show="config.generations"
-              class="ml-6 mt-3 space-y-2 transition-all duration-200"
-            >
-              <div class="flex items-center space-x-4">
-                <label class="flex items-center">
-                  <input
-                    type="radio"
-                    class="form-radio mr-2"
-                    name="generation_range"
-                    value="all"
-                    :checked="config.generation_range === 'all'"
-                    @change="onRadioChange('generation_range', $event)"
-                  >
-                  <span class="text-sm">All generations</span>
-                </label>
-                <label class="flex items-center">
-                  <input
-                    type="radio"
-                    class="form-radio mr-2"
-                    name="generation_range"
-                    value="date_range"
-                    :checked="config.generation_range === 'date_range'"
-                    @change="onRadioChange('generation_range', $event)"
-                  >
-                  <span class="text-sm">Date range</span>
-                </label>
-              </div>
-
-              <div
-                v-show="config.generation_range === 'date_range'"
-                class="grid grid-cols-2 gap-3 transition-all duration-200"
-              >
-                <div>
-                  <label class="form-label text-xs">From Date</label>
-                  <input
-                    type="date"
-                    class="form-input text-sm"
-                    :value="config.date_from"
-                    @input="onInputChange('date_from', $event)"
-                  >
-                </div>
-                <div>
-                  <label class="form-label text-xs">To Date</label>
-                  <input
-                    type="date"
-                    class="form-input text-sm"
-                    :value="config.date_to"
-                    @input="onInputChange('date_to', $event)"
-                  >
-                </div>
-              </div>
-            </div>
-          </div>
-
-          <div>
-            <label class="flex items-center">
-              <input
-                type="checkbox"
-                class="form-checkbox mr-3"
-                :checked="config.user_data"
-                @change="onCheckboxChange('user_data', $event)"
-              >
-              <div>
-                <div class="font-medium">User Data</div>
-                <div class="text-sm text-gray-600">User preferences and settings</div>
-              </div>
-            </label>
-          </div>
-
-          <div>
-            <label class="flex items-center">
-              <input
-                type="checkbox"
-                class="form-checkbox mr-3"
-                :checked="config.system_config"
-                @change="onCheckboxChange('system_config', $event)"
-              >
-              <div>
-                <div class="font-medium">System Configuration</div>
-                <div class="text-sm text-gray-600">System settings and configurations</div>
-              </div>
-            </label>
-          </div>
-
-          <div>
-            <label class="flex items-center">
-              <input
-                type="checkbox"
-                class="form-checkbox mr-3"
-                :checked="config.analytics"
-                @change="onCheckboxChange('analytics', $event)"
-              >
-              <div>
-                <div class="font-medium">Analytics</div>
-                <div class="text-sm text-gray-600">Usage metrics and performance data</div>
-              </div>
-            </label>
-          </div>
-        </div>
-      </div>
-
-      <div class="card">
-        <div class="card-header">
-          <h3 class="text-lg font-semibold">Export Settings</h3>
-        </div>
-        <div class="card-body space-y-4">
-          <div>
-            <label class="form-label">Export Format</label>
-            <select
-              class="form-input"
-              :value="config.format"
-              @change="onSelectChange('format', $event)"
-            >
-              <option value="zip">ZIP Archive</option>
-              <option value="tar.gz">TAR.GZ Archive</option>
-              <option value="json">JSON Files</option>
-            </select>
-          </div>
-
-          <div>
-            <label class="form-label">Compression Level</label>
-            <select
-              class="form-input"
-              :value="config.compression"
-              @change="onSelectChange('compression', $event)"
-            >
-              <option value="none">No Compression</option>
-              <option value="fast">Fast</option>
-              <option value="balanced">Balanced</option>
-              <option value="maximum">Maximum</option>
-            </select>
-          </div>
-
-          <div>
-            <label class="flex items-center">
-              <input
-                type="checkbox"
-                class="form-checkbox mr-2"
-                :checked="config.split_archives"
-                @change="onCheckboxChange('split_archives', $event)"
-              >
-              <span>Split large archives</span>
-            </label>
-            <div
-              v-show="config.split_archives"
-              class="mt-2 transition-all duration-200"
-            >
-              <label class="form-label text-sm">Max size per archive (MB)</label>
-              <input
-                type="number"
-                min="100"
-                max="4096"
-                class="form-input text-sm"
-                :value="config.max_size_mb"
-                @input="onNumberInput('max_size_mb', $event)"
-              >
-            </div>
-          </div>
-
-          <div>
-            <label class="flex items-center">
-              <input
-                type="checkbox"
-                class="form-checkbox mr-2"
-                :checked="config.encrypt"
-                @change="onCheckboxChange('encrypt', $event)"
-              >
-              <span>Encrypt export</span>
-            </label>
-            <div
-              v-show="config.encrypt"
-              class="mt-2 transition-all duration-200"
-            >
-              <label class="form-label text-sm">Password</label>
-              <input
-                type="password"
-                class="form-input text-sm"
-                :value="config.password"
-                @input="onInputChange('password', $event)"
-              >
-            </div>
-          </div>
-
-          <div class="p-3 bg-gray-50 rounded">
-            <div class="text-sm font-medium">Estimated Export Size</div>
-            <div class="text-lg font-bold text-blue-600">{{ estimatedSize }}</div>
-            <div class="text-xs text-gray-600">
-              Processing time: ~{{ estimatedTime }}
-            </div>
-          </div>
-        </div>
-      </div>
+      <ExportDataSelectionForm :config="config" @update-config="onUpdateConfig" />
+      <ExportSettingsForm
+        :config="config"
+        :estimated-size="estimatedSize"
+        :estimated-time="estimatedTime"
+        @update-config="onUpdateConfig"
+      />
     </div>
 
-    <div class="flex justify-between items-center pt-6 border-t">
-      <div class="flex items-center space-x-4">
-        <button class="btn btn-secondary" @click="$emit('validate')">
-          Validate Selection
-        </button>
-        <button class="btn btn-secondary" @click="$emit('preview')">
-          Preview Contents
-        </button>
-      </div>
-      <button
-        class="btn btn-primary"
-        :disabled="!canExport || isExporting"
-        @click="$emit('start')"
-      >
-        <template v-if="!isExporting">
-          <span>Start Export</span>
-        </template>
-        <template v-else>
-          <div class="flex items-center">
-            <svg class="animate-spin w-4 h-4 mr-2" fill="none" viewBox="0 0 24 24">
-              <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
-              <path class="opacity-75" fill="currentColor" d="m 12 2 a 10,10 0 0,1 10,10 h -4 a 6,6 0 0,0 -6,-6 z"></path>
-            </svg>
-            Exporting...
-          </div>
-        </template>
-      </button>
-    </div>
+    <ExportWorkflowActions
+      :can-export="canExport"
+      :is-exporting="isExporting"
+      @validate="$emit('validate')"
+      @preview="$emit('preview')"
+      @start="$emit('start')"
+    />
   </div>
 </template>
 
 <script setup lang="ts">
+import { toRefs } from 'vue';
+
+import ExportDataSelectionForm from './ExportDataSelectionForm.vue';
+import ExportSettingsForm from './ExportSettingsForm.vue';
+import ExportWorkflowActions from './ExportWorkflowActions.vue';
+
 import type { ExportConfig } from '@/composables/useExportWorkflow';
 
-type ExportConfigKey = keyof ExportConfig;
+type UpdateConfigEmitter<TConfig> = {
+  <K extends keyof TConfig>(event: 'update-config', key: K, value: TConfig[K]): void;
+};
 
 const props = defineProps<{
   config: ExportConfig;
@@ -307,9 +41,7 @@ const props = defineProps<{
   isExporting: boolean;
 }>();
 
-type UpdateConfigEmitter<TConfig> = {
-  <K extends keyof TConfig>(event: 'update-config', key: K, value: TConfig[K]): void;
-};
+const { config, canExport, estimatedSize, estimatedTime, isExporting } = toRefs(props);
 
 const emit = defineEmits<
   UpdateConfigEmitter<ExportConfig> & {
@@ -319,43 +51,7 @@ const emit = defineEmits<
   }
 >();
 
-const updateConfig = <K extends ExportConfigKey>(key: K, value: ExportConfig[K]) => {
+const onUpdateConfig = <K extends keyof ExportConfig>(key: K, value: ExportConfig[K]) => {
   emit('update-config', key, value);
-};
-
-const onCheckboxChange = <K extends ExportConfigKey>(key: K, event: Event) => {
-  const target = event.target as HTMLInputElement | null;
-  if (target) {
-    updateConfig(key, target.checked as ExportConfig[K]);
-  }
-};
-
-const onRadioChange = <K extends ExportConfigKey>(key: K, event: Event) => {
-  const target = event.target as HTMLInputElement | null;
-  if (target) {
-    updateConfig(key, target.value as ExportConfig[K]);
-  }
-};
-
-const onSelectChange = <K extends ExportConfigKey>(key: K, event: Event) => {
-  const target = event.target as HTMLSelectElement | null;
-  if (target) {
-    updateConfig(key, target.value as ExportConfig[K]);
-  }
-};
-
-const onInputChange = <K extends ExportConfigKey>(key: K, event: Event) => {
-  const target = event.target as HTMLInputElement | null;
-  if (target) {
-    updateConfig(key, target.value as ExportConfig[K]);
-  }
-};
-
-const onNumberInput = <K extends ExportConfigKey>(key: K, event: Event) => {
-  const target = event.target as HTMLInputElement | null;
-  if (target) {
-    const parsed = Number(target.value);
-    updateConfig(key, (Number.isNaN(parsed) ? 0 : parsed) as ExportConfig[K]);
-  }
 };
 </script>

--- a/app/frontend/src/components/import-export/ExportDataSelectionForm.vue
+++ b/app/frontend/src/components/import-export/ExportDataSelectionForm.vue
@@ -1,0 +1,191 @@
+<template>
+  <div class="card">
+    <div class="card-header">
+      <h3 class="text-lg font-semibold">Select Data to Export</h3>
+    </div>
+    <div class="card-body space-y-4">
+      <div>
+        <label class="flex items-center">
+          <input
+            type="checkbox"
+            class="form-checkbox mr-3"
+            :checked="config.loras"
+            @change="onCheckboxChange('loras', $event)"
+          >
+          <div>
+            <div class="font-medium">LoRA Models</div>
+            <div class="text-sm text-gray-600">All LoRA files, metadata, and configurations</div>
+          </div>
+        </label>
+
+        <div
+          v-show="config.loras"
+          class="ml-6 mt-3 space-y-2 transition-all duration-200"
+        >
+          <label class="flex items-center">
+            <input
+              type="checkbox"
+              class="form-checkbox mr-2"
+              :checked="config.lora_files"
+              @change="onCheckboxChange('lora_files', $event)"
+            >
+            <span class="text-sm">Include model files</span>
+          </label>
+          <label class="flex items-center">
+            <input
+              type="checkbox"
+              class="form-checkbox mr-2"
+              :checked="config.lora_metadata"
+              @change="onCheckboxChange('lora_metadata', $event)"
+            >
+            <span class="text-sm">Include metadata only</span>
+          </label>
+          <label class="flex items-center">
+            <input
+              type="checkbox"
+              class="form-checkbox mr-2"
+              :checked="config.lora_embeddings"
+              @change="onCheckboxChange('lora_embeddings', $event)"
+            >
+            <span class="text-sm">Include embeddings</span>
+          </label>
+        </div>
+      </div>
+
+      <div>
+        <label class="flex items-center">
+          <input
+            type="checkbox"
+            class="form-checkbox mr-3"
+            :checked="config.generations"
+            @change="onCheckboxChange('generations', $event)"
+          >
+          <div>
+            <div class="font-medium">Generation Results</div>
+            <div class="text-sm text-gray-600">Generated images and their parameters</div>
+          </div>
+        </label>
+
+        <div
+          v-show="config.generations"
+          class="ml-6 mt-3 space-y-2 transition-all duration-200"
+        >
+          <div class="flex items-center space-x-4">
+            <label class="flex items-center">
+              <input
+                type="radio"
+                class="form-radio mr-2"
+                name="generation_range"
+                value="all"
+                :checked="config.generation_range === 'all'"
+                @change="onRadioChange('generation_range', $event)"
+              >
+              <span class="text-sm">All generations</span>
+            </label>
+            <label class="flex items-center">
+              <input
+                type="radio"
+                class="form-radio mr-2"
+                name="generation_range"
+                value="date_range"
+                :checked="config.generation_range === 'date_range'"
+                @change="onRadioChange('generation_range', $event)"
+              >
+              <span class="text-sm">Date range</span>
+            </label>
+          </div>
+
+          <div
+            v-show="config.generation_range === 'date_range'"
+            class="grid grid-cols-2 gap-3 transition-all duration-200"
+          >
+            <div>
+              <label class="form-label text-xs">From Date</label>
+              <input
+                type="date"
+                class="form-input text-sm"
+                :value="config.date_from"
+                @input="onInputChange('date_from', $event)"
+              >
+            </div>
+            <div>
+              <label class="form-label text-xs">To Date</label>
+              <input
+                type="date"
+                class="form-input text-sm"
+                :value="config.date_to"
+                @input="onInputChange('date_to', $event)"
+              >
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div>
+        <label class="flex items-center">
+          <input
+            type="checkbox"
+            class="form-checkbox mr-3"
+            :checked="config.user_data"
+            @change="onCheckboxChange('user_data', $event)"
+          >
+          <div>
+            <div class="font-medium">User Data</div>
+            <div class="text-sm text-gray-600">User preferences and settings</div>
+          </div>
+        </label>
+      </div>
+
+      <div>
+        <label class="flex items-center">
+          <input
+            type="checkbox"
+            class="form-checkbox mr-3"
+            :checked="config.system_config"
+            @change="onCheckboxChange('system_config', $event)"
+          >
+          <div>
+            <div class="font-medium">System Configuration</div>
+            <div class="text-sm text-gray-600">System settings and configurations</div>
+          </div>
+        </label>
+      </div>
+
+      <div>
+        <label class="flex items-center">
+          <input
+            type="checkbox"
+            class="form-checkbox mr-3"
+            :checked="config.analytics"
+            @change="onCheckboxChange('analytics', $event)"
+          >
+          <div>
+            <div class="font-medium">Analytics</div>
+            <div class="text-sm text-gray-600">Usage metrics and performance data</div>
+          </div>
+        </label>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { useExportConfigFields } from '@/composables/useExportConfigFields';
+import type { ExportConfig } from '@/composables/useExportWorkflow';
+
+type UpdateConfigEmitter<TConfig> = {
+  <K extends keyof TConfig>(event: 'update-config', key: K, value: TConfig[K]): void;
+};
+
+const props = defineProps<{
+  config: ExportConfig;
+}>();
+
+const config = props.config;
+
+const emit = defineEmits<UpdateConfigEmitter<ExportConfig>>();
+
+const { onCheckboxChange, onRadioChange, onInputChange } = useExportConfigFields((key, value) => {
+  emit('update-config', key, value);
+});
+</script>

--- a/app/frontend/src/components/import-export/ExportSettingsForm.vue
+++ b/app/frontend/src/components/import-export/ExportSettingsForm.vue
@@ -1,0 +1,116 @@
+<template>
+  <div class="card">
+    <div class="card-header">
+      <h3 class="text-lg font-semibold">Export Settings</h3>
+    </div>
+    <div class="card-body space-y-4">
+      <div>
+        <label class="form-label">Export Format</label>
+        <select
+          class="form-input"
+          :value="config.format"
+          @change="onSelectChange('format', $event)"
+        >
+          <option value="zip">ZIP Archive</option>
+          <option value="tar.gz">TAR.GZ Archive</option>
+          <option value="json">JSON Files</option>
+        </select>
+      </div>
+
+      <div>
+        <label class="form-label">Compression Level</label>
+        <select
+          class="form-input"
+          :value="config.compression"
+          @change="onSelectChange('compression', $event)"
+        >
+          <option value="none">No Compression</option>
+          <option value="fast">Fast</option>
+          <option value="balanced">Balanced</option>
+          <option value="maximum">Maximum</option>
+        </select>
+      </div>
+
+      <div>
+        <label class="flex items-center">
+          <input
+            type="checkbox"
+            class="form-checkbox mr-2"
+            :checked="config.split_archives"
+            @change="onCheckboxChange('split_archives', $event)"
+          >
+          <span>Split large archives</span>
+        </label>
+        <div
+          v-show="config.split_archives"
+          class="mt-2 transition-all duration-200"
+        >
+          <label class="form-label text-sm">Max size per archive (MB)</label>
+          <input
+            type="number"
+            min="100"
+            max="4096"
+            class="form-input text-sm"
+            :value="config.max_size_mb"
+            @input="onNumberInput('max_size_mb', $event)"
+          >
+        </div>
+      </div>
+
+      <div>
+        <label class="flex items-center">
+          <input
+            type="checkbox"
+            class="form-checkbox mr-2"
+            :checked="config.encrypt"
+            @change="onCheckboxChange('encrypt', $event)"
+          >
+          <span>Encrypt export</span>
+        </label>
+        <div
+          v-show="config.encrypt"
+          class="mt-2 transition-all duration-200"
+        >
+          <label class="form-label text-sm">Password</label>
+          <input
+            type="password"
+            class="form-input text-sm"
+            :value="config.password"
+            @input="onInputChange('password', $event)"
+          >
+        </div>
+      </div>
+
+      <div class="p-3 bg-gray-50 rounded">
+        <div class="text-sm font-medium">Estimated Export Size</div>
+        <div class="text-lg font-bold text-blue-600">{{ estimatedSize }}</div>
+        <div class="text-xs text-gray-600">
+          Processing time: ~{{ estimatedTime }}
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { useExportConfigFields } from '@/composables/useExportConfigFields';
+import type { ExportConfig } from '@/composables/useExportWorkflow';
+
+type UpdateConfigEmitter<TConfig> = {
+  <K extends keyof TConfig>(event: 'update-config', key: K, value: TConfig[K]): void;
+};
+
+const props = defineProps<{
+  config: ExportConfig;
+  estimatedSize: string;
+  estimatedTime: string;
+}>();
+
+const config = props.config;
+
+const emit = defineEmits<UpdateConfigEmitter<ExportConfig>>();
+
+const { onCheckboxChange, onSelectChange, onNumberInput, onInputChange } = useExportConfigFields((key, value) => {
+  emit('update-config', key, value);
+});
+</script>

--- a/app/frontend/src/components/import-export/ExportWorkflowActions.vue
+++ b/app/frontend/src/components/import-export/ExportWorkflowActions.vue
@@ -1,0 +1,43 @@
+<template>
+  <div class="flex justify-between items-center pt-6 border-t">
+    <div class="flex items-center space-x-4">
+      <button class="btn btn-secondary" @click="$emit('validate')">
+        Validate Selection
+      </button>
+      <button class="btn btn-secondary" @click="$emit('preview')">
+        Preview Contents
+      </button>
+    </div>
+    <button
+      class="btn btn-primary"
+      :disabled="!canExport || isExporting"
+      @click="$emit('start')"
+    >
+      <template v-if="!isExporting">
+        <span>Start Export</span>
+      </template>
+      <template v-else>
+        <div class="flex items-center">
+          <svg class="animate-spin w-4 h-4 mr-2" fill="none" viewBox="0 0 24 24">
+            <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+            <path class="opacity-75" fill="currentColor" d="m 12 2 a 10,10 0 0,1 10,10 h -4 a 6,6 0 0,0 -6,-6 z"></path>
+          </svg>
+          Exporting...
+        </div>
+      </template>
+    </button>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { toRefs } from 'vue';
+
+const props = defineProps<{
+  canExport: boolean;
+  isExporting: boolean;
+}>();
+
+const { canExport, isExporting } = toRefs(props);
+
+defineEmits<{ (e: 'validate'): void; (e: 'preview'): void; (e: 'start'): void }>();
+</script>

--- a/app/frontend/src/composables/useExportConfigFields.ts
+++ b/app/frontend/src/composables/useExportConfigFields.ts
@@ -1,0 +1,51 @@
+import type { ExportConfig } from './useExportWorkflow';
+
+type ExportConfigKey = keyof ExportConfig;
+
+type UpdateConfigFn = <K extends ExportConfigKey>(key: K, value: ExportConfig[K]) => void;
+
+export function useExportConfigFields(updateConfig: UpdateConfigFn) {
+  const onCheckboxChange = <K extends ExportConfigKey>(key: K, event: Event) => {
+    const target = event.target as HTMLInputElement | null;
+    if (target) {
+      updateConfig(key, target.checked as ExportConfig[K]);
+    }
+  };
+
+  const onRadioChange = <K extends ExportConfigKey>(key: K, event: Event) => {
+    const target = event.target as HTMLInputElement | null;
+    if (target) {
+      updateConfig(key, target.value as ExportConfig[K]);
+    }
+  };
+
+  const onSelectChange = <K extends ExportConfigKey>(key: K, event: Event) => {
+    const target = event.target as HTMLSelectElement | null;
+    if (target) {
+      updateConfig(key, target.value as ExportConfig[K]);
+    }
+  };
+
+  const onInputChange = <K extends ExportConfigKey>(key: K, event: Event) => {
+    const target = event.target as HTMLInputElement | null;
+    if (target) {
+      updateConfig(key, target.value as ExportConfig[K]);
+    }
+  };
+
+  const onNumberInput = <K extends ExportConfigKey>(key: K, event: Event) => {
+    const target = event.target as HTMLInputElement | null;
+    if (target) {
+      const parsed = Number(target.value);
+      updateConfig(key, (Number.isNaN(parsed) ? 0 : parsed) as ExportConfig[K]);
+    }
+  };
+
+  return {
+    onCheckboxChange,
+    onRadioChange,
+    onSelectChange,
+    onInputChange,
+    onNumberInput
+  };
+}

--- a/app/frontend/src/composables/useImportExportActions.ts
+++ b/app/frontend/src/composables/useImportExportActions.ts
@@ -1,0 +1,118 @@
+import type { Ref } from 'vue';
+
+import type { ActiveTab } from '@/components/ImportExport.vue';
+import type { NotifyType, UseExportWorkflow } from './useExportWorkflow';
+import type { UseImportWorkflow } from './useImportWorkflow';
+import type { UseBackupWorkflow } from './useBackupWorkflow';
+import type { UseMigrationWorkflow } from './useMigrationWorkflow';
+import type { OperationType } from './useOperationProgress';
+
+interface UseImportExportActionsOptions {
+  exportWorkflow: UseExportWorkflow;
+  importWorkflow: UseImportWorkflow;
+  backupWorkflow: UseBackupWorkflow;
+  migrationWorkflow: UseMigrationWorkflow;
+  activeTab: Ref<ActiveTab>;
+  currentOperation: Ref<OperationType | null>;
+  endProgress: () => void;
+  notify: (message: string, type?: NotifyType) => void;
+}
+
+export function useImportExportActions(options: UseImportExportActionsOptions) {
+  const {
+    exportWorkflow,
+    importWorkflow,
+    backupWorkflow,
+    migrationWorkflow,
+    activeTab,
+    currentOperation,
+    endProgress,
+    notify
+  } = options;
+
+  const handleActiveTabChange = (value: ActiveTab) => {
+    activeTab.value = value;
+  };
+
+  const handleExportConfigUpdate = exportWorkflow.updateConfig;
+  const handleValidateExport = exportWorkflow.validateExport;
+  const handlePreviewExport = exportWorkflow.previewExport;
+  const handleStartExport = () => {
+    void exportWorkflow.startExport();
+  };
+  const handleQuickExportAll = () => {
+    void exportWorkflow.quickExportAll();
+  };
+
+  const handleImportConfigUpdate = importWorkflow.updateConfig;
+  const handleImportFilesAdded = (files: readonly File[]) => {
+    importWorkflow.addFiles([...files]);
+  };
+  const handleImportFileRemoved = (file: File) => {
+    importWorkflow.removeFile(file);
+  };
+  const handleAnalyzeFiles = () => {
+    void importWorkflow.analyzeFiles();
+  };
+  const handleValidateImport = importWorkflow.validateImport;
+  const handleStartImport = () => {
+    void importWorkflow.startImport();
+  };
+
+  const handleCreateFullBackup = () => {
+    void backupWorkflow.createFullBackup();
+  };
+  const handleCreateQuickBackup = () => {
+    void backupWorkflow.createQuickBackup();
+  };
+  const handleScheduleBackup = backupWorkflow.scheduleBackup;
+  const handleDownloadBackup = backupWorkflow.downloadBackup;
+  const handleRestoreBackup = backupWorkflow.restoreBackup;
+  const handleDeleteBackup = backupWorkflow.deleteBackup;
+
+  const handleMigrationConfigUpdate = migrationWorkflow.updateConfig;
+  const handleStartVersionMigration = migrationWorkflow.startVersionMigration;
+  const handleStartPlatformMigration = migrationWorkflow.startPlatformMigration;
+
+  const handleViewHistory = () => {
+    activeTab.value = 'backup';
+  };
+
+  const cancelHandlers: Partial<Record<OperationType, () => void>> = {
+    export: () => exportWorkflow.cancelExport(),
+    import: () => importWorkflow.cancelImport()
+  };
+
+  const handleCancelOperation = () => {
+    const operation = currentOperation.value;
+    cancelHandlers[operation ?? undefined]?.();
+    endProgress();
+    notify('Operation cancelled', 'warning');
+  };
+
+  return {
+    handleActiveTabChange,
+    handleExportConfigUpdate,
+    handleValidateExport,
+    handlePreviewExport,
+    handleStartExport,
+    handleQuickExportAll,
+    handleImportConfigUpdate,
+    handleImportFilesAdded,
+    handleImportFileRemoved,
+    handleAnalyzeFiles,
+    handleValidateImport,
+    handleStartImport,
+    handleCreateFullBackup,
+    handleCreateQuickBackup,
+    handleScheduleBackup,
+    handleDownloadBackup,
+    handleRestoreBackup,
+    handleDeleteBackup,
+    handleMigrationConfigUpdate,
+    handleStartVersionMigration,
+    handleStartPlatformMigration,
+    handleViewHistory,
+    handleCancelOperation
+  };
+}

--- a/app/frontend/src/composables/useOperationProgress.ts
+++ b/app/frontend/src/composables/useOperationProgress.ts
@@ -1,0 +1,81 @@
+import { computed, ref } from 'vue';
+
+import type { ProgressUpdate } from './useExportWorkflow';
+
+export type OperationType = 'export' | 'import' | 'migration';
+
+export interface ProgressMessage {
+  id: number | string;
+  text: string;
+}
+
+const PROGRESS_TITLES: Record<OperationType, string> = {
+  export: 'Export Progress',
+  import: 'Import Progress',
+  migration: 'Migration Progress'
+};
+
+export function useOperationProgress() {
+  const showProgress = ref(false);
+  const progressValue = ref(0);
+  const currentStep = ref('');
+  const progressMessages = ref<ProgressMessage[]>([]);
+  const currentOperation = ref<OperationType | null>(null);
+
+  const progressTitle = computed(() => {
+    if (!currentOperation.value) {
+      return 'Progress';
+    }
+    return PROGRESS_TITLES[currentOperation.value] ?? 'Progress';
+  });
+
+  const reset = () => {
+    progressValue.value = 0;
+    currentStep.value = '';
+    progressMessages.value = [];
+  };
+
+  const begin = (operation: OperationType) => {
+    currentOperation.value = operation;
+    reset();
+    showProgress.value = true;
+  };
+
+  const update = (update: ProgressUpdate) => {
+    if (typeof update.value === 'number') {
+      progressValue.value = update.value;
+    }
+
+    if (typeof update.step === 'string') {
+      currentStep.value = update.step;
+    }
+
+    if (update.message) {
+      progressMessages.value = [
+        ...progressMessages.value,
+        {
+          id: Date.now() + Math.random(),
+          text: `[${new Date().toLocaleTimeString()}] ${update.message}`
+        }
+      ];
+    }
+  };
+
+  const end = () => {
+    showProgress.value = false;
+    currentOperation.value = null;
+  };
+
+  return {
+    showProgress,
+    progressTitle,
+    progressValue,
+    currentStep,
+    progressMessages,
+    currentOperation,
+    begin,
+    update,
+    end,
+    reset
+  };
+}

--- a/app/frontend/src/composables/useWorkflowToast.ts
+++ b/app/frontend/src/composables/useWorkflowToast.ts
@@ -1,0 +1,54 @@
+import { onBeforeUnmount, ref } from 'vue';
+
+import type { NotifyType } from './useExportWorkflow';
+
+export interface UseWorkflowToastOptions {
+  duration?: number;
+}
+
+export function useWorkflowToast(options: UseWorkflowToastOptions = {}) {
+  const { duration = 3000 } = options;
+
+  const showToast = ref(false);
+  const toastMessage = ref('');
+  const toastType = ref<NotifyType>('info');
+
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+
+  const clear = () => {
+    if (timeoutId) {
+      clearTimeout(timeoutId);
+      timeoutId = undefined;
+    }
+  };
+
+  const notify = (message: string, type: NotifyType = 'info') => {
+    toastMessage.value = message;
+    toastType.value = type;
+    showToast.value = true;
+
+    clear();
+
+    timeoutId = setTimeout(() => {
+      showToast.value = false;
+      timeoutId = undefined;
+    }, duration);
+  };
+
+  const dismiss = () => {
+    showToast.value = false;
+    clear();
+  };
+
+  onBeforeUnmount(() => {
+    clear();
+  });
+
+  return {
+    showToast,
+    toastMessage,
+    toastType,
+    notify,
+    dismiss
+  };
+}

--- a/tests/vue/ImportExport.spec.js
+++ b/tests/vue/ImportExport.spec.js
@@ -4,10 +4,10 @@ import { flushPromises, mount } from '@vue/test-utils';
 
 import ImportExportContainer from '../../app/frontend/src/components/import-export/ImportExportContainer.vue';
 
-function stubComponent(name) {
+function stubComponent(name, emits = []) {
   return defineComponent({
     name,
-    emits: [],
+    emits,
     setup(_, { slots }) {
       return () => h('div', { class: name }, slots.default ? slots.default() : name);
     }
@@ -85,19 +85,37 @@ vi.mock('@/composables/useMigrationWorkflow', () => ({
 }));
 
 vi.mock('@/components/import-export/ExportConfigurationPanel.vue', () => ({
-  default: stubComponent('ExportConfigurationPanel')
+  default: stubComponent('ExportConfigurationPanel', ['update-config', 'validate', 'preview', 'start'])
 }));
 
 vi.mock('@/components/import-export/ImportProcessingPanel.vue', () => ({
-  default: stubComponent('ImportProcessingPanel')
+  default: stubComponent('ImportProcessingPanel', [
+    'update-config',
+    'add-files',
+    'remove-file',
+    'analyze',
+    'validate',
+    'start'
+  ])
 }));
 
 vi.mock('@/components/import-export/BackupManagementPanel.vue', () => ({
-  default: stubComponent('BackupManagementPanel')
+  default: stubComponent('BackupManagementPanel', [
+    'create-full-backup',
+    'create-quick-backup',
+    'schedule-backup',
+    'download-backup',
+    'restore-backup',
+    'delete-backup'
+  ])
 }));
 
 vi.mock('@/components/import-export/MigrationWorkflowPanel.vue', () => ({
-  default: stubComponent('MigrationWorkflowPanel')
+  default: stubComponent('MigrationWorkflowPanel', [
+    'update-config',
+    'start-version-migration',
+    'start-platform-migration'
+  ])
 }));
 
 describe('ImportExportContainer.vue', () => {


### PR DESCRIPTION
## Summary
- refactor `ImportExportContainer` to delegate toast/progress handling to new composables and consolidate event handlers
- break the export configuration UI into focused child components backed by shared form helpers
- add a reusable action harness and update unit tests to match the reorganized component structure

## Testing
- npx vitest run tests/vue/ImportExport.spec.js tests/vue/ImportExportView.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68d2cb29b7248329bae4486bf85fdb49