### PR TITLE
Align frontend backend URL defaults with /api/v1

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ npm run dev
 
 Visit `http://localhost:8000` to access the application.
 
+By default the SPA calls the backend relative to the same origin at `/api/v1`. If you run the backend separately (for example on another host or port), set the `BACKEND_URL` environment variable to the full base path such as `http://localhost:8000/api/v1` before starting the FastAPI wrapper.
+
 ### Alternative Development Workflow
 ```bash
 # Option 1: Run both backend and frontend simultaneously
@@ -271,7 +273,7 @@ pytest --cov             # Python test coverage
 - `SDNEXT_POLL_INTERVAL` - Progress polling interval (default: 2)
 
 ### Frontend Configuration
-- `BACKEND_URL` - Backend API base URL (default: `http://localhost:8000`)
+- `BACKEND_URL` - Backend API base URL (default: `/api/v1` relative to the SPA; override with a full URL like `http://localhost:8000/api/v1` for standalone backends)
 - `REQUEST_TIMEOUT` - Frontend request timeout (default: 30.0)
 - `ENVIRONMENT` - Application environment (`development`, `production`)
 

--- a/app/main.py
+++ b/app/main.py
@@ -66,7 +66,8 @@ SPA_STATIC_APP = SPAStaticFiles(SPA_DIST_DIR)
 @app.get("/frontend/settings", tags=["frontend"])
 async def frontend_settings():
     """Expose runtime configuration for the Vue SPA."""
-    backend_url = _fe_settings.backend_url.rstrip("/")
+    raw_backend_url = _fe_settings.backend_url or "/api/v1"
+    backend_url = raw_backend_url.rstrip("/") or "/api/v1"
     return {
         "backendUrl": backend_url,
         "backendApiKey": backend_settings.API_KEY or None,

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -155,7 +155,7 @@ def test_frontend_settings_endpoint(client: TestClient):
     assert response.status_code == 200
     payload = response.json()
     assert "backendUrl" in payload
-    assert payload["backendUrl"].endswith("/v1")
+    assert payload["backendUrl"].endswith("/api/v1")
 
 
 def test_import_export_export_streams_archive(


### PR DESCRIPTION
## Summary
- default the frontend configuration backend URL to the /api/v1 mount and normalise inputs
- ensure the frontend settings endpoint always returns the corrected API base
- document the new default path and override guidance in the quick start guide
- update the integration test to expect the /api/v1 suffix

## Testing
- pytest tests/test_main.py

------
https://chatgpt.com/codex/tasks/task_e_68d2ee3f36808329b766a179c1bcf188