### PR TITLE
Require session when building service container

### DIFF
--- a/backend/workers/context.py
+++ b/backend/workers/context.py
@@ -103,14 +103,16 @@ class WorkerContext:
                 return None
         return None
 
-    def create_service_container(self, db_session: Optional[Session]) -> ServiceRegistry:
+    def create_service_container(self, db_session: Session) -> ServiceRegistry:
         """Instantiate a service container sharing this context's dependencies."""
-        delivery_repository = (
-            DeliveryJobRepository(db_session) if db_session is not None else None
-        )
-        analytics_repository = (
-            AnalyticsRepository(db_session) if db_session is not None else None
-        )
+        if db_session is None:  # Defensive guard for callers bypassing type hints
+            raise ValueError(
+                "WorkerContext.create_service_container() requires an active database "
+                "session to construct repositories.",
+            )
+
+        delivery_repository = DeliveryJobRepository(db_session)
+        analytics_repository = AnalyticsRepository(db_session)
 
         builder = get_service_container_builder()
         return builder.build(

--- a/tests/test_service_container_builder.py
+++ b/tests/test_service_container_builder.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import pytest
+
 from backend.services.queue import BackgroundTaskQueueBackend, QueueOrchestrator
 from backend.services.service_container_builder import ServiceContainerBuilder
 
@@ -46,3 +48,10 @@ def test_service_container_builder_resets_cached_orchestrator() -> None:
     second = builder._get_queue_orchestrator()
     assert second is not first
     assert isinstance(second, RecordingQueueOrchestrator)
+
+
+def test_service_container_builder_rejects_missing_session() -> None:
+    builder = ServiceContainerBuilder()
+
+    with pytest.raises(ValueError, match="requires an active database session"):
+        builder.build(None)  # type: ignore[arg-type]


### PR DESCRIPTION
## Summary
- enforce a real sqlmodel.Session when building the service container and validate repository factories
- make the worker context reject missing sessions while wiring repositories eagerly
- add a regression test covering the new failure mode for missing sessions

## Testing
- pytest tests/test_service_container_builder.py

------
https://chatgpt.com/codex/tasks/task_e_68d365834ebc83299a7b69d9a2e161dc