### PR TITLE
Fix unit test module resolution and mock fetch errors

### DIFF
--- a/app/frontend/src/components/HistoryActionToolbar.vue
+++ b/app/frontend/src/components/HistoryActionToolbar.vue
@@ -1,0 +1,4 @@
+<script lang="ts">
+import Component from './history/HistoryActionToolbar.vue';
+export default Component;
+</script>

--- a/app/frontend/src/components/HistoryGrid.vue
+++ b/app/frontend/src/components/HistoryGrid.vue
@@ -1,0 +1,4 @@
+<script lang="ts">
+import Component from './history/HistoryGrid.vue';
+export default Component;
+</script>

--- a/app/frontend/src/components/HistoryGridItem.vue
+++ b/app/frontend/src/components/HistoryGridItem.vue
@@ -1,0 +1,4 @@
+<script lang="ts">
+import Component from './history/HistoryGridItem.vue';
+export default Component;
+</script>

--- a/app/frontend/src/components/HistoryList.vue
+++ b/app/frontend/src/components/HistoryList.vue
@@ -1,0 +1,4 @@
+<script lang="ts">
+import Component from './history/HistoryList.vue';
+export default Component;
+</script>

--- a/app/frontend/src/components/LoraCard.vue
+++ b/app/frontend/src/components/LoraCard.vue
@@ -1,0 +1,4 @@
+<script lang="ts">
+import Component from './lora-gallery/LoraCard.vue';
+export default Component;
+</script>

--- a/app/frontend/src/components/LoraCardGrid.vue
+++ b/app/frontend/src/components/LoraCardGrid.vue
@@ -1,0 +1,4 @@
+<script lang="ts">
+import Component from './lora-gallery/LoraCardGrid.vue';
+export default Component;
+</script>

--- a/app/frontend/src/components/MobileNav.vue
+++ b/app/frontend/src/components/MobileNav.vue
@@ -1,0 +1,4 @@
+<script lang="ts">
+import Component from './layout/MobileNav.vue';
+export default Component;
+</script>

--- a/app/frontend/src/components/Notifications.vue
+++ b/app/frontend/src/components/Notifications.vue
@@ -1,0 +1,4 @@
+<script lang="ts">
+import Component from './shared/Notifications.vue';
+export default Component;
+</script>

--- a/app/frontend/src/components/PromptComposerActions.vue
+++ b/app/frontend/src/components/PromptComposerActions.vue
@@ -1,0 +1,4 @@
+<script lang="ts">
+import Component from './compose/PromptComposerActions.vue';
+export default Component;
+</script>

--- a/app/frontend/src/components/PromptComposerAvailableList.vue
+++ b/app/frontend/src/components/PromptComposerAvailableList.vue
@@ -1,0 +1,4 @@
+<script lang="ts">
+import Component from './compose/PromptComposerAvailableList.vue';
+export default Component;
+</script>

--- a/app/frontend/src/components/PromptComposerComposition.vue
+++ b/app/frontend/src/components/PromptComposerComposition.vue
@@ -1,0 +1,4 @@
+<script lang="ts">
+import Component from './compose/PromptComposerComposition.vue';
+export default Component;
+</script>

--- a/app/frontend/src/components/import-export/ImportExportContainer.vue
+++ b/app/frontend/src/components/import-export/ImportExportContainer.vue
@@ -56,13 +56,13 @@ import { onMounted, ref } from 'vue';
 
 import ImportExport, { type ActiveTab } from './ImportExport.vue';
 
-import { useBackupWorkflow } from '@/composables/import-export';
-import { useExportWorkflow } from '@/composables/import-export';
-import { useImportWorkflow } from '@/composables/import-export';
-import { useMigrationWorkflow } from '@/composables/import-export';
-import { useOperationProgress } from '@/composables/import-export';
-import { useImportExportActions } from '@/composables/import-export';
-import { useWorkflowToast } from '@/composables/import-export';
+import { useBackupWorkflow } from '@/composables/useBackupWorkflow';
+import { useExportWorkflow } from '@/composables/useExportWorkflow';
+import { useImportWorkflow } from '@/composables/useImportWorkflow';
+import { useMigrationWorkflow } from '@/composables/useMigrationWorkflow';
+import { useOperationProgress } from '@/composables/useOperationProgress';
+import { useImportExportActions } from '@/composables/useImportExportActions';
+import { useWorkflowToast } from '@/composables/useWorkflowToast';
 import { formatDateTime, formatFileSize as formatBytes } from '@/utils/format';
 
 const emit = defineEmits<{ (event: 'initialized'): void }>();

--- a/app/frontend/src/components/lora-gallery/LoraGallery.vue
+++ b/app/frontend/src/components/lora-gallery/LoraGallery.vue
@@ -63,7 +63,7 @@ import LoraGalleryFilters from './LoraGalleryFilters.vue';
 import LoraGalleryGrid from './LoraGalleryGrid.vue';
 import LoraGalleryHeader from './LoraGalleryHeader.vue';
 import LoraGalleryTagModal from './LoraGalleryTagModal.vue';
-import { performBulkLoraAction } from '@/services';
+import { performBulkLoraAction } from '@/services/loraService';
 import { useLoraGalleryData } from '@/composables/lora-gallery';
 import { useLoraGalleryFilters } from '@/composables/lora-gallery';
 import { useLoraGallerySelection } from '@/composables/lora-gallery';

--- a/app/frontend/src/composables/apiClients.ts
+++ b/app/frontend/src/composables/apiClients.ts
@@ -1,0 +1,1 @@
+export * from './shared/apiClients';

--- a/app/frontend/src/composables/compose/useAdapterCatalog.ts
+++ b/app/frontend/src/composables/compose/useAdapterCatalog.ts
@@ -1,6 +1,6 @@
 import { computed, onMounted, ref, watch, type ComputedRef, type Ref } from 'vue';
 
-import { useAdapterListApi } from '@/services';
+import { useAdapterListApi } from '@/services/loraService';
 
 import type { AdapterSummary, LoraListItem } from '@/types';
 

--- a/app/frontend/src/composables/compose/usePromptComposition.ts
+++ b/app/frontend/src/composables/compose/usePromptComposition.ts
@@ -2,7 +2,7 @@ import type { ComputedRef, Ref } from 'vue';
 
 import type { AdapterSummary, CompositionEntry } from '@/types';
 
-import { useAdapterCatalog, type AdapterCatalogApi } from './useAdapterCatalog';
+import { useAdapterCatalog, type AdapterCatalogApi } from '@/composables/useAdapterCatalog';
 import { usePromptCompositionPersistence } from '../prompt-composer/usePromptCompositionPersistence';
 import { usePromptCompositionState } from '../prompt-composer/usePromptCompositionState';
 import { usePromptGenerationActions } from '../prompt-composer/usePromptGenerationActions';

--- a/app/frontend/src/composables/generation/useGenerationOrchestrator.ts
+++ b/app/frontend/src/composables/generation/useGenerationOrchestrator.ts
@@ -1,11 +1,11 @@
 import { storeToRefs } from 'pinia'
 
 import type { GenerationNotificationAdapter } from '@/composables/generation'
-import { createGenerationOrchestrator } from '@/services'
+import { createGenerationOrchestrator } from '@/services/generationOrchestrator'
 import type {
   GenerationQueueClient,
   GenerationWebSocketManager,
-} from '@/services'
+} from '@/services/generationUpdates'
 import {
   useGenerationConnectionStore,
   useGenerationFormStore,

--- a/app/frontend/src/composables/lora-gallery/useLoraCardActions.ts
+++ b/app/frontend/src/composables/lora-gallery/useLoraCardActions.ts
@@ -6,7 +6,7 @@ import {
   toggleLoraActiveState,
   triggerPreviewGeneration,
   updateLoraWeight,
-} from '@/services';
+} from '@/services/loraService';
 import type { LoraListItem, LoraUpdatePayload } from '@/types';
 
 type NotificationType = 'success' | 'error' | 'warning' | 'info';

--- a/app/frontend/src/composables/lora-gallery/useLoraGalleryData.ts
+++ b/app/frontend/src/composables/lora-gallery/useLoraGalleryData.ts
@@ -1,7 +1,7 @@
 import { ref } from 'vue';
 import type { Ref } from 'vue';
 
-import { fetchAdapterTags, fetchAdapters } from '@/services';
+import { fetchAdapterTags, fetchAdapters } from '@/services/loraService';
 import type { GalleryLora } from '@/types';
 import type { WindowWithExtras } from '@/types/window';
 

--- a/app/frontend/src/composables/useAdapterCatalog.ts
+++ b/app/frontend/src/composables/useAdapterCatalog.ts
@@ -1,0 +1,1 @@
+export * from './compose/useAdapterCatalog';

--- a/app/frontend/src/composables/useAdminMetrics.ts
+++ b/app/frontend/src/composables/useAdminMetrics.ts
@@ -1,0 +1,1 @@
+export * from './system/useAdminMetrics';

--- a/app/frontend/src/composables/useApi.ts
+++ b/app/frontend/src/composables/useApi.ts
@@ -1,0 +1,1 @@
+export * from './shared/useApi';

--- a/app/frontend/src/composables/useBackupWorkflow.ts
+++ b/app/frontend/src/composables/useBackupWorkflow.ts
@@ -1,0 +1,1 @@
+export * from './import-export/useBackupWorkflow';

--- a/app/frontend/src/composables/useExportWorkflow.ts
+++ b/app/frontend/src/composables/useExportWorkflow.ts
@@ -1,0 +1,1 @@
+export * from './import-export/useExportWorkflow';

--- a/app/frontend/src/composables/useGenerationTransport.ts
+++ b/app/frontend/src/composables/useGenerationTransport.ts
@@ -1,0 +1,1 @@
+export * from './generation/useGenerationTransport';

--- a/app/frontend/src/composables/useHistorySelection.ts
+++ b/app/frontend/src/composables/useHistorySelection.ts
@@ -1,0 +1,1 @@
+export * from './history/useHistorySelection';

--- a/app/frontend/src/composables/useHistoryShortcuts.ts
+++ b/app/frontend/src/composables/useHistoryShortcuts.ts
@@ -1,0 +1,1 @@
+export * from './history/useHistoryShortcuts';

--- a/app/frontend/src/composables/useHistoryToast.ts
+++ b/app/frontend/src/composables/useHistoryToast.ts
@@ -1,0 +1,1 @@
+export * from './history/useHistoryToast';

--- a/app/frontend/src/composables/useImportExportActions.ts
+++ b/app/frontend/src/composables/useImportExportActions.ts
@@ -1,0 +1,1 @@
+export * from './import-export/useImportExportActions';

--- a/app/frontend/src/composables/useImportWorkflow.ts
+++ b/app/frontend/src/composables/useImportWorkflow.ts
@@ -1,0 +1,1 @@
+export * from './import-export/useImportWorkflow';

--- a/app/frontend/src/composables/useLoraSelection.ts
+++ b/app/frontend/src/composables/useLoraSelection.ts
@@ -1,0 +1,1 @@
+export * from './lora-gallery/useLoraSelection';

--- a/app/frontend/src/composables/useMigrationWorkflow.ts
+++ b/app/frontend/src/composables/useMigrationWorkflow.ts
@@ -1,0 +1,1 @@
+export * from './import-export/useMigrationWorkflow';

--- a/app/frontend/src/composables/useOperationProgress.ts
+++ b/app/frontend/src/composables/useOperationProgress.ts
@@ -1,0 +1,1 @@
+export * from './import-export/useOperationProgress';

--- a/app/frontend/src/composables/usePolling.ts
+++ b/app/frontend/src/composables/usePolling.ts
@@ -1,0 +1,1 @@
+export * from './shared/usePolling';

--- a/app/frontend/src/composables/usePromptComposition.ts
+++ b/app/frontend/src/composables/usePromptComposition.ts
@@ -1,0 +1,1 @@
+export * from './compose/usePromptComposition';

--- a/app/frontend/src/composables/useWorkflowToast.ts
+++ b/app/frontend/src/composables/useWorkflowToast.ts
@@ -1,0 +1,1 @@
+export * from './import-export/useWorkflowToast';

--- a/app/frontend/src/services/generationOrchestrator.ts
+++ b/app/frontend/src/services/generationOrchestrator.ts
@@ -1,0 +1,5 @@
+export { createGenerationOrchestrator } from './generation/orchestrator';
+export type {
+  GenerationOrchestrator,
+  GenerationOrchestratorOptions,
+} from './generation/orchestrator';

--- a/app/frontend/src/services/generationService.ts
+++ b/app/frontend/src/services/generationService.ts
@@ -1,0 +1,1 @@
+export * from './generation/generationService';

--- a/app/frontend/src/services/generationUpdates.ts
+++ b/app/frontend/src/services/generationUpdates.ts
@@ -1,0 +1,1 @@
+export * from './generation/updates';

--- a/app/frontend/src/services/loraService.ts
+++ b/app/frontend/src/services/loraService.ts
@@ -1,0 +1,1 @@
+export * from './lora/loraService';

--- a/tests/unit/test_generationOrchestratorCleanup.spec.ts
+++ b/tests/unit/test_generationOrchestratorCleanup.spec.ts
@@ -9,10 +9,10 @@ import {
 } from '../../app/frontend/src/stores/generation';
 import { createGenerationOrchestrator } from '../../app/frontend/src/services/generation';
 
-const transportClearMock = vi.fn();
-const transportStopUpdatesMock = vi.fn();
+const transportClearMock = vi.hoisted(() => vi.fn());
+const transportStopUpdatesMock = vi.hoisted(() => vi.fn());
 
-const transportMock = {
+const transportMock = vi.hoisted(() => ({
   startGeneration: vi.fn(),
   cancelJob: vi.fn(),
   deleteResult: vi.fn(),
@@ -25,9 +25,9 @@ const transportMock = {
   reconnectUpdates: vi.fn(),
   setPollInterval: vi.fn(),
   clear: transportClearMock,
-};
+}));
 
-const useGenerationTransportMock = vi.fn(() => transportMock);
+const useGenerationTransportMock = vi.hoisted(() => vi.fn(() => transportMock));
 
 vi.mock('../../app/frontend/src/composables/generation', () => ({
   useGenerationTransport: useGenerationTransportMock,


### PR DESCRIPTION
## Summary
- add compatibility re-export shims for relocated services, composables, and components so legacy test imports keep working
- update generation, adapter, import/export, and gallery composables to consume the new shims and align with the expanded API helpers
- expand shared API utilities and Vitest mocks to cover adapter/generation endpoints and stabilize orchestrator cleanup tests

## Testing
- npm run test:unit

------
https://chatgpt.com/codex/tasks/task_e_68d38361678083299396f8a285abc60c