### PR TITLE
Fix history date helper rounding and add tests

### DIFF
--- a/app/frontend/src/components/history/GenerationHistoryContainer.vue
+++ b/app/frontend/src/components/history/GenerationHistoryContainer.vue
@@ -129,6 +129,7 @@ import {
   type HistoryToastType,
 } from '@/composables/history';
 import { useBackendBase } from '@/utils/backend';
+import { formatHistoryDate } from '@/utils/format';
 import type { GenerationHistoryResult } from '@/types';
 
 import type { HistoryViewMode } from './HistoryActionToolbar.vue';
@@ -219,28 +220,7 @@ const loadMore = async (): Promise<void> => {
   await loadMoreResults();
 };
 
-const formatDate = (dateString: string): string => {
-  const date = new Date(dateString);
-  if (!Number.isFinite(date.getTime())) {
-    return '';
-  }
-
-  const now = new Date();
-  const diffTime = Math.abs(now.getTime() - date.getTime());
-  const diffDays = Math.ceil(diffTime / (1000 * 60 * 60 * 24));
-
-  if (diffDays === 1) {
-    return 'Today';
-  }
-  if (diffDays === 2) {
-    return 'Yesterday';
-  }
-  if (diffDays <= 7) {
-    return `${diffDays - 1} days ago`;
-  }
-
-  return date.toLocaleDateString();
-};
+const formatDate = (dateString: string): string => formatHistoryDate(dateString);
 
 const onSelectionChange = (payload: HistorySelectionChangePayload): void => {
   updateSelection(payload);

--- a/app/frontend/src/utils/format.ts
+++ b/app/frontend/src/utils/format.ts
@@ -166,6 +166,35 @@ export function formatRelativeTime(input: DateInput, base: DateInput = new Date(
 }
 
 /**
+ * Format a generation history timestamp into a human-readable label.
+ */
+export function formatHistoryDate(input: DateInput, base: DateInput = new Date()): string {
+  const targetDate = toDate(input);
+  const baseDate = toDate(base) ?? new Date();
+
+  if (!targetDate) {
+    return '';
+  }
+
+  const diff = Math.abs(baseDate.getTime() - targetDate.getTime());
+  const diffDays = Math.floor(diff / (1000 * 60 * 60 * 24));
+
+  if (diffDays === 0) {
+    return 'Today';
+  }
+
+  if (diffDays === 1) {
+    return 'Yesterday';
+  }
+
+  if (diffDays <= 7) {
+    return `${diffDays} days ago`;
+  }
+
+  return targetDate.toLocaleDateString();
+}
+
+/**
  * Format a number using Intl.NumberFormat.
  */
 export function formatNumber(value: number, locale = 'en-US', options?: Intl.NumberFormatOptions): string {

--- a/tests/vue/HistoryDateFormatting.spec.ts
+++ b/tests/vue/HistoryDateFormatting.spec.ts
@@ -1,0 +1,110 @@
+import { mount } from '@vue/test-utils';
+import { describe, expect, it, vi } from 'vitest';
+
+import HistoryGridItem from '../../app/frontend/src/components/history/HistoryGridItem.vue';
+import HistoryListItem from '../../app/frontend/src/components/history/HistoryListItem.vue';
+import HistoryModalLauncher from '../../app/frontend/src/components/history/HistoryModalLauncher.vue';
+import { formatHistoryDate } from '../../app/frontend/src/utils/format';
+import type { GenerationHistoryResult } from '../../app/frontend/src/types';
+
+describe('formatHistoryDate', () => {
+  const baseDate = new Date('2024-05-10T12:00:00Z');
+
+  it('returns "Today" for dates on the same day', () => {
+    expect(formatHistoryDate('2024-05-10T00:00:00Z', baseDate)).toBe('Today');
+  });
+
+  it('returns "Today" for dates within the last 24 hours', () => {
+    expect(formatHistoryDate('2024-05-09T12:01:00Z', baseDate)).toBe('Today');
+  });
+
+  it('returns "Yesterday" for dates at least one day old but less than two days', () => {
+    expect(formatHistoryDate('2024-05-09T11:59:00Z', baseDate)).toBe('Yesterday');
+  });
+
+  it('returns relative copy for multi-day ranges within a week', () => {
+    expect(formatHistoryDate('2024-05-08T12:00:00Z', baseDate)).toBe('2 days ago');
+    expect(formatHistoryDate('2024-05-03T12:00:00Z', baseDate)).toBe('7 days ago');
+  });
+
+  it('falls back to locale date strings beyond one week', () => {
+    const expected = new Date('2024-05-02T12:00:00Z').toLocaleDateString();
+    expect(formatHistoryDate('2024-05-02T12:00:00Z', baseDate)).toBe(expected);
+  });
+
+  it('returns an empty string for invalid input', () => {
+    expect(formatHistoryDate('invalid-date', baseDate)).toBe('');
+  });
+});
+
+describe('History components consuming formatted history dates', () => {
+  const createResult = (overrides: Partial<GenerationHistoryResult> = {}): GenerationHistoryResult => ({
+    id: 1,
+    prompt: 'Prompt',
+    negative_prompt: null,
+    image_url: 'https://example.com/image.png',
+    thumbnail_url: 'https://example.com/thumb.png',
+    created_at: '2024-05-10T12:00:00Z',
+    width: 512,
+    height: 512,
+    steps: 20,
+    cfg_scale: 7,
+    rating: 0,
+    is_favorite: false,
+    ...overrides,
+  });
+
+  const referenceDate = new Date('2024-05-12T12:00:00Z');
+
+  it('displays the formatted label in HistoryGridItem', () => {
+    const result = createResult();
+    const formatted = formatHistoryDate(result.created_at, referenceDate);
+    const wrapper = mount(HistoryGridItem, {
+      props: {
+        result,
+        isSelected: false,
+        formattedDate: formatted,
+      },
+    });
+
+    expect(wrapper.text()).toContain(formatted);
+  });
+
+  it('displays the formatted label in HistoryListItem', () => {
+    const result = createResult();
+    const formatted = formatHistoryDate(result.created_at, referenceDate);
+    const wrapper = mount(HistoryListItem, {
+      props: {
+        result,
+        isSelected: false,
+        formattedDate: formatted,
+      },
+    });
+
+    expect(wrapper.text()).toContain(formatted);
+  });
+
+  it('passes the formatted label through HistoryModalLauncher', () => {
+    const result = createResult();
+    const formatted = formatHistoryDate(result.created_at, referenceDate);
+    const formatDateMock = vi.fn().mockReturnValue(formatted);
+    const wrapper = mount(HistoryModalLauncher, {
+      props: {
+        visible: true,
+        result,
+        formatDate: formatDateMock,
+      },
+      global: {
+        stubs: {
+          HistoryModal: {
+            props: ['visible', 'result', 'formattedDate'],
+            template: '<div data-test="modal">{{ formattedDate }}</div>',
+          },
+        },
+      },
+    });
+
+    expect(formatDateMock).toHaveBeenCalledWith(result.created_at);
+    expect(wrapper.find('[data-test="modal"]').text()).toBe(formatted);
+  });
+});


### PR DESCRIPTION
## Summary
- replace the custom relative date logic in `GenerationHistoryContainer` with the shared `formatHistoryDate` helper that uses floor-based day calculations
- add a `formatHistoryDate` formatter to `utils/format.ts` so other components can reuse the corrected behaviour
- cover the boundary conditions and consumer components with new Vitest specs to confirm copy such as "Today", "Yesterday", and "7 days ago"

## Testing
- npm run test:unit *(fails: suite has numerous pre-existing missing import and mock errors outside this change)*
- npx vitest run tests/vue/HistoryDateFormatting.spec.ts


------
https://chatgpt.com/codex/tasks/task_e_68d36e28a44c8329b0d654d413d58974