### PR TITLE
Align frontend docstrings with Ruff policy

### DIFF
--- a/app/frontend/__init__.py
+++ b/app/frontend/__init__.py
@@ -1,1 +1,1 @@
-"""Frontend application module."""
+"""Initialize the frontend application package."""

--- a/app/frontend/cache.py
+++ b/app/frontend/cache.py
@@ -1,6 +1,6 @@
-"""In-Process TTL Cache Module.
+"""Provide in-process TTL caching utilities.
 
-Provides simple time-to-live caching for expensive operations
+Use simple time-to-live caching for expensive operations
 to avoid repeated backend requests and improve performance.
 """
 
@@ -16,14 +16,14 @@ settings = get_settings()
 
 @dataclass
 class CacheEntry:
-    """Cache entry with value and expiration."""
+    """Represent a cache entry with value and expiration."""
 
     value: Any
     expires_at: float
 
 
 class TTLCache:
-    """Thread-safe TTL cache implementation."""
+    """Implement a thread-safe TTL cache."""
     
     def __init__(self, default_ttl: int = 300):
         """Initialize TTL cache.
@@ -318,7 +318,7 @@ def get_all_cache_stats() -> Dict[str, Dict[str, Any]]:
 
 # Background cleanup task (can be called periodically)
 def periodic_cache_cleanup() -> None:
-    """Periodic cleanup task for all caches."""
+    """Run periodic cleanup tasks for all caches."""
     cleanup_stats = cleanup_all_caches()
     
     # Log cleanup if any entries were removed

--- a/app/frontend/config.py
+++ b/app/frontend/config.py
@@ -1,7 +1,7 @@
-"""Frontend Configuration Module.
+"""Provide frontend configuration utilities.
 
-Centralized configuration management using Pydantic BaseSettings for the LoRA 
-Manager frontend. Handles environment variables, timeouts, feature flags, and 
+Centralize configuration management using Pydantic BaseSettings for the LoRA
+Manager frontend. Handle environment variables, timeouts, feature flags, and
 other application settings.
 """
 
@@ -13,13 +13,15 @@ from pydantic_settings import BaseSettings
 
 
 class FrontendSettings(BaseSettings):
-    """Frontend application settings."""
+    """Define frontend application settings."""
     
     # Backend connection
     backend_url: str = Field(
         default="/api/v1",
         env="BACKEND_URL",
-        description="Backend API base URL (relative or absolute) including the /api/v1 prefix",
+        description=(
+            "Backend API base URL (relative or absolute) including the /api/v1 prefix"
+        ),
     )
     
     backend_host: str = Field(
@@ -37,7 +39,7 @@ class FrontendSettings(BaseSettings):
     @field_validator('backend_url', mode='before')
     @classmethod
     def construct_backend_url(cls, v, info):
-        """Normalise backend URL to match the /api/v1 mount."""
+        """Normalize the backend URL to match the /api/v1 mount."""
         default_path = "/api/v1"
 
         if v is None:
@@ -272,6 +274,8 @@ class FrontendSettings(BaseSettings):
         }
     
     class Config:
+        """Configure environment file handling for settings."""
+
         env_file = ".env"
         env_file_encoding = "utf-8"
         case_sensitive = False

--- a/app/frontend/errors.py
+++ b/app/frontend/errors.py
@@ -1,6 +1,6 @@
-"""Error Handling Utilities.
+"""Provide error handling utilities.
 
-Provides consistent error handling and fallback rendering
+Maintain consistent error handling and fallback rendering
 for the LoRA Manager frontend application.
 """
 
@@ -19,14 +19,15 @@ settings = get_settings()
 
 
 class FrontendError(Exception):
-    """Base exception for frontend errors."""
+    """Represent the base exception for frontend errors."""
     
     def __init__(
-        self, 
-        message: str, 
-        status_code: int = 500, 
+        self,
+        message: str,
+        status_code: int = 500,
         details: Optional[Dict] = None,
     ):
+        """Initialize the frontend error."""
         self.message = message
         self.status_code = status_code
         self.details = details or {}
@@ -34,24 +35,26 @@ class FrontendError(Exception):
 
 
 class BackendConnectionError(FrontendError):
-    """Error when backend is unreachable."""
+    """Represent an error when the backend is unreachable."""
     
     def __init__(
-        self, 
-        message: str = "Backend service unavailable", 
+        self,
+        message: str = "Backend service unavailable",
         details: Optional[Dict] = None,
     ):
+        """Initialize a backend connection error."""
         super().__init__(message, status_code=502, details=details)
 
 
 class ValidationFailedError(FrontendError):
-    """Error for validation failures."""
+    """Represent an error for validation failures."""
     
     def __init__(
-        self, 
-        message: str = "Validation failed", 
+        self,
+        message: str = "Validation failed",
         validation_errors: Optional[Dict] = None,
     ):
+        """Initialize a validation failure error."""
         details = {"validation_errors": validation_errors or {}}
         super().__init__(message, status_code=400, details=details)
 
@@ -346,8 +349,8 @@ def log_error_with_context(
 
 # Decorator for consistent error handling in route handlers
 def handle_route_errors(fallback_template: str, fallback_data: Optional[Dict] = None):
-    """Decorator for consistent error handling in route handlers.
-    
+    """Provide a decorator for consistent error handling in route handlers.
+
     Args:
         fallback_template: Template to render on error
         fallback_data: Default fallback data

--- a/app/frontend/logging.py
+++ b/app/frontend/logging.py
@@ -1,7 +1,7 @@
-"""Logging Configuration.
+"""Configure logging for the frontend application.
 
-Sets up structured logging for the LoRA Manager frontend application.
-Provides JSON output for production and human-readable format for development.
+Set up structured logging for the LoRA Manager frontend application.
+Provide JSON output for production and human-readable format for development.
 """
 
 import logging
@@ -16,7 +16,7 @@ settings = get_settings()
 
 
 class JSONFormatter(logging.Formatter):
-    """Custom JSON formatter for structured logging."""
+    """Implement a custom JSON formatter for structured logging."""
     
     def format(self, record: logging.LogRecord) -> str:
         """Format log record as JSON."""
@@ -53,7 +53,7 @@ class JSONFormatter(logging.Formatter):
 
 
 class ColoredFormatter(logging.Formatter):
-    """Colored formatter for development console output."""
+    """Implement a colored formatter for development console output."""
     
     # ANSI color codes
     COLORS = {
@@ -113,7 +113,7 @@ def setup_logging(
     format_type: Optional[str] = None,
     log_file: Optional[str] = None,
 ) -> None:
-    """Setup logging configuration.
+    """Configure logging settings.
     
     Args:
         level: Log level (DEBUG, INFO, WARNING, ERROR, CRITICAL)

--- a/app/frontend/schemas.py
+++ b/app/frontend/schemas.py
@@ -1,7 +1,11 @@
+"""Define Pydantic schemas used by frontend utilities."""
+
 from pydantic import BaseModel, Field, field_validator
 
 
 class SimilarityForm(BaseModel):
+    """Validate similarity search parameters."""
+
     lora_id: str = Field(..., min_length=1)
     semantic_weight: float = Field(0.4, ge=0.0, le=1.0)
     artistic_weight: float = Field(0.3, ge=0.0, le=1.0)
@@ -11,6 +15,8 @@ class SimilarityForm(BaseModel):
 
 
 class PromptForm(BaseModel):
+    """Validate prompt tuning parameters."""
+
     prompt: str = Field(..., min_length=1)
     semantic_weight: float = Field(0.4, ge=0.0, le=1.0)
     style_weight: float = Field(0.3, ge=0.0, le=1.0)

--- a/app/frontend/utils/__init__.py
+++ b/app/frontend/utils/__init__.py
@@ -1,4 +1,4 @@
-"""Frontend utilities for LoRA Manager."""
+"""Provide frontend utilities for the LoRA Manager."""
 
 from .vite_assets import is_development, vite_asset, vite_asset_css
 

--- a/app/frontend/utils/http.py
+++ b/app/frontend/utils/http.py
@@ -1,4 +1,4 @@
-"""Minimal HTTP client helper for unit tests and utilities.
+"""Provide minimal HTTP client helpers for unit tests and utilities.
 
 This client implements construction and URL building logic required by
 tests/unit/test_backend_validation.py.
@@ -11,7 +11,7 @@ from urllib.parse import urlencode
 
 
 class HTTPClient:
-    """A simple HTTP client facade with URL building support."""
+    """Provide a simple HTTP client facade with URL building support."""
 
     def __init__(
         self,

--- a/app/frontend/utils/vite_assets.py
+++ b/app/frontend/utils/vite_assets.py
@@ -1,7 +1,7 @@
-"""Vite Asset Helper for LoRA Manager.
+"""Provide Vite asset helpers for the LoRA Manager frontend.
 
-This module provides utilities for serving assets built by Vite,
-handling both development and production environments.
+Offer utilities for serving assets built by Vite while handling both
+development and production environments.
 """
 
 import json
@@ -15,6 +15,7 @@ VITE_MANIFEST_PATH = "dist/.vite/manifest.json"
 
 def is_development() -> bool:
     """Determine if we're in development mode.
+
     You can customize this based on your environment setup.
     """
     # Check multiple environment indicators
@@ -22,12 +23,17 @@ def is_development() -> bool:
     debug = os.getenv("DEBUG", "true").lower() in ("true", "1", "yes")
     
     # Also check if Vite dev server is running
-    vite_dev_running = os.getenv("VITE_DEV_SERVER", "true").lower() in ("true", "1", "yes")
+    vite_dev_running = os.getenv("VITE_DEV_SERVER", "true").lower() in (
+        "true",
+        "1",
+        "yes",
+    )
     
     return env == "development" or debug or vite_dev_running
 
 def load_vite_manifest() -> Optional[Dict]:
     """Load the Vite manifest file if it exists.
+
     Returns None if the file doesn't exist or can't be parsed.
     """
     try:

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -394,6 +394,14 @@ npm run type-check        # TypeScript validation (✅ passing)
 npm run validate          # Runs linting + tests (production ready)
 ```
 
+#### Frontend Python docstrings
+
+- Python modules in `app/frontend` use imperative first-line docstrings to
+  satisfy Ruff's `D401` requirement and keep inline documentation consistent.
+- When adding or updating docstrings in this package, phrase the opening
+  sentence as a command (for example, "Configure logging settings." rather than
+  "Logging configuration") and verify the result with `ruff check app/frontend`.
+
 **Quality Standards Achieved:**
 - **Test Coverage**: >95% across backend and frontend with comprehensive test organization
 - **Type Safety**: Full TypeScript and Python type hints with strict validation


### PR DESCRIPTION
## Summary
- rewrite frontend Python docstrings in `app/frontend` to use imperative first-line summaries and satisfy Ruff's D401 rule
- add missing docstrings and wrap long descriptions while preserving Ruff expectations for frontend utilities
- document the frontend Python docstring style guidance in `docs/DEVELOPMENT.md`

## Testing
- ruff check app/frontend

------
https://chatgpt.com/codex/tasks/task_e_68d2f7e8e24083298a38be05d229b2fe