### PR TITLE
Remove legacy job queue fallbacks

### DIFF
--- a/app/frontend/src/composables/generation/useJobQueue.ts
+++ b/app/frontend/src/composables/generation/useJobQueue.ts
@@ -183,7 +183,6 @@ export const useJobQueue = (options: UseJobQueueOptions = {}) => {
   const polling = useJobQueuePolling({
     disabled: isDisabled,
     pollInterval,
-    apiAvailable: transport.apiAvailable,
     fetchJobs: transport.fetchJobs,
     onRecord: (record) =>
       applyJobRecord(
@@ -199,7 +198,6 @@ export const useJobQueue = (options: UseJobQueueOptions = {}) => {
     jobs: activeJobs,
     isReady: polling.isReady,
     isPolling: polling.isPolling,
-    apiAvailable: transport.apiAvailable,
     refresh: polling.refresh,
     startPolling: polling.startPolling,
     stopPolling: polling.stopPolling,

--- a/app/frontend/src/composables/generation/useJobQueuePolling.ts
+++ b/app/frontend/src/composables/generation/useJobQueuePolling.ts
@@ -1,11 +1,10 @@
-import { onBeforeUnmount, onMounted, ref, watch, type ComputedRef, type Ref } from 'vue';
+import { onBeforeUnmount, onMounted, ref, watch, type ComputedRef } from 'vue';
 
 import type { JobQueueRecord } from '@/composables/generation';
 
 export interface UseJobQueuePollingOptions {
   disabled: ComputedRef<boolean>;
   pollInterval: ComputedRef<number>;
-  apiAvailable: Ref<boolean>;
   fetchJobs: () => Promise<JobQueueRecord[] | null>;
   onRecord: (record: JobQueueRecord) => void;
 }
@@ -13,7 +12,6 @@ export interface UseJobQueuePollingOptions {
 export const useJobQueuePolling = ({
   disabled,
   pollInterval,
-  apiAvailable,
   fetchJobs,
   onRecord,
 }: UseJobQueuePollingOptions) => {
@@ -30,7 +28,7 @@ export const useJobQueuePolling = ({
   };
 
   const refresh = async (): Promise<void> => {
-    if (isPolling.value || disabled.value || !apiAvailable.value) {
+    if (isPolling.value || disabled.value) {
       if (!isReady.value) {
         isReady.value = true;
       }
@@ -70,7 +68,7 @@ export const useJobQueuePolling = ({
     void refresh();
 
     pollTimer.value = setInterval(() => {
-      if (!isPolling.value && !disabled.value && apiAvailable.value) {
+      if (!isPolling.value && !disabled.value) {
         void refresh();
       }
     }, pollInterval.value);
@@ -79,7 +77,7 @@ export const useJobQueuePolling = ({
   watch(disabled, (nextDisabled) => {
     if (nextDisabled) {
       stopPolling();
-    } else if (!pollTimer.value && apiAvailable.value) {
+    } else if (!pollTimer.value) {
       startPolling();
     }
   });

--- a/app/frontend/src/composables/generation/useJobQueueTransport.ts
+++ b/app/frontend/src/composables/generation/useJobQueueTransport.ts
@@ -1,10 +1,7 @@
-import { computed, ref, unref, type ComputedRef, type MaybeRefOrGetter, type Ref } from 'vue';
+import { ref, unref, type MaybeRefOrGetter, type Ref } from 'vue';
 
-import { ApiError } from '@/composables/shared';
-import { fetchActiveGenerationJobs, fetchLegacyJobStatuses } from '@/services';
+import { fetchActiveGenerationJobs } from '@/services';
 import { DEFAULT_BACKEND_BASE } from '@/utils/backend';
-
-const PRIMARY_FAILURE_LOG_COOLDOWN = 5000;
 
 export type JobQueueRecord = Record<string, unknown>;
 
@@ -15,8 +12,6 @@ export interface UseJobQueueTransportOptions {
 export interface UseJobQueueTransportReturn {
   fetchJobs: () => Promise<JobQueueRecord[] | null>;
   apiAvailable: Ref<boolean>;
-  legacyEndpointMissing: Ref<boolean>;
-  isLegacyFallbackAvailable: ComputedRef<boolean>;
 }
 
 const resolveBackendBase = (backendBase: MaybeRefOrGetter<string>): string => {
@@ -35,29 +30,10 @@ const resolveBackendBase = (backendBase: MaybeRefOrGetter<string>): string => {
   }
 };
 
-const createPrimaryFailureLogger = () => {
-  const lastPrimaryFailureLogAt = ref<number | null>(null);
-
-  return (error: unknown) => {
-    if (!import.meta.env.DEV) {
-      return;
-    }
-
-    const now = Date.now();
-    if (!lastPrimaryFailureLogAt.value || now - lastPrimaryFailureLogAt.value >= PRIMARY_FAILURE_LOG_COOLDOWN) {
-      console.info('[JobQueue] Generation endpoint unavailable, falling back', error);
-      lastPrimaryFailureLogAt.value = now;
-    }
-  };
-};
-
 export const useJobQueueTransport = (
   options: UseJobQueueTransportOptions,
 ): UseJobQueueTransportReturn => {
   const apiAvailable = ref(true);
-  const legacyEndpointMissing = ref(false);
-  const legacyMissingLogged = ref(false);
-  const logPrimaryFailure = createPrimaryFailureLogger();
 
   const fetchJobs = async (): Promise<JobQueueRecord[] | null> => {
     const backendBase = resolveBackendBase(options.backendBase);
@@ -67,41 +43,14 @@ export const useJobQueueTransport = (
       apiAvailable.value = true;
       return records;
     } catch (error) {
-      logPrimaryFailure(error);
-
-      if (legacyEndpointMissing.value) {
-        return null;
-      }
-
-      try {
-        const fallbackRecords = await fetchLegacyJobStatuses(backendBase);
-        apiAvailable.value = true;
-        legacyEndpointMissing.value = false;
-        legacyMissingLogged.value = false;
-        return fallbackRecords;
-      } catch (fallbackError) {
-        if (fallbackError instanceof ApiError && fallbackError.status === 404) {
-          legacyEndpointMissing.value = true;
-          if (import.meta.env.DEV && !legacyMissingLogged.value) {
-            console.info(
-              '[JobQueue] Legacy job endpoint missing, continuing without fallback',
-            );
-            legacyMissingLogged.value = true;
-          }
-        } else if (import.meta.env.DEV) {
-          console.info('[JobQueue] Legacy job endpoint failed', fallbackError);
-        }
-
-        return null;
-      }
+      apiAvailable.value = false;
+      return null;
     }
   };
 
   return {
     fetchJobs,
     apiAvailable,
-    legacyEndpointMissing,
-    isLegacyFallbackAvailable: computed(() => !legacyEndpointMissing.value),
   } as const;
 };
 

--- a/app/frontend/src/services/generation/generationService.ts
+++ b/app/frontend/src/services/generation/generationService.ts
@@ -78,16 +78,6 @@ export const fetchActiveGenerationJobs = async (
   return Array.isArray(result.data) ? result.data : [];
 };
 
-export const fetchLegacyJobStatuses = async (
-  baseUrl?: string | null,
-): Promise<JobStatusRecord[]> => {
-  const result = await requestJson<JobStatusRecord[]>(
-    resolveBackendUrlHelper('/jobs/status', baseUrl),
-    { credentials: 'same-origin' },
-  );
-  return Array.isArray(result.data) ? result.data : [];
-};
-
 const sanitizeNegativePrompt = (value: string): string | null => {
   const trimmed = value.trim();
   return trimmed.length > 0 ? trimmed : null;
@@ -133,17 +123,6 @@ export const cancelGenerationJob = async (
     },
   );
   return data ?? null;
-};
-
-export const cancelLegacyJob = async (
-  jobId: string,
-  baseUrl?: string | null,
-): Promise<boolean> => {
-  const result = await requestJson(resolveBackendUrlHelper(`/jobs/${encodeURIComponent(jobId)}/cancel`, baseUrl), {
-    method: 'POST',
-    credentials: 'same-origin',
-  });
-  return result.meta.ok;
 };
 
 export const deleteGenerationResult = async (

--- a/tests/e2e/utils/waits.js
+++ b/tests/e2e/utils/waits.js
@@ -1,6 +1,6 @@
 import { expect, test } from '@playwright/test';
 
-const isJobEndpoint = (url) => url.includes('/generation/jobs/active') || url.includes('/jobs/status');
+const isJobEndpoint = (url) => url.includes('/generation/jobs/active');
 
 const importExportLoadingSelector = '[data-testid="import-export-loading"]';
 

--- a/tests/vue/useJobQueue.spec.ts
+++ b/tests/vue/useJobQueue.spec.ts
@@ -2,13 +2,11 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { computed, ref } from 'vue';
 import { mount } from '@vue/test-utils';
 
-import { useJobQueue } from '@/composables/useJobQueue';
+import { useJobQueue } from '@/composables/generation/useJobQueue';
 import { useGenerationQueueStore } from '@/stores/generation';
-import { ApiError } from '@/types';
 
 const serviceMocks = vi.hoisted(() => ({
   fetchActiveGenerationJobs: vi.fn(),
-  fetchLegacyJobStatuses: vi.fn(),
 }));
 
 vi.mock('@/services', () => serviceMocks);
@@ -24,7 +22,7 @@ const notificationMocks = vi.hoisted(() => ({
   clearAll: vi.fn(),
 }));
 
-vi.mock('@/composables/useNotifications', () => ({
+vi.mock('@/composables/shared', () => ({
   useNotifications: () => notificationMocks,
 }));
 
@@ -58,15 +56,7 @@ describe('useJobQueue', () => {
     notificationMocks.notifications.value = [];
   });
 
-  it('retries the primary endpoint when fallback returns 404 and continues polling', async () => {
-    const fallbackNotFound = new ApiError({
-      message: 'Not Found',
-      status: 404,
-      statusText: 'Not Found',
-      payload: null,
-      meta: { ok: false, status: 404, statusText: 'Not Found' },
-    });
-
+  it('continues polling after transient failures', async () => {
     serviceMocks.fetchActiveGenerationJobs
       .mockRejectedValueOnce(new Error('Primary endpoint failed'))
       .mockResolvedValueOnce([
@@ -78,24 +68,21 @@ describe('useJobQueue', () => {
         },
       ]);
 
-    serviceMocks.fetchLegacyJobStatuses.mockRejectedValueOnce(fallbackNotFound);
-
     const disabled = ref(true);
 
     await withQueue(async (queue) => {
       disabled.value = false;
+
       await queue.refresh();
       await Promise.resolve();
 
-      expect(queue.apiAvailable.value).toBe(true);
       expect(serviceMocks.fetchActiveGenerationJobs).toHaveBeenCalledTimes(1);
-      expect(serviceMocks.fetchLegacyJobStatuses).toHaveBeenCalledTimes(1);
+      expect(queue.jobs.value).toHaveLength(0);
 
       await queue.refresh();
       await Promise.resolve();
 
       expect(serviceMocks.fetchActiveGenerationJobs).toHaveBeenCalledTimes(2);
-      expect(serviceMocks.fetchLegacyJobStatuses).toHaveBeenCalledTimes(1);
       expect(queue.jobs.value).toHaveLength(1);
       expect(queue.jobs.value[0]).toMatchObject({ id: 'job-1', status: 'processing', progress: 25 });
     }, () => ({

--- a/tests/vue/useJobQueuePolling.spec.ts
+++ b/tests/vue/useJobQueuePolling.spec.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { computed, ref } from 'vue';
 import { mount } from '@vue/test-utils';
 
-import { useJobQueuePolling } from '@/composables/useJobQueuePolling';
+import { useJobQueuePolling } from '@/composables/generation/useJobQueuePolling';
 
 describe('useJobQueuePolling', () => {
   beforeEach(() => {
@@ -16,7 +16,6 @@ describe('useJobQueuePolling', () => {
   it('executes the fetch callback on an interval and stops when disabled', async () => {
     const disabled = ref(false);
     const pollInterval = ref(100);
-    const apiAvailable = ref(true);
     const fetchJobs = vi.fn().mockResolvedValue([{ id: 'job-1' }, { id: 'job-2' }]);
     const onRecord = vi.fn();
 
@@ -27,7 +26,6 @@ describe('useJobQueuePolling', () => {
         polling = useJobQueuePolling({
           disabled: computed(() => disabled.value),
           pollInterval: computed(() => pollInterval.value),
-          apiAvailable,
           fetchJobs,
           onRecord,
         });


### PR DESCRIPTION
## Summary
- drop legacy job status and cancellation helpers from the generation service
- simplify job queue transport/actions/polling to rely on canonical `/generation/jobs/*` endpoints
- update queue composable tests and Playwright waits to match the streamlined transport

## Testing
- npm run test:unit -- tests/vue/useJobQueueTransport.spec.ts tests/vue/useJobQueueActions.spec.ts tests/vue/useJobQueuePolling.spec.ts tests/vue/useJobQueue.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68d307c8d2c08329bb0904fde6656edf