### PR TITLE
Remove node_modules directory and document dependency management

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,19 @@ on:
   pull_request:
 
 jobs:
+  node-modules-sanity:
+    name: Ensure node_modules directory is absent
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Verify node_modules is not committed
+        run: |
+          if [ -d node_modules ]; then
+            echo "node_modules/ should not be committed to the repository." >&2
+            exit 1
+          fi
+
   backend-settings:
     name: Backend settings validation
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ npm install
 npm run dev
 ```
 
+> **Note:** Node packages are not vendored in this repository. Run `npm install` (or `npm ci`) locally after cloning and keep the generated `node_modules/` directory out of version control.
+
 Visit `http://localhost:8000` to access the application.
 
 ### Alternative Development Workflow


### PR DESCRIPTION
## Summary
- delete the vendored node_modules directory from source control
- document in the README that contributors must install Node dependencies locally instead of relying on committed packages
- add a CI guard that fails if a node_modules directory is committed again

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d2ee41f5548329b4876ae9030bc575