### PR TITLE
Remove legacy WebSocket route

### DIFF
--- a/backend/api/v1/websocket.py
+++ b/backend/api/v1/websocket.py
@@ -3,9 +3,7 @@
 The canonical client-facing path for this socket is ``/api/v1/ws/progress``
 when the backend is served through the main application (``app.main``). When
 connecting directly to the backend service without the ``/api`` mount, the
-route is available at ``/v1/ws/progress``. A legacy compatibility path without
-versioning is also provided by ``backend.main`` so older clients that still use
-``/ws/progress`` continue to function.
+route is available at ``/v1/ws/progress``.
 """
 
 from fastapi import APIRouter, Depends, WebSocket

--- a/backend/main.py
+++ b/backend/main.py
@@ -125,12 +125,6 @@ def create_app() -> FastAPI:
     app.include_router(dashboard.router, prefix="/v1")
     app.include_router(system.router, prefix="/v1")
     app.include_router(websocket.router, prefix="/v1")  # Canonical WebSocket path -> /api/v1/ws/progress
-    # Maintain backward compatibility for legacy clients that still connect to /ws/progress
-    app.add_api_websocket_route(
-        websocket.PROGRESS_WEBSOCKET_ROUTE,
-        websocket.websocket_progress_endpoint,
-        name="legacy-websocket-progress",
-    )
 
     # Note: Unversioned routes are intentionally not included; use /v1/*
 

--- a/docs/WEBSOCKET_IMPLEMENTATION.md
+++ b/docs/WEBSOCKET_IMPLEMENTATION.md
@@ -30,7 +30,6 @@ The implementation consists of three main components:
 
 3.  **WebSocket Endpoint (`backend/api/v1/websocket.py`)**:
     -   Exposes the canonical `/api/v1/ws/progress` endpoint (via the main app's `/api` mount).
-    -   Provides a `/ws/progress` compatibility route for legacy clients connecting directly to the backend service.
     -   Accepts new client connections and passes them to the `WebSocketService`.
 
 ### Message Flow
@@ -136,8 +135,9 @@ The progress WebSocket works with the existing queue pipeline and SDNext
 monitor, but it should still be considered experimental until the surrounding
 delivery infrastructure is hardened.
 
-- ✅ Endpoint wiring is complete: `/ws/progress` delegates to the shared
-  `WebSocketService`, which subscribes to delivery and generation updates.【F:backend/api/v1/websocket.py†L1-L43】
+- ✅ Endpoint wiring is complete: `/v1/ws/progress` (and `/api/v1/ws/progress`
+  via the main app) delegate to the shared `WebSocketService`, which subscribes
+  to delivery and generation updates.【F:backend/api/v1/websocket.py†L1-L43】
 - ✅ The service layer can start and stop job monitors, broadcasting structured
   events as jobs transition states.【F:backend/services/websocket.py†L1-L200】
 - ⚠️ Load and failure-mode testing is limited; queue backpressure and

--- a/docs/contract.md
+++ b/docs/contract.md
@@ -158,11 +158,13 @@ with full test coverage and proper separation of concerns.
 * `GET /v1/system/status` – combine GPU detection, queue statistics, and disk
   usage into a telemetry snapshot for clients.【F:backend/api/v1/system.py†L1-L16】【F:backend/services/system.py†L1-L149】
 
-### WebSocket progress (`/v1/ws/progress` or `/api/v1/ws/progress`)
+### WebSocket progress (`/api/v1/ws/progress` via main app, `/v1/ws/progress` direct)
 
 * `GET /v1/ws/progress` (WebSocket) – subscribe to progress events for delivery
-  and generation jobs. Clients send subscription messages after connecting, and
-  the `WebSocketService` manages broadcasts.【F:backend/api/v1/websocket.py†L1-L43】
+  and generation jobs when addressing the backend service directly. The main
+  FastAPI application mounts the same route at `/api/v1/ws/progress`. Clients
+  send subscription messages after connecting, and the `WebSocketService`
+  manages broadcasts.【F:backend/api/v1/websocket.py†L1-L43】
 
 ---
 


### PR DESCRIPTION
## Summary
- remove the legacy unversioned WebSocket route from the FastAPI app factory
- update the WebSocket router docstring and documentation to reference the supported versioned endpoints

## Testing
- pytest tests/api/test_health.py -q

------
https://chatgpt.com/codex/tasks/task_e_68d307d6bc6083299dce591d1f5d553b