### PR TITLE
Add generation result management endpoints

### DIFF
--- a/backend/schemas/__init__.py
+++ b/backend/schemas/__init__.py
@@ -35,8 +35,10 @@ from .deliveries import (
 )
 from .generation import (
     ComposeDeliverySDNext,
+    GenerationBulkDeleteRequest,
     GenerationCancelResponse,
     GenerationComplete,
+    GenerationExportRequest,
     GenerationJobStatus,
     GenerationResultSummary,
     GenerationStarted,
@@ -107,6 +109,8 @@ __all__ = [
     "GenerationJobStatus",
     "GenerationCancelResponse",
     "GenerationResultSummary",
+    "GenerationBulkDeleteRequest",
+    "GenerationExportRequest",
     # Import/export
     "ExportConfig",
     "ExportEstimate",

--- a/backend/schemas/generation.py
+++ b/backend/schemas/generation.py
@@ -1,7 +1,7 @@
 """Generation and SDNext-related schemas."""
 
 from datetime import datetime
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Union
 
 from pydantic import BaseModel, Field
 
@@ -126,3 +126,16 @@ class GenerationResultSummary(BaseModel):
     created_at: datetime
     finished_at: Optional[datetime] = None
     generation_info: Optional[Dict[str, Any]] = None
+
+
+class GenerationBulkDeleteRequest(BaseModel):
+    """Request payload for bulk deletion of generation results."""
+
+    ids: List[Union[str, int]] = Field(default_factory=list)
+
+
+class GenerationExportRequest(BaseModel):
+    """Request payload for exporting generation results."""
+
+    ids: List[Union[str, int]] = Field(default_factory=list)
+    include_metadata: bool = True

--- a/backend/services/deliveries.py
+++ b/backend/services/deliveries.py
@@ -2,7 +2,16 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Dict, List, Optional
+import base64
+import json
+import mimetypes
+import shutil
+import tempfile
+import zipfile
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Dict, Iterable, Iterator, List, Optional, Sequence
 
 from fastapi import BackgroundTasks
 
@@ -10,8 +19,62 @@ from backend.models import DeliveryJob
 
 from .delivery_repository import DeliveryJobRepository
 
+
+@dataclass
+class ResultAsset:
+    """Representation of a persisted generation asset."""
+
+    filename: str
+    content_type: str
+    path: Optional[str] = None
+    data: Optional[bytes] = None
+    size: Optional[int] = None
+
+    def iter_bytes(self, chunk_size: int = 64 * 1024) -> Iterator[bytes]:
+        """Yield file content as chunks or a single in-memory blob."""
+        if self.path:
+            path = Path(self.path)
+            with path.open("rb") as stream:
+                while True:
+                    chunk = stream.read(chunk_size)
+                    if not chunk:
+                        break
+                    yield chunk
+            return
+
+        if self.data is not None:
+            yield self.data
+
+
+@dataclass
+class ResultArchive:
+    """Streaming archive payload for exported generation results."""
+
+    iterator: Iterable[bytes]
+    manifest: Dict[str, Any]
+    size: int
+    filename: str
+
+
+@dataclass
+class ResultDownload:
+    """Metadata describing a downloadable generation artifact."""
+
+    filename: str
+    content_type: str
+    iterator: Iterable[bytes]
+    size: Optional[int] = None
+
+
+def _json_default(value: Any) -> str:
+    if isinstance(value, datetime):
+        return value.isoformat()
+    return str(value)
+
 if TYPE_CHECKING:  # pragma: no cover - imported for type checking only
+    from .generation import GenerationCoordinator
     from .queue import QueueOrchestrator
+    from .storage import StorageService
 
 
 class DeliveryService:
@@ -126,6 +189,397 @@ class DeliveryService:
     def get_job_result(self, job: DeliveryJob) -> Optional[Dict[str, Any]]:
         """Parse and return job result as dict."""
         return self._repository.get_job_result(job)
+
+    # ------------------------------------------------------------------
+    # Result management helpers
+    # ------------------------------------------------------------------
+    def delete_job_result(
+        self,
+        job_id: str,
+        *,
+        storage: "StorageService",
+        coordinator: Optional["GenerationCoordinator"] = None,
+    ) -> bool:
+        """Remove a persisted result and delete the associated job record."""
+        job = self.get_job(job_id)
+        if job is None:
+            return False
+
+        self.remove_job_assets(job, storage, coordinator=coordinator)
+        return self._repository.delete_job(job_id)
+
+    def bulk_delete_job_results(
+        self,
+        job_ids: Sequence[str],
+        *,
+        storage: "StorageService",
+        coordinator: Optional["GenerationCoordinator"] = None,
+    ) -> int:
+        """Bulk delete results by removing assets then deleting rows."""
+        jobs = self._repository.list_jobs_by_ids(job_ids)
+        if not jobs:
+            return 0
+
+        for job in jobs:
+            self.remove_job_assets(job, storage, coordinator=coordinator)
+
+        deleted = self._repository.delete_jobs([job.id for job in jobs])
+        return deleted
+
+    def build_results_archive(
+        self,
+        job_ids: Sequence[str],
+        *,
+        storage: "StorageService",
+        coordinator: "GenerationCoordinator",
+        include_metadata: bool = True,
+        chunk_size: int = 64 * 1024,
+        spooled_file_max_size: int = 32 * 1024 * 1024,
+    ) -> Optional[ResultArchive]:
+        """Create a streaming archive for the specified results."""
+        jobs = self._repository.list_jobs_by_ids(job_ids)
+        if not jobs:
+            return None
+
+        generated_at = datetime.now(timezone.utc)
+        manifest: Dict[str, Any] = {
+            "generated_at": generated_at.isoformat(),
+            "count": len(jobs),
+            "results": [],
+        }
+
+        spool = tempfile.SpooledTemporaryFile(max_size=spooled_file_max_size)
+        with zipfile.ZipFile(spool, "w", compression=zipfile.ZIP_DEFLATED) as archive:
+            for job in jobs:
+                serialized = coordinator.serialize_delivery_job(job)
+                params_payload = serialized.get("params")
+                if not isinstance(params_payload, dict):
+                    params_payload = {}
+                result_payload = serialized.get("result")
+                if not isinstance(result_payload, dict):
+                    result_payload = {}
+
+                assets = self._extract_assets_from_payload(
+                    job,
+                    result_payload,
+                    storage,
+                    params=params_payload,
+                )
+
+                asset_entries = []
+                base_path = f"results/{job.id}"
+                metadata_payload: Dict[str, Any] = {
+                    "id": job.id,
+                    "prompt": job.prompt,
+                    "status": job.status,
+                    "created_at": job.created_at,
+                    "finished_at": job.finished_at,
+                }
+                if include_metadata:
+                    metadata_payload["params"] = params_payload
+                    metadata_payload["result"] = result_payload
+
+                archive.writestr(
+                    f"{base_path}/metadata.json",
+                    json.dumps(metadata_payload, indent=2, default=_json_default),
+                )
+
+                for index, asset in enumerate(assets):
+                    archive_name = f"{base_path}/{index:03d}_{asset.filename}"
+                    asset_entry = {
+                        "filename": asset.filename,
+                        "archive_path": archive_name,
+                        "content_type": asset.content_type,
+                        "size": asset.size,
+                    }
+
+                    try:
+                        with archive.open(archive_name, "w") as target:
+                            if asset.path:
+                                path = Path(asset.path)
+                                with path.open("rb") as source:
+                                    shutil.copyfileobj(source, target, chunk_size)
+                            elif asset.data is not None:
+                                target.write(asset.data)
+                            else:
+                                continue
+                    except OSError:
+                        continue
+
+                    asset_entries.append(asset_entry)
+
+                manifest["results"].append(
+                    {
+                        "id": job.id,
+                        "prompt": job.prompt,
+                        "status": job.status,
+                        "created_at": job.created_at.isoformat()
+                        if job.created_at
+                        else None,
+                        "finished_at": job.finished_at.isoformat()
+                        if job.finished_at
+                        else None,
+                        "assets": asset_entries,
+                    }
+                )
+
+        size = spool.tell()
+        spool.seek(0)
+        filename = f"generation-results-{generated_at.strftime('%Y%m%d-%H%M%S')}.zip"
+
+        def _iterator() -> Iterator[bytes]:
+            try:
+                while True:
+                    chunk = spool.read(chunk_size)
+                    if not chunk:
+                        break
+                    yield chunk
+            finally:
+                spool.close()
+
+        return ResultArchive(iterator=_iterator(), manifest=manifest, size=size, filename=filename)
+
+    def build_result_download(
+        self,
+        job: DeliveryJob,
+        *,
+        storage: "StorageService",
+        coordinator: "GenerationCoordinator",
+        chunk_size: int = 64 * 1024,
+    ) -> Optional[ResultDownload]:
+        """Prepare a download payload for the primary asset of ``job``."""
+        assets = self._collect_result_assets(job, storage, coordinator=coordinator)
+        if not assets:
+            return None
+
+        primary = assets[0]
+        if primary.path:
+            path = Path(primary.path)
+            if not storage.validate_file_path(primary.path):
+                return None
+
+            def _stream() -> Iterator[bytes]:
+                with path.open("rb") as stream:
+                    while True:
+                        chunk = stream.read(chunk_size)
+                        if not chunk:
+                            break
+                        yield chunk
+
+            size: Optional[int] = primary.size
+            if size is None:
+                try:
+                    size = path.stat().st_size
+                except OSError:
+                    size = None
+
+            return ResultDownload(
+                filename=primary.filename,
+                content_type=primary.content_type,
+                iterator=_stream(),
+                size=size,
+            )
+
+        if primary.data is not None:
+            data = primary.data
+
+            def _bytes() -> Iterator[bytes]:
+                yield data
+
+            return ResultDownload(
+                filename=primary.filename,
+                content_type=primary.content_type,
+                iterator=_bytes(),
+                size=len(data),
+            )
+
+        return None
+
+    def remove_job_assets(
+        self,
+        job: DeliveryJob,
+        storage: "StorageService",
+        *,
+        coordinator: Optional["GenerationCoordinator"] = None,
+    ) -> List[str]:
+        """Remove persisted files referenced by a job's result payload."""
+        removed: List[str] = []
+        for asset in self._collect_result_assets(job, storage, coordinator=coordinator):
+            if not asset.path:
+                continue
+            try:
+                path = Path(asset.path)
+                path.unlink(missing_ok=True)
+                removed.append(asset.path)
+            except OSError:  # pragma: no cover - best effort cleanup
+                continue
+        return removed
+
+    def _collect_result_assets(
+        self,
+        job: DeliveryJob,
+        storage: "StorageService",
+        *,
+        coordinator: Optional["GenerationCoordinator"] = None,
+    ) -> List[ResultAsset]:
+        """Collect assets referenced by job results using available context."""
+        result_payload: Dict[str, Any] = {}
+        params_payload: Dict[str, Any] = {}
+
+        if coordinator is not None:
+            serialized = coordinator.serialize_delivery_job(job)
+            maybe_params = serialized.get("params")
+            if isinstance(maybe_params, dict):
+                params_payload = dict(maybe_params)
+            maybe_result = serialized.get("result")
+            if isinstance(maybe_result, dict):
+                result_payload = dict(maybe_result)
+        else:
+            maybe_params = self.get_job_params(job)
+            if isinstance(maybe_params, dict):
+                params_payload = dict(maybe_params)
+            maybe_result = self.get_job_result(job)
+            if isinstance(maybe_result, dict):
+                result_payload = dict(maybe_result)
+
+        return self._extract_assets_from_payload(
+            job,
+            result_payload,
+            storage,
+            params=params_payload,
+        )
+
+    def _extract_assets_from_payload(
+        self,
+        job: DeliveryJob,
+        result_payload: Dict[str, Any],
+        storage: "StorageService",
+        *,
+        params: Optional[Dict[str, Any]] = None,
+    ) -> List[ResultAsset]:
+        assets: List[ResultAsset] = []
+        seen_paths: set[str] = set()
+
+        return_format: Optional[str] = None
+        if isinstance(params, dict):
+            maybe_format = params.get("return_format")
+            if isinstance(maybe_format, str):
+                return_format = maybe_format.lower()
+
+        images = result_payload.get("images")
+        if isinstance(images, list):
+            for index, value in enumerate(images):
+                asset = self._resolve_asset_value(
+                    value,
+                    storage,
+                    default_filename=f"{job.id}-{index:03d}.png",
+                    return_format=return_format,
+                )
+                if asset is None:
+                    continue
+                if asset.path:
+                    if asset.path in seen_paths:
+                        continue
+                    seen_paths.add(asset.path)
+                assets.append(asset)
+
+        for key in ("image_url", "thumbnail_url"):
+            value = result_payload.get(key)
+            asset = self._resolve_asset_value(
+                value,
+                storage,
+                default_filename=f"{job.id}-{key}.png",
+                return_format=return_format,
+            )
+            if asset is None:
+                continue
+            if asset.path and asset.path in seen_paths:
+                continue
+            if asset.path:
+                seen_paths.add(asset.path)
+            assets.append(asset)
+
+        return assets
+
+    def _resolve_asset_value(
+        self,
+        value: Any,
+        storage: "StorageService",
+        *,
+        default_filename: str,
+        return_format: Optional[str] = None,
+        fallback_mime: str = "image/png",
+    ) -> Optional[ResultAsset]:
+        if not isinstance(value, str):
+            return None
+
+        candidate = value.strip()
+        if not candidate:
+            return None
+
+        if candidate.startswith("data:"):
+            header, _, payload = candidate.partition(",")
+            mime = fallback_mime
+            prefix = header[5:] if header.startswith("data:") else ""
+            if ";" in prefix:
+                mime = prefix.split(";", 1)[0] or fallback_mime
+            elif prefix:
+                mime = prefix
+            try:
+                binary = base64.b64decode(payload, validate=False)
+            except Exception:  # pragma: no cover - invalid payload
+                return None
+            return ResultAsset(
+                filename=default_filename,
+                content_type=mime or fallback_mime,
+                data=binary,
+                size=len(binary),
+            )
+
+        normalized_format = (return_format or "").lower()
+        path_candidate: Optional[str] = None
+
+        if candidate.startswith("file://"):
+            path_candidate = candidate[len("file://") :]
+        elif normalized_format in {"file_path", "url"}:
+            path_candidate = candidate
+
+        if path_candidate is not None:
+            filename = Path(path_candidate).name or default_filename
+            mime_type, _ = mimetypes.guess_type(path_candidate)
+            size_value: Optional[int] = None
+            try:
+                exists = storage.validate_file_path(path_candidate)
+            except Exception:  # pragma: no cover - defensive guard
+                exists = False
+
+            if exists:
+                file_info = storage.get_file_info(path_candidate) or {}
+                if isinstance(file_info, dict):
+                    size_raw = file_info.get("size")
+                    if isinstance(size_raw, int):
+                        size_value = size_raw
+                    elif isinstance(size_raw, float):
+                        size_value = int(size_raw)
+
+            return ResultAsset(
+                filename=filename,
+                content_type=mime_type or fallback_mime,
+                path=path_candidate,
+                size=size_value,
+            )
+
+        try:
+            binary = base64.b64decode(candidate, validate=False)
+        except Exception:  # pragma: no cover - invalid base64
+            return None
+
+        return ResultAsset(
+            filename=default_filename,
+            content_type=fallback_mime,
+            data=binary,
+            size=len(binary),
+        )
 
     def _require_orchestrator(self) -> "QueueOrchestrator":
         if self._queue_orchestrator is None:

--- a/tests/generation/test_results.py
+++ b/tests/generation/test_results.py
@@ -1,0 +1,111 @@
+"""Tests for generation results management endpoints."""
+
+from __future__ import annotations
+
+import base64
+import io
+import zipfile
+from typing import Dict
+
+from fastapi.testclient import TestClient
+
+from backend.services.deliveries import DeliveryService
+
+PNG_BASE64 = (
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg=="
+)
+
+
+def _store_completed_job(
+    delivery_service: DeliveryService,
+    prompt: str,
+    *,
+    result_overrides: Dict[str, object] | None = None,
+):
+    job = delivery_service.create_job(prompt, "sdnext", {"generation_params": {"prompt": prompt}})
+    payload = {
+        "status": "completed",
+        "images": [PNG_BASE64],
+    }
+    if result_overrides:
+        payload.update(result_overrides)
+
+    delivery_service.update_job_status(job.id, "succeeded", payload)
+    return job
+
+
+def test_download_generation_result_returns_image(
+    client: TestClient,
+    delivery_service: DeliveryService,
+):
+    """The download endpoint streams the primary image payload."""
+    job = _store_completed_job(delivery_service, "Download prompt")
+
+    response = client.get(f"/api/v1/generation/results/{job.id}/download")
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("image/")
+    assert "attachment" in response.headers.get("content-disposition", "")
+
+    expected_bytes = base64.b64decode(PNG_BASE64)
+    assert response.content == expected_bytes
+
+
+def test_delete_generation_result_removes_job(
+    client: TestClient,
+    delivery_service: DeliveryService,
+):
+    """Deleting a result removes the record and associated assets."""
+    job = _store_completed_job(delivery_service, "Delete prompt")
+
+    response = client.delete(f"/api/v1/generation/results/{job.id}")
+    assert response.status_code == 204
+
+    assert delivery_service.get_job(job.id) is None
+
+
+def test_bulk_delete_generation_results(
+    client: TestClient,
+    delivery_service: DeliveryService,
+):
+    """Bulk deletion removes all specified results."""
+    first = _store_completed_job(delivery_service, "Bulk A")
+    second = _store_completed_job(delivery_service, "Bulk B")
+
+    response = client.request(
+        "DELETE",
+        "/api/v1/generation/results/bulk-delete",
+        json={"ids": [first.id, second.id]},
+    )
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["deleted"] == 2
+
+    assert delivery_service.get_job(first.id) is None
+    assert delivery_service.get_job(second.id) is None
+
+
+def test_export_generation_results_returns_archive(
+    client: TestClient,
+    delivery_service: DeliveryService,
+):
+    """Exporting results streams a ZIP archive with metadata and assets."""
+    job = _store_completed_job(delivery_service, "Export prompt")
+
+    response = client.post(
+        "/api/v1/generation/results/export",
+        json={"ids": [job.id]},
+    )
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "application/zip"
+    assert "attachment" in response.headers.get("content-disposition", "")
+
+    archive_data = io.BytesIO(response.content)
+    with zipfile.ZipFile(archive_data) as archive:
+        names = archive.namelist()
+        assert any(name.endswith("metadata.json") for name in names)
+        assert any(name.endswith(".png") for name in names)
+
+        metadata_name = next(name for name in names if name.endswith("metadata.json"))
+        with archive.open(metadata_name) as meta_file:
+            metadata = meta_file.read().decode("utf-8")
+            assert "Export prompt" in metadata


### PR DESCRIPTION
## Summary
- add generation result REST endpoints for deletion, downloads, and exports
- extend delivery services to clean up assets, build archives, and stream downloads
- expose new request schemas and add API coverage for the generation history client

## Testing
- pytest tests/generation -q

------
https://chatgpt.com/codex/tasks/task_e_68d3169817008329868b9d8c54af31f6