### PR TITLE
feat: centralize lora selection logic

### DIFF
--- a/app/frontend/src/components/LoraGallery.vue
+++ b/app/frontend/src/components/LoraGallery.vue
@@ -36,7 +36,7 @@
 
       <LoraGalleryBulkActions
         :bulk-mode="bulkMode"
-        :selected-count="selectedLoras.length"
+        :selected-count="selectedCount"
         :all-selected="allSelected"
         @perform="performBulkAction"
         @toggle-select-all="toggleSelectAll"
@@ -99,6 +99,7 @@ const {
 
 const {
   selectedLoras,
+  selectedCount,
   viewMode,
   bulkMode,
   allSelected,
@@ -107,6 +108,8 @@ const {
   handleSelectionChange,
   toggleSelectAll,
   initializeSelection,
+  clearSelection,
+  deselect,
 } = useLoraGallerySelection(filteredLoras);
 
 const isTagModalOpen = ref(false);
@@ -125,19 +128,19 @@ const closeTagModal = () => {
 };
 
 const performBulkAction = async (action: LoraBulkAction) => {
-  if (selectedLoras.value.length === 0) {
+  if (selectedCount.value === 0) {
     windowExtras.htmx?.trigger(document.body, 'show-notification', {
       detail: { message: 'No LoRAs selected.', type: 'warning' },
     });
     return;
   }
 
-  const confirmMsg = `Are you sure you want to ${action} ${selectedLoras.value.length} LoRA(s)?`;
+  const confirmMsg = `Are you sure you want to ${action} ${selectedCount.value} LoRA(s)?`;
   if (!confirm(confirmMsg)) {
     return;
   }
 
-  const count = selectedLoras.value.length;
+  const count = selectedCount.value;
 
   try {
     await performBulkLoraAction(apiBaseUrl.value, {
@@ -146,7 +149,7 @@ const performBulkAction = async (action: LoraBulkAction) => {
     });
 
     await loadLoras();
-    selectedLoras.value = [];
+    clearSelection();
 
     windowExtras.htmx?.trigger(document.body, 'show-notification', {
       detail: {
@@ -186,10 +189,7 @@ const handleLoraDelete = (id: string) => {
     loras.value.splice(index, 1);
   }
 
-  const selectionIndex = selectedLoras.value.indexOf(id);
-  if (selectionIndex !== -1) {
-    selectedLoras.value.splice(selectionIndex, 1);
-  }
+  deselect(id);
 };
 
 onMounted(async () => {

--- a/app/frontend/src/composables/useLoraGallerySelection.ts
+++ b/app/frontend/src/composables/useLoraGallerySelection.ts
@@ -1,16 +1,17 @@
 import { computed, ref, watch } from 'vue';
 import type { Ref } from 'vue';
 
+import { useLoraSelection } from './useLoraSelection';
 import type { GalleryLora, LoraGallerySelectionState } from '@/types';
 
 export function useLoraGallerySelection(filteredLoras: Ref<GalleryLora[]>) {
-  const selectedLoras = ref<string[]>([]);
+  const selection = useLoraSelection();
   const viewMode = ref<LoraGallerySelectionState['viewMode']>('grid');
   const bulkMode = ref(false);
 
   const allSelected = computed(() =>
     filteredLoras.value.length > 0 &&
-    selectedLoras.value.length === filteredLoras.value.length
+    selection.selectedCount.value === filteredLoras.value.length
   );
 
   const setViewMode = (mode: LoraGallerySelectionState['viewMode']) => {
@@ -23,20 +24,16 @@ export function useLoraGallerySelection(filteredLoras: Ref<GalleryLora[]>) {
   };
 
   const handleSelectionChange = (loraId: string) => {
-    const index = selectedLoras.value.indexOf(loraId);
-    if (index === -1) {
-      selectedLoras.value.push(loraId);
-    } else {
-      selectedLoras.value.splice(index, 1);
-    }
+    selection.toggleSelection(loraId);
   };
 
   const toggleSelectAll = () => {
     if (allSelected.value) {
-      selectedLoras.value = [];
-    } else {
-      selectedLoras.value = filteredLoras.value.map(lora => lora.id);
+      selection.clearSelection();
+      return;
     }
+
+    selection.setSelection(filteredLoras.value.map(lora => lora.id));
   };
 
   const initializeSelection = () => {
@@ -48,11 +45,20 @@ export function useLoraGallerySelection(filteredLoras: Ref<GalleryLora[]>) {
 
   watch(filteredLoras, newLoras => {
     const availableIds = new Set(newLoras.map(lora => lora.id));
-    selectedLoras.value = selectedLoras.value.filter(id => availableIds.has(id));
+    selection.withUpdatedSelection((next) => {
+      next.forEach((id) => {
+        if (!availableIds.has(id)) {
+          next.delete(id);
+        }
+      });
+    });
   });
 
   return {
-    selectedLoras,
+    selectedItems: selection.selectedItems,
+    selectedSet: selection.selectedSet,
+    selectedCount: selection.selectedCount,
+    selectedLoras: selection.selectedIds,
     viewMode,
     bulkMode,
     allSelected,
@@ -61,5 +67,13 @@ export function useLoraGallerySelection(filteredLoras: Ref<GalleryLora[]>) {
     handleSelectionChange,
     toggleSelectAll,
     initializeSelection,
+    clearSelection: selection.clearSelection,
+    setSelection: selection.setSelection,
+    isSelected: selection.isSelected,
+    select: selection.select,
+    deselect: selection.deselect,
+    toggleSelection: selection.toggleSelection,
+    onSelectionChange: selection.onSelectionChange,
+    withUpdatedSelection: selection.withUpdatedSelection,
   };
 }

--- a/app/frontend/src/composables/useLoraSelection.ts
+++ b/app/frontend/src/composables/useLoraSelection.ts
@@ -1,0 +1,79 @@
+import { computed, ref } from 'vue';
+
+export type LoraSelectionChangePayload = {
+  id: string;
+  selected: boolean;
+};
+
+const cloneSelection = (current: Set<string>): Set<string> => new Set(current);
+
+export const useLoraSelection = () => {
+  const selectedItems = ref<Set<string>>(new Set());
+
+  const selectedSet = computed(() => selectedItems.value);
+  const selectedCount = computed(() => selectedItems.value.size);
+  const selectedIds = computed(() => Array.from(selectedItems.value));
+
+  const withUpdatedSelection = (updater: (next: Set<string>) => void): void => {
+    const next = cloneSelection(selectedItems.value);
+    updater(next);
+    selectedItems.value = next;
+  };
+
+  const select = (id: string): void => {
+    withUpdatedSelection((next) => {
+      next.add(id);
+    });
+  };
+
+  const deselect = (id: string): void => {
+    withUpdatedSelection((next) => {
+      next.delete(id);
+    });
+  };
+
+  const toggleSelection = (id: string): void => {
+    withUpdatedSelection((next) => {
+      if (next.has(id)) {
+        next.delete(id);
+        return;
+      }
+
+      next.add(id);
+    });
+  };
+
+  const onSelectionChange = ({ id, selected }: LoraSelectionChangePayload): void => {
+    if (selected) {
+      select(id);
+      return;
+    }
+
+    deselect(id);
+  };
+
+  const clearSelection = (): void => {
+    selectedItems.value = new Set();
+  };
+
+  const setSelection = (ids: Iterable<string>): void => {
+    selectedItems.value = new Set(ids);
+  };
+
+  const isSelected = (id: string): boolean => selectedItems.value.has(id);
+
+  return {
+    selectedItems,
+    selectedSet,
+    selectedCount,
+    selectedIds,
+    withUpdatedSelection,
+    select,
+    deselect,
+    toggleSelection,
+    onSelectionChange,
+    clearSelection,
+    setSelection,
+    isSelected,
+  } as const;
+};

--- a/tests/vue/LoraGallery.spec.js
+++ b/tests/vue/LoraGallery.spec.js
@@ -106,4 +106,29 @@ describe('LoraGallery', () => {
     expect(mocks.fetchAdaptersMock).toHaveBeenCalledWith('/api/v1', expect.objectContaining({ perPage: 100 }));
     expect(mocks.fetchAdapterTagsMock).toHaveBeenCalledWith('/api/v1');
   });
+
+  it('performs bulk actions using shared selection state', async () => {
+    const wrapper = await mountGallery();
+
+    expect(wrapper.vm.selectedCount).toBe(0);
+
+    wrapper.vm.handleSelectionChange('1');
+    await flushPromises();
+
+    expect(wrapper.vm.selectedCount).toBe(1);
+    expect(wrapper.vm.selectedLoras).toEqual(['1']);
+
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
+
+    await wrapper.vm.performBulkAction('activate');
+    await flushPromises();
+
+    expect(mocks.performBulkLoraActionMock).toHaveBeenCalledWith('/api/v1', {
+      action: 'activate',
+      lora_ids: ['1'],
+    });
+    expect(wrapper.vm.selectedCount).toBe(0);
+
+    confirmSpy.mockRestore();
+  });
 });

--- a/tests/vue/useLoraSelection.spec.ts
+++ b/tests/vue/useLoraSelection.spec.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+
+import { useLoraSelection } from '../../app/frontend/src/composables/useLoraSelection';
+
+describe('useLoraSelection', () => {
+  it('adds and removes ids using payload helper', () => {
+    const selection = useLoraSelection();
+
+    selection.onSelectionChange({ id: 'lora-1', selected: true });
+    expect(selection.selectedCount.value).toBe(1);
+    expect(selection.isSelected('lora-1')).toBe(true);
+
+    selection.onSelectionChange({ id: 'lora-2', selected: true });
+    expect(selection.selectedIds.value).toEqual(['lora-1', 'lora-2']);
+
+    selection.onSelectionChange({ id: 'lora-1', selected: false });
+    expect(selection.selectedCount.value).toBe(1);
+    expect(selection.isSelected('lora-1')).toBe(false);
+    expect(selection.isSelected('lora-2')).toBe(true);
+  });
+
+  it('supports toggle, clear, and bulk updates', () => {
+    const selection = useLoraSelection();
+
+    selection.toggleSelection('a');
+    selection.toggleSelection('b');
+    expect(selection.selectedIds.value).toEqual(['a', 'b']);
+
+    selection.toggleSelection('a');
+    expect(selection.selectedIds.value).toEqual(['b']);
+
+    selection.setSelection(['x', 'y', 'z']);
+    expect(selection.selectedIds.value).toEqual(['x', 'y', 'z']);
+
+    selection.clearSelection();
+    expect(selection.selectedCount.value).toBe(0);
+
+    selection.withUpdatedSelection((next) => {
+      next.add('1');
+      next.add('2');
+      next.delete('1');
+    });
+
+    expect(selection.selectedIds.value).toEqual(['2']);
+  });
+});


### PR DESCRIPTION
## Summary
- add a reusable `useLoraSelection` composable that exposes helpers for managing LoRA id selection sets
- wire `LoraGallery` and its selection composable to the shared selection state for bulk workflows
- cover the new selection flows in dedicated unit tests and extend gallery tests to verify bulk actions

## Testing
- npm run test:unit

------
https://chatgpt.com/codex/tasks/task_e_68d2cebd26bc8329824e41b4170fdb4a