### PR TITLE
Reformat HTTPClient __init__ signature

### DIFF
--- a/app/frontend/utils/http.py
+++ b/app/frontend/utils/http.py
@@ -13,7 +13,13 @@ from urllib.parse import urlencode
 class HTTPClient:
     """A simple HTTP client facade with URL building support."""
 
-    def __init__(self, base_url: str, timeout: float = 30.0, max_retries: int = 0) -> None:
+    def __init__(
+        self,
+        base_url: str,
+        timeout: float = 30.0,
+        max_retries: int = 0,
+    ) -> None:
+        """Initialize an HTTP client configuration."""
         if not isinstance(base_url, str) or not base_url:
             raise ValueError("base_url must be a non-empty string")
         if not (base_url.startswith("http://") or base_url.startswith("https://")):


### PR DESCRIPTION
## Summary
- reflow the `HTTPClient.__init__` signature so each parameter appears on its own line for PEP 8 compliance
- add a concise initializer docstring while keeping the existing validation logic intact

## Testing
- ruff check app/frontend/utils/http.py

------
https://chatgpt.com/codex/tasks/task_e_68d2f70159e88329ad4f7adae5e82606