### PR TITLE
Remove legacy frontend helpers and tighten docstring linting

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -11,7 +11,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
 
 from backend.core.config import settings as backend_settings
-from backend.main import app as backend_app
+from backend.main import create_app as create_backend_app
 
 app = FastAPI(
     title="LoRA Manager",
@@ -22,7 +22,6 @@ app = FastAPI(
 
 def _build_cors_config() -> Dict[str, Any]:
     """Construct the CORS options from the backend settings."""
-
     allow_origins = list(backend_settings.CORS_ORIGINS)
     allow_credentials = backend_settings.CORS_ALLOW_CREDENTIALS
     if "*" in allow_origins:
@@ -38,7 +37,6 @@ def _build_cors_config() -> Dict[str, Any]:
 
 def _normalise_public_api_url(raw_url: str | None) -> str:
     """Normalise the backend URL exposed to the SPA settings endpoint."""
-
     if raw_url is None:
         return "/api/v1"
 
@@ -65,6 +63,7 @@ app.add_middleware(
 )
 
 # Include backend API routes
+backend_app = create_backend_app()
 app.mount("/api", backend_app)
 
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -177,5 +177,9 @@ def create_app() -> FastAPI:
     return app
 
 
-# Create the app instance for backward compatibility
-app = create_app()
+def app() -> FastAPI:
+    """Return a FastAPI application for ASGI factory loaders."""
+    return create_app()
+
+
+__all__ = ["create_app", "lifespan", "app"]

--- a/backend/services/analytics/insights.py
+++ b/backend/services/analytics/insights.py
@@ -21,6 +21,7 @@ class InsightGenerator:
         errors: List[ErrorAnalysisEntry],
         charts: PerformanceAnalyticsCharts,
     ) -> List[PerformanceInsightEntry]:
+        """Return narrative insights derived from analytics data."""
         del charts  # Currently unused but reserved for future heuristics
 
         insights: List[PerformanceInsightEntry] = []

--- a/backend/services/analytics/service.py
+++ b/backend/services/analytics/service.py
@@ -43,6 +43,7 @@ class AnalyticsService:
         time_series_builder: TimeSeriesBuilder | None = None,
         insight_generator: InsightGenerator | None = None,
     ) -> None:
+        """Initialise analytics helpers with optional overrides."""
         self.db_session = db_session
         self.repository = repository or AnalyticsRepository(db_session)
         self.time_series_builder = time_series_builder or TimeSeriesBuilder()

--- a/backend/services/analytics/time_series.py
+++ b/backend/services/analytics/time_series.py
@@ -29,6 +29,7 @@ class TimeSeriesBuilder:
         time_range: PerformanceTimeRange,
         default_timestamp: datetime,
     ) -> PerformanceAnalyticsCharts:
+        """Transform database rows into time-series metrics for charts."""
         bucket_stats: MutableMapping[datetime, Dict[str, float]] = defaultdict(
             lambda: {"count": 0, "succeeded": 0, "failed": 0},
         )

--- a/backend/services/analytics_repository.py
+++ b/backend/services/analytics_repository.py
@@ -22,6 +22,7 @@ class AnalyticsRepository:
     """Encapsulate SQLModel interactions for analytics computations."""
 
     def __init__(self, session: Session) -> None:
+        """Store the session used for analytics queries."""
         self._session = session
 
     # ------------------------------------------------------------------

--- a/backend/services/archive/backup_service.py
+++ b/backend/services/archive/backup_service.py
@@ -27,6 +27,7 @@ class BackupService:
         *,
         base_directory: Optional[Path | str] = None,
     ) -> None:
+        """Initialise backup storage paths and dependencies."""
         self._archive_service = archive_service
         root = Path(base_directory or settings.IMPORT_PATH or (Path.cwd() / "loras"))
         self._backups_dir = root / "backups"

--- a/backend/services/archive/executor.py
+++ b/backend/services/archive/executor.py
@@ -45,6 +45,7 @@ class ArchiveImportExecutor:
         *,
         chunk_size: int = 64 * 1024,
     ) -> None:
+        """Initialise executor with adapter service and chunk size."""
         self._adapter_service = adapter_service
         self._chunk_size = chunk_size
 

--- a/backend/services/archive/facade.py
+++ b/backend/services/archive/facade.py
@@ -38,6 +38,7 @@ class ArchiveService:
         chunk_size: int = 64 * 1024,
         spooled_file_max_size: int = 32 * 1024 * 1024,
     ) -> None:
+        """Initialise archive planners and executors with optional overrides."""
         self._adapter_service = adapter_service
         self._chunk_size = chunk_size
         self._spooled_file_max_size = spooled_file_max_size

--- a/backend/services/archive/planner.py
+++ b/backend/services/archive/planner.py
@@ -70,6 +70,7 @@ class ArchiveExportPlanner:
         *,
         throughput_bytes_per_sec: int = 10 * 1024 * 1024,
     ) -> None:
+        """Configure planner dependencies and throughput assumptions."""
         self._adapter_service = adapter_service
         self._storage = storage_service
         self._throughput_bytes_per_sec = throughput_bytes_per_sec

--- a/backend/services/core_container.py
+++ b/backend/services/core_container.py
@@ -1,3 +1,5 @@
+"""Core service registry wiring for backend dependencies."""
+
 from __future__ import annotations
 
 from typing import Optional
@@ -21,6 +23,7 @@ class CoreServiceRegistry:
         delivery_repository: Optional[DeliveryJobRepository] = None,
         analytics_repository: Optional[AnalyticsRepository] = None,
     ) -> None:
+        """Store shared service factories and repositories."""
         self.db_session = db_session
         self._storage_provider = storage_provider
         self._storage_service: Optional[StorageService] = None

--- a/backend/services/deliveries.py
+++ b/backend/services/deliveries.py
@@ -27,20 +27,24 @@ class DeliveryService:
         *,
         result_manager: Optional[DeliveryResultManager] = None,
     ) -> None:
+        """Initialise delivery dependencies and optional orchestrator."""
         self._repository = repository
         self._queue_orchestrator = queue_orchestrator
         self._result_manager = result_manager or DeliveryResultManager(repository)
 
     @property
     def repository(self) -> DeliveryJobRepository:
+        """Return the repository handling delivery persistence."""
         return self._repository
 
     @property
     def queue_orchestrator(self) -> Optional["QueueOrchestrator"]:
+        """Return the configured queue orchestrator, if any."""
         return self._queue_orchestrator
 
     @property
     def result_manager(self) -> DeliveryResultManager:
+        """Return the delivery result manager."""
         return self._result_manager
 
     @property

--- a/backend/services/delivery_results/archive_builder.py
+++ b/backend/services/delivery_results/archive_builder.py
@@ -27,6 +27,7 @@ class ResultArchiveBuilder:
         repository: DeliveryJobRepository,
         asset_resolver: ResultAssetResolver,
     ) -> None:
+        """Initialise the builder with persistence and asset resolvers."""
         self._repository = repository
         self._assets = asset_resolver
 

--- a/backend/services/delivery_results/asset_resolver.py
+++ b/backend/services/delivery_results/asset_resolver.py
@@ -21,6 +21,7 @@ class ResultAssetResolver:
     """Discover and delete persisted result assets."""
 
     def __init__(self, repository: DeliveryJobRepository) -> None:
+        """Initialise resolver with the delivery repository."""
         self._repository = repository
 
     # ------------------------------------------------------------------

--- a/backend/services/delivery_results/download_builder.py
+++ b/backend/services/delivery_results/download_builder.py
@@ -19,6 +19,7 @@ class ResultDownloadBuilder:
     """Prepare download metadata for a result's primary asset."""
 
     def __init__(self, asset_resolver: ResultAssetResolver) -> None:
+        """Initialise the builder with an asset resolver."""
         self._assets = asset_resolver
 
     def build(

--- a/backend/services/delivery_results/manager.py
+++ b/backend/services/delivery_results/manager.py
@@ -28,6 +28,7 @@ class DeliveryResultManager:
         archive_builder: Optional[ResultArchiveBuilder] = None,
         download_builder: Optional[ResultDownloadBuilder] = None,
     ) -> None:
+        """Compose helper utilities used to manage delivery results."""
         self._repository = repository
         self._assets = asset_resolver or ResultAssetResolver(repository)
         self._archive_builder = archive_builder or ResultArchiveBuilder(

--- a/backend/services/domain_container.py
+++ b/backend/services/domain_container.py
@@ -1,3 +1,5 @@
+"""Domain service registry composition helpers."""
+
 from __future__ import annotations
 
 from typing import Optional
@@ -43,6 +45,7 @@ class DomainServiceRegistry:
         ),
         recommendation_gpu_available: Optional[bool] = None,
     ) -> None:
+        """Initialise factories for domain-level service construction."""
         self._core = core
         self.db_session = db_session
         self._analytics_repository = analytics_repository

--- a/backend/services/generation/__init__.py
+++ b/backend/services/generation/__init__.py
@@ -185,6 +185,7 @@ class GenerationCoordinator:
         websocket: WebSocketService,
         generation_service: GenerationService,
     ) -> None:
+        """Store dependencies used to orchestrate generation jobs."""
         self._deliveries = deliveries
         self._websocket = websocket
         self._generation_service = generation_service

--- a/backend/services/infra_container.py
+++ b/backend/services/infra_container.py
@@ -1,3 +1,5 @@
+"""Infrastructure service registry assembly utilities."""
+
 from __future__ import annotations
 
 from typing import Optional
@@ -40,6 +42,7 @@ class InfrastructureServiceRegistry:
         websocket_provider: Optional[WebSocketServiceFactory] = None,
         system_provider: SystemServiceFactory = make_system_service,
     ) -> None:
+        """Prepare infrastructure service factories and optional overrides."""
         self._core = core
         self._domain = domain
         self._queue_orchestrator = queue_orchestrator

--- a/backend/services/queue.py
+++ b/backend/services/queue.py
@@ -139,6 +139,7 @@ class RedisQueueBackend(QueueBackend):
         background_tasks: Optional[BackgroundTasks] = None,
         **enqueue_kwargs: Any,
     ) -> Any:
+        """Enqueue ``job_id`` on the configured Redis queue."""
         queue = self._get_queue()
         try:
             return queue.enqueue(self.task_name, job_id, **enqueue_kwargs)
@@ -194,6 +195,7 @@ class BackgroundTaskQueueBackend(QueueBackend):
         background_tasks: Optional[BackgroundTasks] = None,
         **enqueue_kwargs: Any,
     ) -> None:
+        """Schedule ``job_id`` for in-process execution."""
         if background_tasks is not None:
             background_tasks.add_task(self._execute, job_id)
         else:
@@ -211,6 +213,7 @@ class QueueOrchestrator:
         redis_url_factory: Callable[[], Optional[str]] = lambda: settings.REDIS_URL,
         delivery_runner_factory: Optional[Callable[[], DeliveryRunner]] = None,
     ) -> None:
+        """Initialise the orchestrator with optional backends and factories."""
         self._initial_primary = primary_backend
         self._initial_fallback = fallback_backend
         self._primary_backend = primary_backend
@@ -320,7 +323,7 @@ def create_queue_orchestrator(
     redis_url_factory: Callable[[], Optional[str]] = lambda: settings.REDIS_URL,
     delivery_runner_factory: Optional[Callable[[], DeliveryRunner]] = None,
 ) -> QueueOrchestrator:
-    """Factory helper that builds the default :class:`QueueOrchestrator`."""
+    """Build the default :class:`QueueOrchestrator`."""
     return QueueOrchestrator(
         redis_url_factory=redis_url_factory,
         delivery_runner_factory=delivery_runner_factory,

--- a/backend/services/recommendations/builder.py
+++ b/backend/services/recommendations/builder.py
@@ -17,6 +17,7 @@ class RecommendationServiceBuilder:
     """Fluent builder for :class:`RecommendationService`."""
 
     def __init__(self) -> None:
+        """Initialise builder defaults for optional collaborators."""
         self._embedding_coordinator: Optional[EmbeddingCoordinator] = None
         self._feedback_manager: Optional[FeedbackManager] = None
         self._stats_reporter: Optional[StatsReporter] = None

--- a/backend/services/recommendations/components/engine.py
+++ b/backend/services/recommendations/components/engine.py
@@ -305,6 +305,7 @@ class LoRARecommendationEngine(RecommendationEngineProtocol):
             return 0.0
 
     def update_index_incremental(self, new_loras: Sequence[Any]) -> None:
+        """Append ``new_loras`` to the in-memory similarity index."""
         if not new_loras:
             return
 

--- a/backend/services/recommendations/components/scoring.py
+++ b/backend/services/recommendations/components/scoring.py
@@ -32,9 +32,11 @@ class ScoreCalculator(ScoreCalculatorProtocol):
     ]
 
     def __init__(self, *, logger: logging.Logger | None = None) -> None:
+        """Initialise the score calculator with an optional logger."""
         self._logger = logger or logging.getLogger(__name__)
 
     def compute(self, lora: Any) -> Dict[str, Any]:
+        """Calculate heuristic scoring data for ``lora``."""
         stats = getattr(lora, "stats", None)
         tags = getattr(lora, "tags", None)
         sd_version = getattr(lora, "sd_version", None)

--- a/backend/services/recommendations/components/sentence_transformer_provider.py
+++ b/backend/services/recommendations/components/sentence_transformer_provider.py
@@ -67,6 +67,7 @@ class SentenceTransformerProvider:
         force_fallback: bool = False,
         model_configs: Optional[Mapping[str, Mapping[str, Any]]] = None,
     ) -> None:
+        """Initialise model configuration and optional fallbacks."""
         self._logger = logger or logging.getLogger(__name__)
         self._preferred_device = device
 
@@ -99,6 +100,7 @@ class SentenceTransformerProvider:
     # ------------------------------------------------------------------
     @property
     def transformers_available(self) -> bool:
+        """Return whether optional transformer dependencies are present."""
         return self._transformers_available
 
     def get_model(self, model_key: str) -> Any:

--- a/backend/services/recommendations/components/sentiment_style.py
+++ b/backend/services/recommendations/components/sentiment_style.py
@@ -39,12 +39,14 @@ class SentimentStyleAnalyzer(SentimentStyleAnalyzerProtocol):
     def __init__(
         self, *, device: str = "cuda", logger: logging.Logger | None = None
     ) -> None:
+        """Initialise the analyser with device preference and logging."""
         self._device = device
         self._logger = logger or logging.getLogger(__name__)
         self._sentiment_pipeline: Any | None = None
         self._style_pipeline: Any | None = None
 
     def analyze_sentiment(self, text: str) -> Dict[str, Any]:
+        """Analyse ``text`` and return sentiment metadata."""
         if not text:
             return {"sentiment_label": "NEUTRAL", "sentiment_score": 0.5}
 
@@ -65,6 +67,7 @@ class SentimentStyleAnalyzer(SentimentStyleAnalyzerProtocol):
             return self._fallback_sentiment(text)
 
     def classify_style(self, text: str) -> Dict[str, Any]:
+        """Classify ``text`` into coarse style categories."""
         if not text:
             return {"predicted_style": "unknown", "style_confidence": 0.0}
 

--- a/backend/services/recommendations/components/text_features.py
+++ b/backend/services/recommendations/components/text_features.py
@@ -20,6 +20,7 @@ class KeywordExtractor(KeywordExtractorProtocol):
     """Keyword extractor that prefers KeyBERT but falls back to heuristics."""
 
     def __init__(self, *, logger: logging.Logger | None = None) -> None:
+        """Initialise the extractor with an optional logger."""
         self._logger = logger or logging.getLogger(__name__)
         self._model: Any | None = None
 

--- a/backend/services/recommendations/config.py
+++ b/backend/services/recommendations/config.py
@@ -9,6 +9,7 @@ class RecommendationConfig:
     """Expose tunable persistence paths for recommendations."""
 
     def __init__(self, persistence: RecommendationPersistenceService) -> None:
+        """Store the persistence service used to resolve paths."""
         self._persistence = persistence
 
     @property

--- a/backend/services/recommendations/embedding_batch_runner.py
+++ b/backend/services/recommendations/embedding_batch_runner.py
@@ -18,6 +18,7 @@ class EmbeddingBatchRunner:
         repository: LoRAEmbeddingRepository,
         computer: EmbeddingComputer,
     ) -> None:
+        """Initialise the batch runner with persistence and compute helpers."""
         self._repository = repository
         self._computer = computer
 

--- a/backend/services/recommendations/embedding_computer.py
+++ b/backend/services/recommendations/embedding_computer.py
@@ -17,6 +17,7 @@ class EmbeddingComputer:
         repository: LoRAEmbeddingRepository,
         feature_extractor_getter: Callable[[], FeatureExtractorProtocol],
     ) -> None:
+        """Initialise the computer with persistence and feature extractors."""
         self._repository = repository
         self._feature_extractor_getter = feature_extractor_getter
 

--- a/backend/services/recommendations/model_registry.py
+++ b/backend/services/recommendations/model_registry.py
@@ -35,6 +35,7 @@ class RecommendationModelRegistry:
         gpu_enabled: bool = False,
         logger: Optional[logging.Logger] = None,
     ) -> None:
+        """Initialise registry state for the requested device."""
         self.device = device
         self.gpu_enabled = gpu_enabled
         self._logger = logger or logging.getLogger(__name__)

--- a/backend/services/recommendations/persistence_manager.py
+++ b/backend/services/recommendations/persistence_manager.py
@@ -28,6 +28,7 @@ class RecommendationPersistenceManager:
         index_cache_path: str | Path = "cache/similarity_index.pkl",
         clock: Callable[[], float] = time.time,
     ) -> None:
+        """Initialise cache paths and collaborators for persistence."""
         self._embedding_manager = embedding_manager
         self._engine_getter = engine_getter
         self._embedding_cache_dir = Path(embedding_cache_dir)

--- a/backend/services/recommendations/persistence_service.py
+++ b/backend/services/recommendations/persistence_service.py
@@ -14,6 +14,7 @@ class RecommendationPersistenceService(PersistenceServiceProtocol):
     """Adapter around ``RecommendationPersistenceManager`` with friendly APIs."""
 
     def __init__(self, manager: RecommendationPersistenceManager) -> None:
+        """Store the low-level persistence manager."""
         self._manager = manager
 
     async def rebuild_similarity_index(

--- a/backend/services/recommendations/repository.py
+++ b/backend/services/recommendations/repository.py
@@ -23,6 +23,7 @@ class RecommendationRepository:
     """Encapsulate persistence concerns for recommendations."""
 
     def __init__(self, session: Session):
+        """Store the database session used for recommendation persistence."""
         self._session = session
 
     # ------------------------------------------------------------------

--- a/backend/services/recommendations/service.py
+++ b/backend/services/recommendations/service.py
@@ -36,6 +36,7 @@ class RecommendationService:
         config: RecommendationConfig,
         logger: Optional[logging.Logger] = None,
     ) -> None:
+        """Initialise the service facade with its core collaborators."""
         self._logger = logger or logging.getLogger(__name__)
 
         self._embedding_coordinator = embedding_coordinator

--- a/backend/services/recommendations/similarity_index_builder.py
+++ b/backend/services/recommendations/similarity_index_builder.py
@@ -17,6 +17,7 @@ class SimilarityIndexBuilder:
         repository: LoRAEmbeddingRepository,
         engine_getter: Callable[[], RecommendationEngineProtocol],
     ) -> None:
+        """Store repository and callback used to obtain the engine."""
         self._repository = repository
         self._engine_getter = engine_getter
 

--- a/backend/services/recommendations/stats_reporter.py
+++ b/backend/services/recommendations/stats_reporter.py
@@ -16,6 +16,7 @@ class StatsReporter:
         metrics_tracker: RecommendationMetricsTracker,
         repository: RecommendationRepository,
     ) -> None:
+        """Persist metrics and repository collaborators."""
         self._metrics_tracker = metrics_tracker
         self._repository = repository
 

--- a/backend/services/recommendations/use_cases.py
+++ b/backend/services/recommendations/use_cases.py
@@ -32,6 +32,7 @@ class SimilarLoraUseCase:
         engine_provider: Callable[[], Any],
         metrics: RecommendationMetricsTracker,
     ) -> None:
+        """Store collaborators used to resolve similarity queries."""
         self._repository = repository
         self._embedding_workflow = embedding_workflow
         self._engine_provider = engine_provider
@@ -76,6 +77,7 @@ class PromptRecommendationUseCase:
         metrics: RecommendationMetricsTracker,
         device: str,
     ) -> None:
+        """Persist dependencies required to generate prompt recommendations."""
         self._repository = repository
         self._embedder_provider = embedder_provider
         self._metrics = metrics

--- a/backend/services/service_container_builder.py
+++ b/backend/services/service_container_builder.py
@@ -1,3 +1,5 @@
+"""Builder for composing core, domain, and infrastructure service registries."""
+
 from __future__ import annotations
 
 from dataclasses import dataclass, replace
@@ -94,6 +96,7 @@ class ServiceContainerBuilder:
             [], bool
         ] = RecommendationService.is_gpu_available,
     ) -> None:
+        """Capture override factories and lazily constructed dependencies."""
         if websocket_factory is not None:
             infrastructure_factories = replace(
                 infrastructure_factories or InfrastructureFactories(),

--- a/backend/services/service_registry.py
+++ b/backend/services/service_registry.py
@@ -1,3 +1,5 @@
+"""Facade exposing composed service registries to the application layer."""
+
 from __future__ import annotations
 
 from dataclasses import dataclass
@@ -38,22 +40,27 @@ class DomainServices:
 
     @property
     def adapters(self) -> AdapterService:
+        """Return the adapter service facade."""
         return self._registry.adapters
 
     @property
     def compose(self) -> ComposeService:
+        """Return the composition service facade."""
         return self._registry.compose
 
     @property
     def generation(self) -> GenerationService:
+        """Return the generation service facade."""
         return self._registry.generation
 
     @property
     def analytics(self) -> AnalyticsService:
+        """Return the analytics service facade."""
         return self._registry.analytics
 
     @property
     def recommendations(self) -> RecommendationService:
+        """Return the recommendation service facade."""
         return self._registry.recommendations
 
 
@@ -66,28 +73,34 @@ class ApplicationServices:
 
     @property
     def archive(self) -> ArchiveService:
+        """Return the archive service used for import/export."""
         return self._registry.archive
 
     @property
     def backups(self) -> BackupService:
+        """Return the backup service responsible for history metadata."""
         return self._registry.backups
 
     @property
     def deliveries(self) -> DeliveryService:
+        """Return the delivery service facade."""
         return self._registry.deliveries
 
     @property
     def generation_coordinator(self) -> GenerationCoordinator:
+        """Return the generation coordinator, honoring overrides."""
         if self._generation_coordinator_override is not None:
             return self._generation_coordinator_override
         return self._registry.generation_coordinator
 
     @property
     def websocket(self) -> WebSocketService:
+        """Return the WebSocket service facade."""
         return self._registry.websocket
 
     @property
     def system(self) -> SystemService:
+        """Return the system status service facade."""
         return self._registry.system
 
 
@@ -100,6 +113,7 @@ class ServiceRegistry:
         domain: DomainServiceRegistry,
         infrastructure: InfrastructureServiceRegistry,
     ) -> None:
+        """Store component registries and initialise service facades."""
         self._core_registry = core
         self._domain_registry = domain
         self._infrastructure_registry = infrastructure
@@ -124,61 +138,68 @@ class ServiceRegistry:
         return self._application_services
 
     @property
-    def infrastructure(self) -> ApplicationServices:
-        """Backward compatible alias for application services."""
-        return self._application_services
-
-    @property
     def db_session(self):
         """Expose the database session associated with the registries."""
         return self._core_registry.db_session
 
     @property
     def storage(self) -> StorageService:
+        """Return the storage service provided by the core registry."""
         return self.core.storage
 
     @property
     def adapters(self) -> AdapterService:
+        """Return the adapter service facade."""
         return self.domain.adapters
 
     @property
     def archive(self) -> ArchiveService:
+        """Return the archive service used for import/export."""
         return self.application.archive
 
     @property
     def backups(self) -> BackupService:
+        """Return the backup service facade."""
         return self.application.backups
 
     @property
     def deliveries(self) -> DeliveryService:
+        """Return the delivery service facade."""
         return self.application.deliveries
 
     @property
     def compose(self) -> ComposeService:
+        """Return the compose service facade."""
         return self.domain.compose
 
     @property
     def generation(self) -> GenerationService:
+        """Return the generation service facade."""
         return self.domain.generation
 
     @property
     def generation_coordinator(self) -> GenerationCoordinator:
+        """Return the generation coordinator facade."""
         return self.application.generation_coordinator
 
     @property
     def websocket(self) -> WebSocketService:
+        """Return the WebSocket service facade."""
         return self.application.websocket
 
     @property
     def system(self) -> SystemService:
+        """Return the system service facade."""
         return self.application.system
 
     @property
     def analytics(self) -> AnalyticsService:
+        """Return the analytics service facade."""
         return self.domain.analytics
 
     @property
     def recommendations(self) -> RecommendationService:
+        """Return the recommendation service facade."""
         return self.domain.recommendations
 
 

--- a/backend/services/system.py
+++ b/backend/services/system.py
@@ -117,6 +117,7 @@ class SystemHealthSummary:
     storage_usage: str
 
     def as_dict(self) -> Dict[str, str]:
+        """Return the summary as a serializable dictionary."""
         return {
             "status": self.status,
             "gpu_status": self.gpu_status,
@@ -130,6 +131,7 @@ class SystemService:
     """Service that aggregates system health metrics."""
 
     def __init__(self, delivery_service: "DeliveryService") -> None:
+        """Store the delivery service used to query queue statistics."""
         self._delivery_service = delivery_service
 
     def _get_storage_usage_fallback(self) -> str:

--- a/backend/services/websocket/connection_manager.py
+++ b/backend/services/websocket/connection_manager.py
@@ -31,6 +31,7 @@ class ConnectionManager:
     """Manage WebSocket connections and subscription routing."""
 
     def __init__(self) -> None:
+        """Initialise connection registries."""
         self.active_connections: Dict[str, WebSocket] = {}
         self.job_subscriptions: Dict[str, Set[str]] = {}
         self.connection_subscriptions: Dict[str, Set[str]] = {}

--- a/backend/services/websocket/job_monitor.py
+++ b/backend/services/websocket/job_monitor.py
@@ -37,7 +37,9 @@ class PersistedJobState:
 class JobStateRepository(Protocol):
     """Protocol for loading persisted job state."""
 
-    def get_job_state(self, job_id: str) -> Optional[PersistedJobState]: ...
+    def get_job_state(self, job_id: str) -> Optional[PersistedJobState]:
+        """Return persisted state for ``job_id`` if available."""
+        ...
 
 
 ProgressCallback = Callable[[ProgressUpdate], Awaitable[None]]
@@ -53,6 +55,7 @@ class JobProgressMonitor:
         repository: Optional[JobStateRepository] = None,
         poll_interval: float = 2.0,
     ) -> None:
+        """Configure the repository and polling interval."""
         self._repository = repository
         self._poll_interval = poll_interval
         self._tasks: Dict[str, asyncio.Task[None]] = {}

--- a/backend/services/websocket/persistence.py
+++ b/backend/services/websocket/persistence.py
@@ -26,9 +26,11 @@ class DeliveryJobStateRepository(JobStateRepository):
             [], AbstractContextManager[Session]
         ] = get_session_context,
     ) -> None:
+        """Store the session factory used to access delivery data."""
         self._session_factory = session_factory
 
     def get_job_state(self, job_id: str) -> Optional[PersistedJobState]:
+        """Return persisted state for ``job_id`` using a service context."""
         with self._session_factory() as session:
             repository = DeliveryJobRepository(session)
             service = DeliveryService(repository)

--- a/backend/services/websocket/service.py
+++ b/backend/services/websocket/service.py
@@ -32,6 +32,7 @@ class WebSocketService:
         connection_manager: Optional[ConnectionManager] = None,
         job_monitor: Optional[JobProgressMonitor] = None,
     ) -> None:
+        """Initialise WebSocket collaborators with sensible defaults."""
         self.manager = connection_manager or ConnectionManager()
         self.job_monitor = job_monitor or JobProgressMonitor(
             repository=DeliveryJobStateRepository(),

--- a/backend/utils/cache.py
+++ b/backend/utils/cache.py
@@ -18,6 +18,7 @@ class TTLCache:
     """
 
     def __init__(self, default_ttl: float = 60.0) -> None:
+        """Initialise the cache with a default time-to-live in seconds."""
         if not isinstance(default_ttl, (int, float)) or default_ttl <= 0:
             raise ValueError("default_ttl must be a positive number")
         self._default_ttl = float(default_ttl)
@@ -31,6 +32,7 @@ class TTLCache:
         return self._now() >= exp
 
     def set(self, key: Any, value: Any, ttl: Optional[float] = None) -> None:
+        """Store ``value`` under ``key`` using either the provided or default TTL."""
         ttl_val = float(ttl if ttl is not None else self._default_ttl)
         if ttl_val <= 0:
             with self._lock:
@@ -41,6 +43,7 @@ class TTLCache:
             self._data[key] = (value, exp)
 
     def get(self, key: Any, default: Any = None) -> Any:
+        """Return the cached value for ``key`` or ``default`` when absent/expired."""
         with self._lock:
             item = self._data.get(key)
             if not item:
@@ -52,10 +55,12 @@ class TTLCache:
             return value
 
     def clear(self) -> None:
+        """Remove all entries from the cache."""
         with self._lock:
             self._data.clear()
 
     def __len__(self) -> int:  # pragma: no cover
+        """Return the count of non-expired entries in the cache."""
         with self._lock:
             now = self._now()
             # prune

--- a/backend/workers/context.py
+++ b/backend/workers/context.py
@@ -57,6 +57,7 @@ class WorkerContext:
         recommendation_gpu_available: Optional[bool] = None,
         async_runner: Optional[AsyncRunner] = None,
     ) -> None:
+        """Capture queue, runner, and scheduling helpers for worker tasks."""
         primary, fallback = queue_orchestrator.get_backends()
         queue_backend = primary or fallback
         if queue_backend is None:  # pragma: no cover - defensive guard

--- a/backend/workers/delivery_runner.py
+++ b/backend/workers/delivery_runner.py
@@ -18,6 +18,7 @@ class DeliveryRunner:
     """Coordinate delivery job execution using registered backends."""
 
     def __init__(self, delivery_registry: DeliveryRegistry) -> None:
+        """Store the registry used to resolve delivery backends."""
         self._delivery_registry = delivery_registry
 
     def process_delivery_job(
@@ -56,7 +57,7 @@ class DeliveryRunner:
         retries_left: Optional[int] = None,
         raise_on_error: bool = False,
     ) -> None:
-        """Internal coroutine that loads state and executes the backend."""
+        """Load delivery state and execute the selected backend."""
         prompt: str
         mode: str
         params: Dict[str, Any]

--- a/backend/workers/tasks.py
+++ b/backend/workers/tasks.py
@@ -221,7 +221,7 @@ def process_embeddings_batch(
     *,
     context: Optional[WorkerContext] = None,
 ):
-    """Synchronously execute :func:`process_embeddings_batch_async`."""
+    """Run :func:`process_embeddings_batch_async` synchronously."""
     ctx = context or get_worker_context()
     return ctx.run_async(
         process_embeddings_batch_async(
@@ -283,7 +283,7 @@ def compute_single_embedding(
     *,
     context: Optional[WorkerContext] = None,
 ) -> bool:
-    """Synchronously execute :func:`compute_single_embedding_async`."""
+    """Run :func:`compute_single_embedding_async` synchronously."""
     ctx = context or get_worker_context()
     return ctx.run_async(
         compute_single_embedding_async(

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -7,3 +7,9 @@
 - **Tooling Alignment:** npm scripts, linting, and type-checking run solely against Vue sources; Vitest + Playwright cover unit, integration, and end-to-end scenarios.
 - **Documentation Refresh:** README, migration guide, and onboarding docs now describe the Vue-only stack so downstream teams know Alpine assets are no longer shipped.
 - **Operational Guidance:** Tailwind builds compile from `static/css/input.css`, and new release consumers should run `npm install && npm run build` to generate SPA assets before deploying FastAPI.
+
+## 2.2.0 – Backend Compatibility Cleanup
+
+- **Service Registry Simplification:** `ServiceRegistry.infrastructure` was removed; use the existing `ServiceRegistry.application` facade for application-tier dependencies.
+- **Explicit ASGI Factories:** `backend.main` now exposes `create_app()` and an ASGI factory callable instead of a pre-instantiated `app`. Callers should import `create_app` (or run `uvicorn backend.main:app --factory`) to obtain a configured backend application.
+- **Docstring Enforcement:** Temporary Ruff docstring exemptions for services and workers were dropped, re-enabling full documentation linting across backend modules.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,10 +23,6 @@ ignore = ["D203", "D213", "COM812"]
 "tests/**/*.py" = ["D"]
 "infrastructure/alembic/versions/*.py" = ["D"]
 "backend/migrations/versions/*.py" = ["D"]
-# TODO: remove these docstring exemptions once legacy services/workers gain documentation.
-"backend/services/**/*.py" = ["D100", "D101", "D102", "D103", "D105", "D107", "D401"]
-"backend/utils/cache.py" = ["D100", "D101", "D102", "D103", "D105", "D107", "D401"]
-"backend/workers/**/*.py" = ["D100", "D101", "D102", "D103", "D105", "D107", "D401"]
 "examples/**/*.py" = ["D"]
 
 [tool.ruff.lint.flake8-bugbear]

--- a/tests/api/test_cli.py
+++ b/tests/api/test_cli.py
@@ -5,8 +5,8 @@ from unittest.mock import AsyncMock
 import pytest
 from fastapi.testclient import TestClient
 
+from app.main import backend_app
 from backend.core.dependencies import get_service_container
-from backend.main import app as backend_app
 from backend.services import get_service_container_builder
 from backend.services.analytics_repository import AnalyticsRepository
 from backend.services.delivery_repository import DeliveryJobRepository

--- a/tests/api/test_generation.py
+++ b/tests/api/test_generation.py
@@ -6,8 +6,8 @@ from unittest.mock import AsyncMock
 import pytest
 from fastapi.testclient import TestClient
 
+from app.main import backend_app
 from backend.core.dependencies import get_application_services, get_domain_services
-from backend.main import app as backend_app
 from backend.schemas import SDNextGenerationResult
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,10 +10,8 @@ from sqlalchemy.pool import StaticPool
 from sqlmodel import Session, SQLModel, create_engine
 
 from app.main import app as fastapi_app
-
-# Use new app import paths
+from app.main import backend_app
 from backend.core.database import get_session
-from backend.main import app as backend_app
 from backend.services import get_service_container_builder
 from backend.services.adapters import AdapterService
 from backend.services.analytics_repository import AnalyticsRepository

--- a/tests/generation/test_jobs.py
+++ b/tests/generation/test_jobs.py
@@ -10,9 +10,9 @@ import pytest
 from fastapi import BackgroundTasks
 from fastapi.testclient import TestClient
 
+from app.main import backend_app
 from backend.core.dependencies import get_service_container
 from backend.delivery.base import DeliveryRegistry, GenerationBackend
-from backend.main import app as backend_app
 from backend.schemas import SDNextGenerationParams, SDNextGenerationResult
 from backend.services import get_service_container_builder
 from backend.services.analytics_repository import AnalyticsRepository

--- a/tests/unit/test_frontend_structure.py
+++ b/tests/unit/test_frontend_structure.py
@@ -24,6 +24,23 @@ class TestFrontendStructure:
         legacy_root = FRONTEND_DIR / "static" / "js"
         assert not legacy_root.exists(), "legacy Alpine bundles should be removed"
 
+    def test_python_frontend_package_removed(self) -> None:
+        """Historical Python frontend modules should no longer exist."""
+
+        legacy_modules = [
+            FRONTEND_DIR / "__init__.py",
+            FRONTEND_DIR / "config.py",
+            FRONTEND_DIR / "cache.py",
+            FRONTEND_DIR / "errors.py",
+            FRONTEND_DIR / "schemas.py",
+            FRONTEND_DIR / "logging.py",
+            FRONTEND_DIR / "utils",
+        ]
+
+        for module in legacy_modules:
+            message = f"{module} should be removed with the SPA migration"
+            assert not module.exists(), message
+
     def test_vue_views_cover_workflows(self) -> None:
         """Ensure that workflow views include the core feature components."""
         workflows = {


### PR DESCRIPTION
## Summary
- update the SPA entrypoint to instantiate the backend via `create_app()` and drop the old `backend.main.app` shortcut
- remove the `ServiceRegistry.infrastructure` alias, refresh release notes, and extend the frontend regression test to assert that no Python package remnants remain
- tighten Ruff’s docstring policy by deleting the legacy per-directory ignores and documenting the remaining service classes

## Testing
- ruff check
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d3781ec4c08329919c9e055f5e114e