### PR TITLE
Remove import-export alias routes

### DIFF
--- a/app/frontend/src/services/analytics/analyticsService.ts
+++ b/app/frontend/src/services/analytics/analyticsService.ts
@@ -32,7 +32,7 @@ export const exportAnalyticsReport = async (
   };
 
   const { blob, response } = await requestBlob(
-    resolveBackendUrl('/import-export/export', baseUrl ?? undefined),
+    resolveBackendUrl('/export', baseUrl ?? undefined),
     {
       method: 'POST',
       credentials: 'same-origin',

--- a/backend/api/v1/import_export.py
+++ b/backend/api/v1/import_export.py
@@ -160,16 +160,3 @@ async def delete_backup(
     return Response(status_code=204)
 
 
-# ---------------------------------------------------------------------------
-# Prefixed route aliases for `/import-export/*`
-# ---------------------------------------------------------------------------
-# Maintain backwards compatibility by exposing import/export endpoints with
-# the expected `/import-export` prefix used by the frontend SPA. Legacy routes
-# without the prefix remain available because the primary decorators above use
-# the original paths.
-router.add_api_route("/import-export/export", export_data, methods=["POST"])
-router.add_api_route("/import-export/export/estimate", estimate_export, methods=["POST"])
-router.add_api_route("/import-export/import", import_data, methods=["POST"])
-router.add_api_route("/import-export/backups/history", get_backup_history, methods=["GET"])
-router.add_api_route("/import-export/backup/create", create_backup, methods=["POST"])
-router.add_api_route("/import-export/backups/{backup_id}", delete_backup, methods=["DELETE"])

--- a/docs/contract.md
+++ b/docs/contract.md
@@ -140,18 +140,20 @@ with full test coverage and proper separation of concerns.
   service’s featured query.【F:backend/api/v1/dashboard.py†L25-L37】
 * `GET /v1/dashboard/activity-feed` – expose recent delivery job activity.【F:backend/api/v1/dashboard.py†L39-L40】
 
-### Import/export (`/v1/import-export`)
+### Import/export (`/v1/export`, `/v1/import`, `/v1/backups`)
 
-* `POST /v1/import-export/export/estimate` – returns estimated archive size and
-  duration using adapter statistics; if LoRA export is disabled, returns zeros.【F:backend/api/v1/import_export.py†L1-L64】
-* `POST /v1/import-export/export` – streams a ZIP archive built from adapters via
-  the archive service; rejects unsupported formats.【F:backend/api/v1/import_export.py†L66-L98】
-* `POST /v1/import-export/import` – validate and import uploaded archives into
-  the local filesystem. Errors are reported per file, and the import path defaults
-  to `settings.IMPORT_PATH` or `./loras`.【F:backend/api/v1/import_export.py†L100-L170】
-* `GET /v1/import-export/backups/history` & `POST /v1/import-export/backup/create`
-  – placeholder backup endpoints that currently return mock data or simple
-  success payloads pending a full backup workflow.【F:backend/api/v1/import_export.py†L172-L209】
+* `POST /v1/export/estimate` – returns estimated archive size and duration using
+  adapter statistics; if LoRA export is disabled, returns zeros.【F:backend/api/v1/import_export.py†L24-L38】
+* `POST /v1/export` – streams a ZIP archive built from adapters via the archive
+  service; rejects unsupported formats.【F:backend/api/v1/import_export.py†L41-L62】
+* `POST /v1/import` – validate and import uploaded archives into the local
+  filesystem. Errors are reported per file, and the import path defaults to
+  `settings.IMPORT_PATH` or `./loras`.【F:backend/api/v1/import_export.py†L65-L123】
+* `GET /v1/backups/history` & `POST /v1/backup/create` – placeholder backup
+  endpoints that currently return mock data or simple success payloads pending a
+  full backup workflow.【F:backend/api/v1/import_export.py†L126-L148】
+* `DELETE /v1/backups/{backup_id}` – remove a backup entry and its archive,
+  returning `204` or `404` when missing.【F:backend/api/v1/import_export.py†L151-L160】
 
 ### System status (`/v1/system`)
 

--- a/tests/api/test_import_export.py
+++ b/tests/api/test_import_export.py
@@ -38,7 +38,7 @@ def test_import_export_streams_archive(
     assert create_response.status_code == 201
 
     export_response = client.post(
-        "/api/v1/import-export/export",
+        "/api/v1/export",
         json={"loras": True, "format": "zip"},
     )
 

--- a/tests/vue/PerformanceAnalytics.spec.js
+++ b/tests/vue/PerformanceAnalytics.spec.js
@@ -15,6 +15,13 @@ const downloadFileMock = vi.hoisted(() => vi.fn());
 vi.mock('@/composables/useNotifications', () => ({
   useNotifications: () => notificationSpies,
 }));
+vi.mock('@/composables/shared', async () => {
+  const actual = await vi.importActual('@/composables/shared');
+  return {
+    ...actual,
+    useNotifications: () => notificationSpies,
+  };
+});
 
 vi.mock('@/utils/browser', () => ({
   downloadFile: downloadFileMock,
@@ -221,7 +228,7 @@ describe('PerformanceAnalyticsPage.vue', () => {
       if (url.includes('/adapters')) {
         return createJsonResponse(adapterListResponse);
       }
-      if (url.includes('/import-export/export')) {
+      if (url.includes('/api/v1/export')) {
         return createBlobResponse();
       }
       return createJsonResponse({});


### PR DESCRIPTION
## Summary
- remove the legacy `/import-export` FastAPI route aliases so only the canonical `/v1` endpoints remain
- point the analytics export service at `/api/v1/export` and extend the unit test stubs to match the canonical paths
- refresh the API contract documentation and backend/frontend tests to reflect the canonical import/export URLs

## Testing
- pytest tests/api/test_import_export.py tests/test_backup_endpoints.py
- npx vitest run tests/vue/PerformanceAnalytics.spec.js

------
https://chatgpt.com/codex/tasks/task_e_68d307e01a4083299e96b950a462c0fe