### PR TITLE
Make service container builder thread-safe

### DIFF
--- a/backend/core/dependencies.py
+++ b/backend/core/dependencies.py
@@ -12,14 +12,12 @@ from backend.services import (
     get_service_container_builder,
 )
 
-_BUILDER = get_service_container_builder()
-
 
 def get_service_container(
     db_session: Session = Depends(get_session),  # noqa: B008 - FastAPI DI
 ) -> ServiceRegistry:
     """Return a service registry tied to the current database session."""
-    return _BUILDER.build(db_session)
+    return get_service_container_builder().build(db_session)
 
 
 def get_core_services(

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -42,7 +42,10 @@ Key concepts:
 
 - `ServiceContainerBuilder` composes `CoreServiceRegistry`,
   `DomainServiceRegistry`, and `InfrastructureServiceRegistry` objects so each
-  request receives the correct service graph.
+  request receives the correct service graph. Use
+  `service_container_builder_scope()` when you need an isolated container for a
+  test or request; it stores the active builder in context-local storage so
+  overrides never leak across async tasks.【F:backend/services/__init__.py†L1-L70】
 - WebSockets are handled by `backend/api/v1/websocket.py`, which delegates to
   `WebSocketService` for subscription management and broadcasting.
 - Import/export flows live under `backend/services/archive`, exposing

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,7 +12,7 @@ from sqlmodel import Session, SQLModel, create_engine
 from app.main import app as fastapi_app
 from app.main import backend_app
 from backend.core.database import get_session
-from backend.services import get_service_container_builder
+from backend.services import get_service_container_builder, service_container_builder_scope
 from backend.services.adapters import AdapterService
 from backend.services.analytics_repository import AnalyticsRepository
 from backend.services.composition import ComposeService
@@ -26,6 +26,14 @@ from backend.services.queue import create_queue_orchestrator
 def anyio_backend():
     """Force AnyIO tests to execute using the asyncio backend."""
     return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+def isolated_service_container_builder():
+    """Provide an isolated service container builder per test."""
+
+    with service_container_builder_scope():
+        yield
 
 
 @pytest.fixture(name="mock_storage")

--- a/tests/test_service_container_builder.py
+++ b/tests/test_service_container_builder.py
@@ -2,6 +2,10 @@ from __future__ import annotations
 
 import pytest
 
+from backend.services import (
+    get_service_container_builder,
+    service_container_builder_scope,
+)
 from backend.services.queue import BackgroundTaskQueueBackend, QueueOrchestrator
 from backend.services.service_container_builder import ServiceContainerBuilder
 
@@ -59,3 +63,13 @@ def test_service_container_builder_rejects_missing_session() -> None:
 
     with pytest.raises(ValueError, match="requires an active database session"):
         builder.build(None)  # type: ignore[arg-type]
+
+
+def test_service_container_builder_scope_restores_previous_builder() -> None:
+    original = get_service_container_builder()
+
+    with service_container_builder_scope() as scoped:
+        assert scoped is get_service_container_builder()
+        assert scoped is not original
+
+    assert get_service_container_builder() is original


### PR DESCRIPTION
## Summary
- guard queue orchestrator and GPU detection caches with a re-entrant lock in `ServiceContainerBuilder`
- swap the module-level singleton for a context-local builder scope and expose a helper for tests
- scope pytest fixtures to per-test builders and document the new lifecycle in the developer guide

## Testing
- `pytest tests/test_service_container_builder.py`


------
https://chatgpt.com/codex/tasks/task_e_68d37e5bc0748329a686d02e44dcbcf3