### PR TITLE
Guard orchestrator cleanup registration outside Vue scopes

### DIFF
--- a/app/frontend/src/services/generation/orchestrator.ts
+++ b/app/frontend/src/services/generation/orchestrator.ts
@@ -1,4 +1,4 @@
-import { onScopeDispose, watch, type Ref } from 'vue';
+import { getCurrentScope, onScopeDispose, watch, type Ref } from 'vue';
 import { storeToRefs } from 'pinia';
 
 import {
@@ -117,7 +117,7 @@ export const createGenerationOrchestrator = ({
   };
 
   const cleanup = (): void => {
-    transport.stopUpdates();
+    transport.clear();
   };
 
   const startGeneration = async (
@@ -200,9 +200,11 @@ export const createGenerationOrchestrator = ({
     transport.setPollInterval(next);
   });
 
-  onScopeDispose(() => {
-    transport.clear();
-  });
+  if (getCurrentScope()) {
+    onScopeDispose(() => {
+      transport.clear();
+    });
+  }
 
   return {
     initialize,

--- a/tests/unit/test_generationOrchestratorCleanup.spec.ts
+++ b/tests/unit/test_generationOrchestratorCleanup.spec.ts
@@ -1,0 +1,74 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ref } from 'vue';
+import { createPinia, setActivePinia, storeToRefs } from 'pinia';
+
+import {
+  useGenerationConnectionStore,
+  useGenerationQueueStore,
+  useGenerationResultsStore,
+} from '../../app/frontend/src/stores/generation';
+import { createGenerationOrchestrator } from '../../app/frontend/src/services/generation';
+
+const transportClearMock = vi.fn();
+const transportStopUpdatesMock = vi.fn();
+
+const transportMock = {
+  startGeneration: vi.fn(),
+  cancelJob: vi.fn(),
+  deleteResult: vi.fn(),
+  refreshSystemStatus: vi.fn(),
+  refreshActiveJobs: vi.fn(),
+  refreshRecentResults: vi.fn(),
+  refreshAllData: vi.fn(),
+  initializeUpdates: vi.fn(),
+  stopUpdates: transportStopUpdatesMock,
+  reconnectUpdates: vi.fn(),
+  setPollInterval: vi.fn(),
+  clear: transportClearMock,
+};
+
+const useGenerationTransportMock = vi.fn(() => transportMock);
+
+vi.mock('../../app/frontend/src/composables/generation', () => ({
+  useGenerationTransport: useGenerationTransportMock,
+}));
+
+describe('createGenerationOrchestrator without Vue scope', () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setActivePinia(createPinia());
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  it('does not warn when instantiated outside a scope and manual cleanup clears transport', () => {
+    const queueStore = useGenerationQueueStore();
+    const resultsStore = useGenerationResultsStore();
+    const connectionStore = useGenerationConnectionStore();
+
+    const { historyLimit } = storeToRefs(resultsStore);
+    const { pollIntervalMs } = storeToRefs(connectionStore);
+
+    const orchestrator = createGenerationOrchestrator({
+      showHistory: ref(false),
+      configuredBackendUrl: ref(null),
+      notificationAdapter: { notify: vi.fn(), debug: vi.fn() },
+      queueStore,
+      resultsStore,
+      connectionStore,
+      historyLimit,
+      pollIntervalMs,
+    });
+
+    orchestrator.cleanup();
+
+    expect(warnSpy).not.toHaveBeenCalled();
+    expect(transportClearMock).toHaveBeenCalledTimes(1);
+    expect(transportStopUpdatesMock).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- guard the generation orchestrator against registering scope disposal handlers when no Vue scope is active and ensure manual cleanup fully clears the transport
- add a unit test that instantiates the orchestrator without a Vue scope to verify no warnings are emitted while cleanup still clears the mocked transport

## Testing
- npm run lint
- npm run test *(fails: suite already has numerous missing-component mocks and `exactKey` reference errors in existing Vue tests)*

------
https://chatgpt.com/codex/tasks/task_e_68d2f4e5ccc48329b6cc12ec40ef5756