### PR TITLE
refactor: migrate tests to service registry builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The codebase demonstrates strong engineering foundations but has identified comp
 - ✅ Component decomposition (ImportExport → specialized panels)
 - ✅ Shared Pydantic model standardization
 - ✅ Analytics containerization and coordinator patterns
-- 🔄 **Current Focus**: ServiceContainer simplification and composable extraction
+- 🔄 **Current Focus**: Service registry builder adoption and composable extraction
 
 ## 🚀 Quick Start
 
@@ -141,21 +141,23 @@ The project implements a sophisticated modular architecture with clear separatio
 
 ### Service Architecture
 
-The backend implements a sophisticated service layer with dependency injection:
+The backend implements a sophisticated service registry with explicit dependency injection:
 
 ```python
-# Service Container with 12+ specialized services
-services = ServiceContainer(
-    db_session=session,
-    adapters=AdapterService,           # LoRA adapter management
-    recommendations=RecommendationService,  # AI-powered suggestions
-    analytics=AnalyticsService,        # Metrics and insights
-    generation=GenerationCoordinator,  # Image generation orchestration
-    deliveries=DeliveryService,        # Job queue management
-    archive=ArchiveService,            # Import/export workflows
-    websocket=WebSocketService,        # Real-time communication
-    # ... and more specialized services
-)
+from backend.services import get_service_container_builder
+
+# Typed service registry built via the shared builder
+builder = get_service_container_builder()
+services = builder.build(session)
+
+# Domain facades expose rich service APIs
+adapters = services.domain.adapters            # LoRA adapter management
+recommendations = services.domain.recommendations  # AI-powered suggestions
+analytics = services.domain.analytics          # Metrics and insights
+generation = services.application.generation_coordinator  # Image orchestration
+deliveries = services.application.deliveries   # Queue management
+archive = services.application.archive         # Import/export workflows
+websocket = services.application.websocket     # Real-time communication
 ```
 
 **Key Patterns**:
@@ -207,7 +209,7 @@ The project is actively undergoing architectural improvements based on comprehen
 - Recommendation service coordinator pattern implementation
 
 ### Active Focus Areas 🔄
-- **ServiceContainer Simplification**: Breaking down 387-line God Object into focused containers
+- **Service registry maturation**: Breaking down legacy container patterns into focused registries
 - **Composable Extraction**: Splitting 378-line useJobQueue into specialized utilities
 - **Component Architecture**: Decomposing 713-line GenerationHistory into sub-components
 - **Test Organization**: Reorganizing 608-line test files into focused modules
@@ -334,7 +336,7 @@ The application provides robust LoRA management, generation workflows, and real-
 - ✅ **Performance**: Optimized builds with lazy loading and PWA features
 
 **Next Steps**:
-- Complete ServiceContainer architectural refactoring
+- Complete service registry architectural refactoring
 - Finalize component decomposition initiative  
 - Enhanced GPU acceleration documentation
 - Performance optimization through lazy loading

--- a/backend/services/__init__.py
+++ b/backend/services/__init__.py
@@ -1,11 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import replace
-from typing import Callable, Optional
-
 from sqlmodel import Session
-
-from backend.core.database import get_session
 
 from .adapters import AdapterService
 from .analytics import AnalyticsService, InsightGenerator, TimeSeriesBuilder
@@ -20,27 +15,8 @@ from .composition import ComposeService
 from .deliveries import DeliveryService
 from .delivery_repository import DeliveryJobRepository
 from .generation import GenerationCoordinator, GenerationService
-from .providers.analytics import make_analytics_service
-from .providers.archive import make_archive_service
-from .providers.deliveries import make_delivery_service
-from .providers.generation import (
-    make_compose_service,
-    make_generation_coordinator,
-    make_generation_service,
-)
-from .providers.recommendations import make_recommendation_service
-from .providers.storage import (
-    StorageProviders,
-    make_adapter_service,
-    make_storage_service,
-)
-from .providers.system import make_system_service
 from .queue import QueueOrchestrator
-from .service_container_builder import (
-    DomainFactories,
-    InfrastructureFactories,
-    ServiceContainerBuilder,
-)
+from .service_container_builder import ServiceContainerBuilder
 from .service_registry import (
     ApplicationServices,
     CoreServices,
@@ -59,155 +35,6 @@ def get_service_container_builder() -> ServiceContainerBuilder:
     return _DEFAULT_BUILDER
 
 
-class ServiceContainer:
-    """Backward compatible wrapper around :class:`ServiceRegistry`."""
-
-    def __init__(
-        self,
-        db_session: Optional[Session],
-        *,
-        queue_orchestrator: Optional[QueueOrchestrator] = None,
-        delivery_repository: Optional[DeliveryJobRepository] = None,
-        analytics_repository: Optional[AnalyticsRepository] = None,
-        recommendation_gpu_available: Optional[bool] = None,
-        storage_provider=None,
-        adapter_provider=make_adapter_service,
-        archive_provider=make_archive_service,
-        delivery_provider=make_delivery_service,
-        compose_provider=make_compose_service,
-        generation_provider=make_generation_service,
-        generation_coordinator_provider=make_generation_coordinator,
-        websocket_provider=None,
-        system_provider=make_system_service,
-        analytics_provider=make_analytics_service,
-        recommendation_provider=make_recommendation_service,
-    ) -> None:
-        storage_override = self._make_storage_override(
-            storage_provider, adapter_provider
-        )
-        domain_override = self._make_domain_override(
-            compose_provider,
-            generation_provider,
-            analytics_provider,
-            recommendation_provider,
-        )
-        infrastructure_override = self._make_infrastructure_override(
-            archive_provider,
-            delivery_provider,
-            generation_coordinator_provider,
-            system_provider,
-        )
-
-        builder = _DEFAULT_BUILDER.with_overrides(
-            storage=storage_override,
-            domain=domain_override,
-            infrastructure=infrastructure_override,
-            websocket_factory=websocket_provider,
-        )
-        registry = builder.build(
-            db_session,
-            queue_orchestrator=queue_orchestrator,
-            delivery_repository=delivery_repository,
-            analytics_repository=analytics_repository,
-            recommendation_gpu_available=recommendation_gpu_available,
-        )
-        self._registry = registry
-        self._builder = builder
-        self._generation_coordinator_override: Optional[GenerationCoordinator] = None
-
-    def __getattr__(self, name: str):
-        return getattr(self._registry, name)
-
-    def __setattr__(self, name, value):
-        if name == "_generation_coordinator":
-            object.__setattr__(self, "_generation_coordinator_override", value)
-            return
-        super().__setattr__(name, value)
-
-    @property
-    def registry(self) -> ServiceRegistry:
-        return self._registry
-
-    @property
-    def core(self) -> CoreServices:
-        return self._registry.core
-
-    @property
-    def domain(self) -> DomainServices:
-        return self._registry.domain
-
-    @property
-    def application(self) -> ApplicationServices:
-        application_services = self._registry.application
-        if self._generation_coordinator_override is None:
-            return application_services
-        return replace(
-            application_services,
-            _generation_coordinator_override=self._generation_coordinator_override,
-        )
-
-    @property
-    def generation_coordinator(self) -> GenerationCoordinator:
-        override = self._generation_coordinator_override
-        if override is not None:
-            return override
-        return self._registry.generation_coordinator
-
-    @staticmethod
-    def _make_storage_override(
-        storage_provider,
-        adapter_provider,
-    ) -> Optional[Callable[[StorageProviders], StorageProviders]]:
-        updates = {}
-        if storage_provider is not None:
-            updates["storage"] = storage_provider
-        if adapter_provider is not None:
-            updates["adapter"] = adapter_provider
-        if not updates:
-            return None
-        return lambda config, updates=updates: replace(config, **updates)
-
-    @staticmethod
-    def _make_domain_override(
-        compose_provider,
-        generation_provider,
-        analytics_provider,
-        recommendation_provider,
-    ) -> Optional[Callable[[DomainFactories], DomainFactories]]:
-        updates = {}
-        if compose_provider is not None:
-            updates["compose"] = compose_provider
-        if generation_provider is not None:
-            updates["generation"] = generation_provider
-        if analytics_provider is not None:
-            updates["analytics"] = analytics_provider
-        if recommendation_provider is not None:
-            updates["recommendation"] = recommendation_provider
-        if not updates:
-            return None
-        return lambda config, updates=updates: replace(config, **updates)
-
-    @staticmethod
-    def _make_infrastructure_override(
-        archive_provider,
-        delivery_provider,
-        generation_coordinator_provider,
-        system_provider,
-    ) -> Optional[Callable[[InfrastructureFactories], InfrastructureFactories]]:
-        updates = {}
-        if archive_provider is not None:
-            updates["archive"] = archive_provider
-        if delivery_provider is not None:
-            updates["delivery"] = delivery_provider
-        if generation_coordinator_provider is not None:
-            updates["generation_coordinator"] = generation_coordinator_provider
-        if system_provider is not None:
-            updates["system"] = system_provider
-        if not updates:
-            return None
-        return lambda config, updates=updates: replace(config, **updates)
-
-
 def create_service_container(db_session: Session) -> ServiceRegistry:
     """Create a service registry for the provided database session."""
     return _DEFAULT_BUILDER.build(db_session)
@@ -218,7 +45,6 @@ __all__ = [
     "CoreServices",
     "DomainServices",
     "ServiceRegistry",
-    "ServiceContainer",
     "ServiceContainerBuilder",
     "create_service_container",
     "AdapterService",
@@ -229,6 +55,5 @@ __all__ = [
     "GenerationService",
     "StorageService",
     "QueueOrchestrator",
-    "get_session",
     "get_service_container_builder",
 ]

--- a/scripts/importer.py
+++ b/scripts/importer.py
@@ -21,10 +21,7 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 
 from backend.core.config import settings
 from backend.core.database import get_session_context
-
-# Backwards compatibility for tests that monkeypatch importer.get_session
-get_session = get_session_context
-from backend.services import ServiceContainer
+from backend.services import get_service_container_builder
 from backend.services.adapters import AdapterService
 from backend.services.analytics_repository import AnalyticsRepository
 
@@ -317,12 +314,12 @@ def register_adapter_from_metadata(
     ac = AdapterCreate(**{k: v for k, v in payload.items() if v is not None})
     try:
         with get_session_context() as session:
-            container = ServiceContainer(
+            services = get_service_container_builder().build(
                 session,
                 analytics_repository=AnalyticsRepository(session),
                 recommendation_gpu_available=False,
             )
-            adapter = container.domain.adapters.upsert_adapter(ac)
+            adapter = services.domain.adapters.upsert_adapter(ac)
         logger.info("Upserted adapter %s (id=%s)", adapter.name, adapter.id)
         result["status"] = "upserted"
         result["id"] = adapter.id

--- a/tests/README.md
+++ b/tests/README.md
@@ -192,14 +192,19 @@ npx playwright test --project=mobile      # Mobile workflows
 **Backend Test Environment:**
 ```python
 # Sophisticated fixture setup in conftest.py
+from unittest.mock import Mock
+
+from backend.services import get_service_container_builder
+
 @pytest.fixture
-def service_container_with_mocks(db_session):
-    """Service container with mocked dependencies for isolated testing"""
-    return ServiceContainer(
-        db_session=db_session,
+def service_registry_with_mocks(db_session):
+    """Typed service registry with mocked dependencies for isolated testing"""
+    builder = get_service_container_builder()
+    return builder.build(
+        db_session,
         recommendation_gpu_available=False,  # CPU testing mode
         queue_orchestrator=Mock(spec=QueueOrchestrator),
-        analytics_repository=Mock(spec=AnalyticsRepository)
+        analytics_repository=Mock(spec=AnalyticsRepository),
     )
 
 @pytest.fixture

--- a/tests/api/test_cli.py
+++ b/tests/api/test_cli.py
@@ -7,7 +7,7 @@ from fastapi.testclient import TestClient
 
 from backend.core.dependencies import get_service_container
 from backend.main import app as backend_app
-from backend.services import ServiceContainer
+from backend.services import get_service_container_builder
 from backend.services.analytics_repository import AnalyticsRepository
 from backend.services.delivery_repository import DeliveryJobRepository
 from backend.services.queue import QueueOrchestrator
@@ -29,7 +29,8 @@ def test_compose_uses_primary_queue_backend(
         orchestrator = QueueOrchestrator(primary_backend=recording_queue_backend)
         repository = DeliveryJobRepository(db_session)
         analytics_repository = AnalyticsRepository(db_session)
-        return ServiceContainer(
+        builder = get_service_container_builder()
+        return builder.build(
             db_session,
             queue_orchestrator=orchestrator,
             delivery_repository=repository,
@@ -74,7 +75,8 @@ def test_compose_falls_back_to_background_queue(
         )
         repository = DeliveryJobRepository(db_session)
         analytics_repository = AnalyticsRepository(db_session)
-        return ServiceContainer(
+        builder = get_service_container_builder()
+        return builder.build(
             db_session,
             queue_orchestrator=orchestrator,
             delivery_repository=repository,
@@ -137,7 +139,8 @@ async def test_queue_generation_job_uses_primary_queue_backend(
             primary_backend=primary_queue,
             fallback_backend=fallback_queue,
         )
-        return ServiceContainer(
+        builder = get_service_container_builder()
+        return builder.build(
             db_session,
             queue_orchestrator=orchestrator,
             delivery_repository=DeliveryJobRepository(db_session),
@@ -229,7 +232,8 @@ async def test_queue_generation_job_falls_back_to_background_tasks(
             primary_backend=primary_queue,
             fallback_backend=fallback_queue,
         )
-        return ServiceContainer(
+        builder = get_service_container_builder()
+        return builder.build(
             db_session,
             queue_orchestrator=orchestrator,
             delivery_repository=DeliveryJobRepository(db_session),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,7 +14,7 @@ from app.main import app as fastapi_app
 # Use new app import paths
 from backend.core.database import get_session
 from backend.main import app as backend_app
-from backend.services import ServiceContainer
+from backend.services import get_service_container_builder
 from backend.services.adapters import AdapterService
 from backend.services.analytics_repository import AnalyticsRepository
 from backend.services.composition import ComposeService
@@ -95,27 +95,27 @@ def db_session_fixture():
 def adapter_service(db_session: Session, mock_storage) -> AdapterService:
     """AdapterService fixture using the new modular service."""
     # Use the mocked storage service
-    container = ServiceContainer(
+    builder = get_service_container_builder()
+    services = builder.build(
         db_session,
         analytics_repository=AnalyticsRepository(db_session),
         recommendation_gpu_available=False,
-        storage_provider=lambda: mock_storage.storage_service,
     )
-    return container.domain.adapters
+    return services.domain.adapters
 
 
 @pytest.fixture
 def delivery_service(db_session: Session, mock_storage) -> DeliveryService:
     """DeliveryService fixture using the new modular service."""
-    container = ServiceContainer(
+    builder = get_service_container_builder()
+    services = builder.build(
         db_session,
         queue_orchestrator=create_queue_orchestrator(),
         delivery_repository=DeliveryJobRepository(db_session),
         analytics_repository=AnalyticsRepository(db_session),
         recommendation_gpu_available=False,
-        storage_provider=lambda: mock_storage.storage_service,
     )
-    return container.application.deliveries
+    return services.application.deliveries
 
 
 @pytest.fixture

--- a/tests/recommendations/test_service.py
+++ b/tests/recommendations/test_service.py
@@ -5,7 +5,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from backend.services import ServiceContainer
+from backend.services import get_service_container_builder
 from backend.services.analytics_repository import AnalyticsRepository
 from backend.services.recommendations import (
     EmbeddingCoordinator,
@@ -140,13 +140,14 @@ class TestRecommendationService:
         assert service.gpu_enabled is False
         assert service.device == "cpu"
 
-    def test_service_container_builds_dependencies(self, db_session):
-        container = ServiceContainer(
+    def test_service_registry_builds_dependencies(self, db_session):
+        builder = get_service_container_builder()
+        services = builder.build(
             db_session,
             analytics_repository=AnalyticsRepository(db_session),
             recommendation_gpu_available=False,
         )
-        service = container.recommendations
+        service = services.recommendations
 
         assert isinstance(service, RecommendationService)
         assert service.device == "cpu"

--- a/tests/test_importer_integration.py
+++ b/tests/test_importer_integration.py
@@ -25,20 +25,17 @@ def test_importer_integration_creates_adapter(
     # Ensure storage check returns True
     mock_storage.exists.return_value = True
 
-    # Monkeypatch importer and services get_session to use the test db_session
+    # Monkeypatch importer session helper to use the test db_session
     from contextlib import contextmanager
     
     @contextmanager
     def get_test_session():
         yield db_session
     
-    monkeypatch.setattr(importer, "get_session", get_test_session)
-    # Patch the backend.services module to ensure service helpers use test session
-    import backend.services as _backend_services
-    monkeypatch.setattr(_backend_services, "get_session", get_test_session)
+    monkeypatch.setattr(importer, "get_session_context", get_test_session)
 
     # Parse and register (non-dry run). register_adapter_from_metadata will
-    # call the service helper which now uses the patched get_session.
+    # call the session helper which now uses the patched get_session_context.
     parsed = importer.parse_civitai_json(str(jp))
     result = importer.register_adapter_from_metadata(
         parsed, json_path=str(jp), dry_run=False,

--- a/tests/test_queue_configuration.py
+++ b/tests/test_queue_configuration.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from backend.core.config import settings
-from backend.services import ServiceContainer
+from backend.services import get_service_container_builder
 from backend.services.analytics_repository import AnalyticsRepository
 from backend.services.delivery_repository import DeliveryJobRepository
 from backend.services.queue import (
@@ -31,14 +31,15 @@ def test_queue_factory_shared_backend_with_redis(db_session) -> None:
         assert isinstance(primary, RedisQueueBackend)
         assert isinstance(fallback, BackgroundTaskQueueBackend)
 
-        container = ServiceContainer(
+        builder = get_service_container_builder()
+        services = builder.build(
             db_session,
             queue_orchestrator=orchestrator,
             delivery_repository=DeliveryJobRepository(db_session),
             analytics_repository=AnalyticsRepository(db_session),
             recommendation_gpu_available=False,
         )
-        deliveries_service = container.application.deliveries
+        deliveries_service = services.application.deliveries
 
         assert deliveries_service.queue_orchestrator is orchestrator
         assert context.queue_orchestrator is orchestrator
@@ -67,14 +68,15 @@ def test_queue_factory_shared_backend_without_redis(db_session) -> None:
         assert primary is None
         assert isinstance(fallback, BackgroundTaskQueueBackend)
 
-        container = ServiceContainer(
+        builder = get_service_container_builder()
+        services = builder.build(
             db_session,
             queue_orchestrator=orchestrator,
             delivery_repository=DeliveryJobRepository(db_session),
             analytics_repository=AnalyticsRepository(db_session),
             recommendation_gpu_available=False,
         )
-        deliveries_service = container.application.deliveries
+        deliveries_service = services.application.deliveries
 
         assert deliveries_service.queue_orchestrator is orchestrator
         assert context.queue_orchestrator is orchestrator

--- a/tests/test_upsert.py
+++ b/tests/test_upsert.py
@@ -3,7 +3,7 @@
 from sqlalchemy.exc import IntegrityError
 
 from backend.schemas.adapters import AdapterCreate
-from backend.services import ServiceContainer
+from backend.services import get_service_container_builder
 from backend.services.adapters import AdapterService
 from backend.services.analytics_repository import AnalyticsRepository
 
@@ -12,13 +12,13 @@ def test_upsert_creates_and_updates(db_session, mock_storage):
     """Test that upsert creates and updates adapters correctly."""
     # initial create
     mock_storage.exists.return_value = True
-    container = ServiceContainer(
+    builder = get_service_container_builder()
+    services = builder.build(
         db_session,
         analytics_repository=AnalyticsRepository(db_session),
         recommendation_gpu_available=False,
-        storage_provider=lambda: mock_storage.storage_service,
     )
-    adapter_service = container.domain.adapters
+    adapter_service = services.domain.adapters
     payload = AdapterCreate(
         name="u1",
         version="v1",


### PR DESCRIPTION
## Summary
- remove the legacy ServiceContainer wrapper and rely on the shared ServiceContainerBuilder exports
- update the importer and tests to construct service registries via the builder, adjusting fixtures and overrides accordingly
- refresh documentation to demonstrate the ServiceRegistry workflow instead of the deprecated ServiceContainer helper

## Testing
- pytest tests/test_service_providers.py tests/test_queue_configuration.py tests/test_upsert.py tests/generation/test_jobs.py tests/api/test_cli.py tests/recommendations/test_service.py tests/test_importer_integration.py
- python scripts/importer.py --dry-run --path /tmp

------
https://chatgpt.com/codex/tasks/task_e_68d3080645d483299180053c3d850fa5