### PR TITLE
Remove deprecated GenerationStatus alias

### DIFF
--- a/backend/services/generation/statuses.py
+++ b/backend/services/generation/statuses.py
@@ -17,10 +17,6 @@ class NormalizedGenerationStatus(str, Enum):
     FAILED = "failed"
 
 
-# Backwards compatibility alias for legacy imports
-GenerationStatus = NormalizedGenerationStatus
-
-
 STATUS_NORMALIZATION_MAP: Dict[str, NormalizedGenerationStatus] = {
     status.value: status for status in NormalizedGenerationStatus
 }
@@ -50,7 +46,6 @@ def normalize_status(status: Optional[str]) -> NormalizedGenerationStatus:
 
 
 __all__ = [
-    "GenerationStatus",
     "NormalizedGenerationStatus",
     "STATUS_NORMALIZATION_MAP",
     "normalize_status",


### PR DESCRIPTION
## Summary
- remove the deprecated GenerationStatus alias and stop exporting it from the generation status helpers
- regenerate the job status TypeScript output to ensure consistency after the Python export change

## Testing
- pytest tests/unit/python/test_generation_statuses.py

------
https://chatgpt.com/codex/tasks/task_e_68d307f5b14883299edab4dfd8d7b78d