### PR TITLE
Streamline generation history state management

### DIFF
--- a/app/frontend/src/components/history/GenerationHistoryContainer.vue
+++ b/app/frontend/src/components/history/GenerationHistoryContainer.vue
@@ -9,7 +9,7 @@
       :date-filter="state.dateFilter.value"
       :rating-filter="state.ratingFilter.value"
       :dimension-filter="state.dimensionFilter.value"
-      :stats="state.stats"
+      :stats="state.stats.value"
       :results="state.filteredResults.value"
       :selected-set="state.selectedSet.value"
       :is-loading="state.isLoading.value"


### PR DESCRIPTION
## Summary
- derive generation history results and aggregate statistics from computed state instead of mutating mirror arrays
- ensure filter changes reset pagination declaratively while reusing server-provided metrics when available
- expand generation history tests to cover stats fallbacks, pagination resets, and array identity under pagination

## Testing
- npm run test:unit *(fails: suite expects additional component stubs and unresolved aliases outside the touched scope)*
- npx vitest run tests/vue/GenerationHistory.spec.js

------
https://chatgpt.com/codex/tasks/task_e_68d38f1a52148329b10bf5cbbd65e339