### PR TITLE
Improve queue resiliency, migrations, and history UX

### DIFF
--- a/alembic.ini
+++ b/alembic.ini
@@ -1,0 +1,35 @@
+[alembic]
+script_location = backend/migrations
+sqlalchemy.url = sqlite:///./db.sqlite
+
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+
+[logger_sqlalchemy]
+level = WARN
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)s [%(name)s] %(message)s

--- a/app/frontend/src/services/history/historyService.ts
+++ b/app/frontend/src/services/history/historyService.ts
@@ -50,6 +50,10 @@ export interface ListResultsOutput {
   response: GenerationHistoryListResponse | null;
 }
 
+export interface ListResultsOptions {
+  signal?: AbortSignal;
+}
+
 const toListOutput = (payload: GenerationHistoryListPayload | null): ListResultsOutput => {
   if (!payload) {
     return {
@@ -173,13 +177,14 @@ export const useGenerationHistoryApi = (
 export const listResults = async (
   baseUrl: string,
   query: GenerationHistoryQuery = {},
+  options: ListResultsOptions = {},
 ): Promise<ListResultsOutput> => {
   const base = sanitizeBaseUrl(baseUrl);
   const targetUrl = `${base}/results${buildHistoryQuery(query)}`;
   const api = useApi<GenerationHistoryListPayload>(() => targetUrl, {
     credentials: 'same-origin',
   });
-  const payload = await api.fetchData();
+  const payload = await api.fetchData({ signal: options.signal });
   return toListOutput(payload ?? null);
 };
 

--- a/backend/core/database.py
+++ b/backend/core/database.py
@@ -7,7 +7,7 @@ can override the backend database (sqlite for local runs, Postgres in CI).
 from typing import Optional
 
 from sqlalchemy.pool import NullPool
-from sqlmodel import Session, SQLModel, create_engine
+from sqlmodel import Session, create_engine
 
 from backend.core.config import settings
 
@@ -42,8 +42,10 @@ else:
 
 
 def init_db():
-    """Create database tables from SQLModel metadata."""
-    SQLModel.metadata.create_all(ENGINE)
+    """Ensure database migrations are applied for the configured engine."""
+    from backend.core import migrations as migration_module
+
+    migration_module.run_database_migrations()
 
 
 def get_session():

--- a/backend/core/migrations.py
+++ b/backend/core/migrations.py
@@ -1,0 +1,37 @@
+"""Helpers for running Alembic migrations programmatically."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+from alembic import command
+from alembic.config import Config
+
+
+def _resolve_project_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def _build_config(database_url: Optional[str] = None) -> Config:
+    root = _resolve_project_root()
+    config = Config(str(root / "alembic.ini"))
+    config.set_main_option("script_location", str(root / "backend" / "migrations"))
+
+    if database_url is None:
+        from backend.core.database import ENGINE
+
+        database_url = ENGINE.url.render_as_string(hide_password=False)
+
+    config.set_main_option("sqlalchemy.url", database_url)
+    return config
+
+
+def run_database_migrations(revision: str = "head", *, database_url: Optional[str] = None) -> None:
+    """Upgrade the configured database to ``revision`` (defaults to ``head``)."""
+
+    config = _build_config(database_url)
+    command.upgrade(config, revision)
+
+
+__all__ = ["run_database_migrations"]

--- a/backend/migrations/README
+++ b/backend/migrations/README
@@ -1,0 +1,3 @@
+This directory stores Alembic migration scripts for the backend database schema.
+
+Revisions can be generated with `alembic revision --autogenerate -m "message"`.

--- a/backend/migrations/env.py
+++ b/backend/migrations/env.py
@@ -1,0 +1,73 @@
+"""Alembic environment script configured for SQLModel metadata."""
+
+from __future__ import annotations
+
+from logging.config import fileConfig
+
+from alembic import context
+from sqlalchemy import engine_from_config, pool
+from sqlmodel import SQLModel
+
+from backend.core.config import settings
+from backend.models import Adapter  # noqa: F401  # ensure models are imported
+from backend.models import DeliveryJob  # noqa: F401
+from backend.models import LoRAEmbedding  # noqa: F401
+from backend.models import RecommendationFeedback  # noqa: F401
+from backend.models import RecommendationSession  # noqa: F401
+from backend.models import UserPreference  # noqa: F401
+
+config = context.config
+
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+
+
+def _configure_url() -> None:
+    database_url = settings.DATABASE_URL
+    if not database_url:
+        from backend.core.database import ENGINE
+
+        database_url = ENGINE.url.render_as_string(hide_password=False)
+    config.set_main_option("sqlalchemy.url", database_url)
+
+
+target_metadata = SQLModel.metadata
+
+
+def run_migrations_offline() -> None:
+    """Run migrations in 'offline' mode."""
+
+    _configure_url()
+    url = config.get_main_option("sqlalchemy.url")
+    context.configure(
+        url=url,
+        target_metadata=target_metadata,
+        literal_binds=True,
+        dialect_opts={"paramstyle": "named"},
+    )
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online() -> None:
+    """Run migrations in 'online' mode."""
+
+    _configure_url()
+    connectable = engine_from_config(
+        config.get_section(config.config_ini_section, {}),
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
+
+    with connectable.connect() as connection:
+        context.configure(connection=connection, target_metadata=target_metadata)
+
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/backend/migrations/script.py.mako
+++ b/backend/migrations/script.py.mako
@@ -1,0 +1,20 @@
+"""Generic Alembic revision template."""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = ${repr(revision)}
+down_revision = ${repr(down_revision)}
+branch_labels = ${repr(branch_labels)}
+depends_on = ${repr(depends_on)}
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass

--- a/backend/migrations/versions/0001_initial_schema.py
+++ b/backend/migrations/versions/0001_initial_schema.py
@@ -1,0 +1,168 @@
+"""Initial database schema."""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+from sqlmodel.sql.sqltypes import AutoString
+
+# revision identifiers, used by Alembic.
+revision = "0001_initial_schema"
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "adapter",
+        sa.Column("id", AutoString(), nullable=False),
+        sa.Column("name", AutoString(), nullable=False),
+        sa.Column("version", AutoString(), nullable=True),
+        sa.Column("canonical_version_name", AutoString(), nullable=True),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column("author_username", AutoString(), nullable=True),
+        sa.Column("visibility", AutoString(), nullable=False),
+        sa.Column("published_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("tags", sa.JSON(), nullable=False),
+        sa.Column("trained_words", sa.JSON(), nullable=False),
+        sa.Column("triggers", sa.JSON(), nullable=False),
+        sa.Column("file_path", AutoString(), nullable=False),
+        sa.Column("weight", sa.Float(), nullable=False),
+        sa.Column("active", sa.Boolean(), nullable=False),
+        sa.Column("ordinal", sa.Integer(), nullable=True),
+        sa.Column("archetype", AutoString(), nullable=True),
+        sa.Column("archetype_confidence", sa.Float(), nullable=True),
+        sa.Column("primary_file_name", AutoString(), nullable=True),
+        sa.Column("primary_file_size_kb", sa.Integer(), nullable=True),
+        sa.Column("primary_file_sha256", AutoString(), nullable=True),
+        sa.Column("primary_file_download_url", AutoString(), nullable=True),
+        sa.Column("primary_file_local_path", AutoString(), nullable=True),
+        sa.Column("supports_generation", sa.Boolean(), nullable=False),
+        sa.Column("sd_version", AutoString(), nullable=True),
+        sa.Column("nsfw_level", sa.Integer(), nullable=False),
+        sa.Column("activation_text", sa.Text(), nullable=True),
+        sa.Column("stats", sa.JSON(), nullable=True),
+        sa.Column("extra", sa.JSON(), nullable=True),
+        sa.Column("json_file_path", AutoString(), nullable=True),
+        sa.Column("json_file_mtime", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("json_file_size", sa.Integer(), nullable=True),
+        sa.Column("last_ingested_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "ux_adapter_name_version",
+        "adapter",
+        ["name", "version"],
+        unique=True,
+    )
+    op.create_index("idx_adapter_active", "adapter", ["active"])
+    op.create_index("idx_adapter_json_file_path", "adapter", ["json_file_path"])
+    op.create_index("idx_adapter_created_at", "adapter", ["created_at"])
+    op.create_index("idx_adapter_updated_at", "adapter", ["updated_at"])
+    op.create_index("idx_adapter_last_ingested_at", "adapter", ["last_ingested_at"])
+
+    op.create_table(
+        "deliveryjob",
+        sa.Column("id", AutoString(), nullable=False),
+        sa.Column("prompt", sa.Text(), nullable=False),
+        sa.Column("mode", AutoString(), nullable=False),
+        sa.Column("params", sa.Text(), nullable=True),
+        sa.Column("status", AutoString(), nullable=False),
+        sa.Column("result", sa.Text(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("started_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("finished_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("rating", sa.Integer(), nullable=True),
+        sa.Column("is_favorite", sa.Boolean(), nullable=False),
+        sa.Column("rating_updated_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("favorite_updated_at", sa.DateTime(timezone=True), nullable=True),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+    op.create_table(
+        "recommendationsession",
+        sa.Column("id", AutoString(), nullable=False),
+        sa.Column("context_prompt", sa.Text(), nullable=True),
+        sa.Column("active_loras", sa.JSON(), nullable=False),
+        sa.Column("target_lora_id", AutoString(), nullable=True),
+        sa.Column("recommendation_type", AutoString(), nullable=False),
+        sa.Column("recommendations", sa.JSON(), nullable=False),
+        sa.Column("user_feedback", sa.JSON(), nullable=True),
+        sa.Column("generated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+    op.create_table(
+        "userpreference",
+        sa.Column("id", AutoString(), nullable=False),
+        sa.Column("preference_type", AutoString(), nullable=False),
+        sa.Column("preference_value", AutoString(), nullable=False),
+        sa.Column("confidence", sa.Float(), nullable=False),
+        sa.Column("learned_from", AutoString(), nullable=False),
+        sa.Column("evidence_count", sa.Integer(), nullable=False),
+        sa.Column("last_evidence_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "ix_userpreference_type_value",
+        "userpreference",
+        ["preference_type", "preference_value"],
+    )
+
+    op.create_table(
+        "loraembedding",
+        sa.Column("adapter_id", AutoString(), nullable=False),
+        sa.Column("semantic_embedding", sa.LargeBinary(), nullable=True),
+        sa.Column("artistic_embedding", sa.LargeBinary(), nullable=True),
+        sa.Column("technical_embedding", sa.LargeBinary(), nullable=True),
+        sa.Column("extracted_keywords", sa.JSON(), nullable=False),
+        sa.Column("keyword_scores", sa.JSON(), nullable=False),
+        sa.Column("predicted_style", AutoString(), nullable=True),
+        sa.Column("style_confidence", sa.Float(), nullable=True),
+        sa.Column("sentiment_label", AutoString(), nullable=True),
+        sa.Column("sentiment_score", sa.Float(), nullable=True),
+        sa.Column("quality_score", sa.Float(), nullable=True),
+        sa.Column("popularity_score", sa.Float(), nullable=True),
+        sa.Column("recency_score", sa.Float(), nullable=True),
+        sa.Column("compatibility_score", sa.Float(), nullable=True),
+        sa.Column("last_computed", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(["adapter_id"], ["adapter.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("adapter_id"),
+    )
+
+    op.create_table(
+        "recommendationfeedback",
+        sa.Column("id", AutoString(), nullable=False),
+        sa.Column("session_id", AutoString(), nullable=False),
+        sa.Column("recommended_lora_id", AutoString(), nullable=False),
+        sa.Column("feedback_type", AutoString(), nullable=False),
+        sa.Column("feedback_reason", sa.Text(), nullable=True),
+        sa.Column("implicit_signal", sa.Boolean(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(["recommended_lora_id"], ["adapter.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["session_id"], ["recommendationsession.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("recommendationfeedback")
+    op.drop_table("loraembedding")
+    op.drop_index("ix_userpreference_type_value", table_name="userpreference")
+    op.drop_table("userpreference")
+    op.drop_table("recommendationsession")
+    op.drop_table("deliveryjob")
+    op.drop_index("idx_adapter_last_ingested_at", table_name="adapter")
+    op.drop_index("idx_adapter_updated_at", table_name="adapter")
+    op.drop_index("idx_adapter_created_at", table_name="adapter")
+    op.drop_index("idx_adapter_json_file_path", table_name="adapter")
+    op.drop_index("idx_adapter_active", table_name="adapter")
+    op.drop_index("ux_adapter_name_version", table_name="adapter")
+    op.drop_table("adapter")

--- a/backend/services/service_container_builder.py
+++ b/backend/services/service_container_builder.py
@@ -112,6 +112,20 @@ class ServiceContainerBuilder:
             self._cached_gpu_available = self._recommendation_gpu_detector()
         return self._cached_gpu_available
 
+    def reset_cached_queue_orchestrator(self) -> None:
+        """Drop the cached queue orchestrator so the next build recreates it."""
+        if self._cached_queue_orchestrator is not None:
+            self._cached_queue_orchestrator.reset()
+        self._cached_queue_orchestrator = None
+
+    def invalidate_recommendation_gpu_cache(self) -> None:
+        """Force the next build to recompute the GPU availability flag."""
+        self._cached_gpu_available = None
+
+    def get_recommendation_gpu_available(self) -> bool:
+        """Return the cached recommendation GPU availability flag."""
+        return self._get_gpu_available()
+
     def with_overrides(
         self,
         *,
@@ -168,7 +182,7 @@ class ServiceContainerBuilder:
         gpu_available = (
             recommendation_gpu_available
             if recommendation_gpu_available is not None
-            else self._get_gpu_available()
+            else self.get_recommendation_gpu_available()
         )
 
         if db_session is not None:

--- a/tests/test_queue_configuration.py
+++ b/tests/test_queue_configuration.py
@@ -2,6 +2,11 @@
 
 from __future__ import annotations
 
+import asyncio
+import types
+
+from redis.exceptions import ConnectionError as RedisConnectionError
+
 from backend.core.config import settings
 from backend.services import get_service_container_builder
 from backend.services.analytics_repository import AnalyticsRepository
@@ -88,3 +93,94 @@ def test_queue_factory_shared_backend_without_redis(db_session) -> None:
         if orchestrator is not None:
             orchestrator.reset()
         reset_worker_context()
+
+
+def test_redis_backend_recovers_from_connection_error(monkeypatch) -> None:
+    """RedisQueueBackend should reset its queue when a connection error occurs."""
+
+    backend = RedisQueueBackend("redis://localhost:6379/0")
+    created_queues = []
+
+    class FakeQueue:
+        def __init__(self, idx: int) -> None:
+            self.idx = idx
+            self.enqueued: list[tuple[str, str, dict]] = []
+
+        def enqueue(self, task_name: str, job_id: str, **kwargs):
+            if self.idx == 0:
+                raise RedisConnectionError("redis unavailable")
+            self.enqueued.append((task_name, job_id, kwargs))
+            return {"job_id": job_id}
+
+    def fake_get_queue(self):  # pragma: no cover - exercised in test
+        if self._queue is None:
+            queue = FakeQueue(len(created_queues))
+            created_queues.append(queue)
+            self._queue = queue
+        return self._queue
+
+    monkeypatch.setattr(
+        backend,
+        "_get_queue",
+        types.MethodType(fake_get_queue, backend),
+    )
+
+    result = backend.enqueue_delivery("job-1")
+
+    assert len(created_queues) == 2
+    assert backend._queue is created_queues[1]
+    assert created_queues[1].enqueued[0][1] == "job-1"
+    assert result == {"job_id": "job-1"}
+
+
+def test_background_queue_schedules_coroutine(monkeypatch) -> None:
+    """BackgroundTaskQueueBackend should schedule coroutines on the running loop."""
+
+    scheduled = []
+
+    async def runner(job_id: str):
+        return job_id
+
+    backend = BackgroundTaskQueueBackend(lambda job_id: runner(job_id))
+
+    class DummyLoop:
+        def create_task(self, coro):
+            scheduled.append(coro)
+            return object()
+
+    monkeypatch.setattr(asyncio, "get_running_loop", lambda: DummyLoop())
+
+    backend.enqueue_delivery("job-2")
+
+    assert scheduled
+    assert asyncio.iscoroutine(scheduled[0])
+    scheduled[0].close()
+
+
+def test_background_queue_runs_coroutine_without_loop(monkeypatch) -> None:
+    """BackgroundTaskQueueBackend should fall back to anyio when no loop is active."""
+
+    executed: list[str] = []
+
+    async def runner(job_id: str):
+        executed.append(job_id)
+
+    backend = BackgroundTaskQueueBackend(lambda job_id: runner(job_id))
+
+    def raise_no_loop():
+        raise RuntimeError("no event loop")
+
+    monkeypatch.setattr(asyncio, "get_running_loop", raise_no_loop)
+
+    import anyio
+    from anyio import from_thread
+
+    def fail_portal(*args, **kwargs):
+        raise RuntimeError("no portal")
+
+    monkeypatch.setattr(from_thread, "run", fail_portal)
+    monkeypatch.setattr(anyio, "run", lambda func, coro: asyncio.run(func(coro)))
+
+    backend.enqueue_delivery("job-3")
+
+    assert executed == ["job-3"]

--- a/tests/test_service_container_builder.py
+++ b/tests/test_service_container_builder.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from backend.services.queue import BackgroundTaskQueueBackend, QueueOrchestrator
+from backend.services.service_container_builder import ServiceContainerBuilder
+
+
+def test_service_container_builder_gpu_cache_invalidation() -> None:
+    calls: list[int] = []
+
+    def detector() -> bool:
+        calls.append(len(calls))
+        return len(calls) == 1
+
+    builder = ServiceContainerBuilder(
+        queue_orchestrator_factory=lambda: QueueOrchestrator(
+            fallback_backend=BackgroundTaskQueueBackend(lambda _: None)
+        ),
+        recommendation_gpu_detector=detector,
+    )
+
+    assert builder.get_recommendation_gpu_available() is True
+    assert builder.get_recommendation_gpu_available() is True
+    builder.invalidate_recommendation_gpu_cache()
+    assert builder.get_recommendation_gpu_available() is False
+    assert len(calls) == 2
+
+
+def test_service_container_builder_resets_cached_orchestrator() -> None:
+    class RecordingQueueOrchestrator(QueueOrchestrator):
+        def __init__(self) -> None:
+            super().__init__(fallback_backend=BackgroundTaskQueueBackend(lambda _: None))
+            self.reset_calls = 0
+
+        def reset(self) -> None:
+            self.reset_calls += 1
+            super().reset()
+
+    builder = ServiceContainerBuilder(queue_orchestrator_factory=RecordingQueueOrchestrator)
+
+    first = builder._get_queue_orchestrator()
+    assert isinstance(first, RecordingQueueOrchestrator)
+
+    builder.reset_cached_queue_orchestrator()
+    assert first.reset_calls == 1
+
+    second = builder._get_queue_orchestrator()
+    assert second is not first
+    assert isinstance(second, RecordingQueueOrchestrator)


### PR DESCRIPTION
## Summary
- add reconnection logic to the Redis queue backend, safer BackgroundTask execution, and expose cache invalidation hooks on the service container builder
- introduce Alembic-based migration wiring with an initial schema revision and update database startup to run migrations
- teach the generation history composable and useApi helper to consume backend stats and cancel stale requests while propagating abort signals

## Testing
- pytest
- npm run type-check

------
https://chatgpt.com/codex/tasks/task_e_68d3551ef0808329b3cf4ba94c11899c