### PR TITLE
Update Vue tests for new frontend module layout

### DIFF
--- a/tests/integration/generationWebsocketManager.test.js
+++ b/tests/integration/generationWebsocketManager.test.js
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { ref } from 'vue'
 import { setActivePinia, createPinia, storeToRefs } from 'pinia'
 
-import { createGenerationOrchestrator } from '../../app/frontend/src/services/generationOrchestrator'
+import { createGenerationOrchestrator } from '../../app/frontend/src/services/generation/orchestrator'
 import {
   useGenerationQueueStore,
   useGenerationResultsStore,

--- a/tests/vue/HistoryActionToolbar.spec.ts
+++ b/tests/vue/HistoryActionToolbar.spec.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { mount } from '@vue/test-utils';
 
-import HistoryActionToolbar from '../../app/frontend/src/components/HistoryActionToolbar.vue';
+import HistoryActionToolbar from '../../app/frontend/src/components/history/HistoryActionToolbar.vue';
 
 describe('HistoryActionToolbar', () => {
   it('emits update:viewMode when toggling view mode', async () => {

--- a/tests/vue/HistoryVirtualization.spec.ts
+++ b/tests/vue/HistoryVirtualization.spec.ts
@@ -2,9 +2,9 @@ import { mount } from '@vue/test-utils';
 import { nextTick } from 'vue';
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 
-import HistoryGrid from '../../app/frontend/src/components/HistoryGrid.vue';
-import HistoryGridItem from '../../app/frontend/src/components/HistoryGridItem.vue';
-import HistoryList from '../../app/frontend/src/components/HistoryList.vue';
+import HistoryGrid from '@/components/history/HistoryGrid.vue';
+import HistoryGridItem from '@/components/history/HistoryGridItem.vue';
+import HistoryList from '@/components/history/HistoryList.vue';
 
 const createResults = (count: number) =>
   Array.from({ length: count }, (_, index) => ({

--- a/tests/vue/LoraCard.spec.js
+++ b/tests/vue/LoraCard.spec.js
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { flushPromises, mount } from '@vue/test-utils';
-import LoraCard from '../../app/frontend/src/components/LoraCard.vue';
-import LoraCardGrid from '../../app/frontend/src/components/LoraCardGrid.vue';
+import LoraCard from '@/components/lora-gallery/LoraCard.vue';
+import LoraCardGrid from '@/components/lora-gallery/LoraCardGrid.vue';
 
 const mocks = vi.hoisted(() => ({
   updateLoraWeightMock: vi.fn(),
@@ -9,10 +9,10 @@ const mocks = vi.hoisted(() => ({
   triggerPreviewGenerationMock: vi.fn(),
   deleteLoraMock: vi.fn(),
   buildRecommendationsUrlMock: vi.fn(),
-}))
+}));
 
-vi.mock('../../app/frontend/src/services/loraService.ts', async () => {
-  const actual = await vi.importActual('../../app/frontend/src/services/loraService.ts');
+vi.mock('@/services', async () => {
+  const actual = await vi.importActual('@/services');
   return {
     ...actual,
     updateLoraWeight: mocks.updateLoraWeightMock,

--- a/tests/vue/LoraGallery.spec.js
+++ b/tests/vue/LoraGallery.spec.js
@@ -1,16 +1,16 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { flushPromises, mount } from '@vue/test-utils';
-import LoraGallery from '../../app/frontend/src/components/lora-gallery/LoraGallery.vue';
-import LoraCard from '../../app/frontend/src/components/LoraCard.vue';
+import LoraGallery from '@/components/lora-gallery/LoraGallery.vue';
+import LoraCard from '@/components/lora-gallery/LoraCard.vue';
 
 const mocks = vi.hoisted(() => ({
   fetchAdaptersMock: vi.fn(),
   fetchAdapterTagsMock: vi.fn(),
   performBulkLoraActionMock: vi.fn(),
-}))
+}));
 
-vi.mock('../../app/frontend/src/services/loraService.ts', async () => {
-  const actual = await vi.importActual('../../app/frontend/src/services/loraService.ts');
+vi.mock('@/services', async () => {
+  const actual = await vi.importActual('@/services');
   return {
     ...actual,
     fetchAdapters: mocks.fetchAdaptersMock,

--- a/tests/vue/MobileNav.spec.js
+++ b/tests/vue/MobileNav.spec.js
@@ -1,7 +1,7 @@
 import { mount } from '@vue/test-utils';
 import { defineComponent, h, nextTick } from 'vue';
 import { vi } from 'vitest';
-import MobileNav from '../../app/frontend/src/components/MobileNav.vue';
+import MobileNav from '../../app/frontend/src/components/layout/MobileNav.vue';
 
 vi.mock('vue-router', () => ({
   RouterLink: defineComponent({

--- a/tests/vue/Notifications.spec.js
+++ b/tests/vue/Notifications.spec.js
@@ -1,7 +1,7 @@
 import { mount } from '@vue/test-utils';
 import { nextTick } from 'vue';
 
-import Notifications from '../../app/frontend/src/components/Notifications.vue';
+import Notifications from '../../app/frontend/src/components/shared/Notifications.vue';
 import { useAppStore } from '../../app/frontend/src/stores/app';
 
 beforeEach(() => {

--- a/tests/vue/PromptComposerActions.spec.ts
+++ b/tests/vue/PromptComposerActions.spec.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { mount } from '@vue/test-utils';
 
-import PromptComposerActions from '../../app/frontend/src/components/PromptComposerActions.vue';
+import PromptComposerActions from '../../app/frontend/src/components/compose/PromptComposerActions.vue';
 
 describe('PromptComposerActions', () => {
   const factory = (overrides = {}) =>

--- a/tests/vue/PromptComposerAvailableList.spec.ts
+++ b/tests/vue/PromptComposerAvailableList.spec.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import { mount } from '@vue/test-utils';
 
-import PromptComposerAvailableList from '../../app/frontend/src/components/PromptComposerAvailableList.vue';
+import PromptComposerAvailableList from '../../app/frontend/src/components/compose/PromptComposerAvailableList.vue';
 
 describe('PromptComposerAvailableList', () => {
   const baseProps = {

--- a/tests/vue/PromptComposerComposition.spec.ts
+++ b/tests/vue/PromptComposerComposition.spec.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { mount } from '@vue/test-utils';
 
-import PromptComposerComposition from '../../app/frontend/src/components/PromptComposerComposition.vue';
+import PromptComposerComposition from '../../app/frontend/src/components/compose/PromptComposerComposition.vue';
 
 describe('PromptComposerComposition', () => {
   const items = [

--- a/tests/vue/apiClients.spec.ts
+++ b/tests/vue/apiClients.spec.ts
@@ -5,7 +5,7 @@ import {
   useAdapterListApi,
   useDashboardStatsApi,
   useSystemStatusApi,
-} from '../../app/frontend/src/composables/apiClients';
+} from '../../app/frontend/src/composables/shared/apiClients';
 import { useSettingsStore } from '../../app/frontend/src/stores/settings';
 
 const createJsonResponse = (payload: unknown): Response => ({

--- a/tests/vue/generationService.spec.ts
+++ b/tests/vue/generationService.spec.ts
@@ -8,7 +8,7 @@ import {
   resolveBackendUrl,
   resolveGenerationBaseUrl,
   startGeneration,
-} from '../../app/frontend/src/services/generationService.ts'
+} from '../../app/frontend/src/services/generation/generationService.ts'
 import { useSettingsStore } from '../../app/frontend/src/stores/settings'
 import type {
   GenerationCancelResponse,

--- a/tests/vue/useAdapterCatalog.spec.ts
+++ b/tests/vue/useAdapterCatalog.spec.ts
@@ -14,16 +14,20 @@ const fetchData = vi.fn(async () => {
   return adaptersRef.value;
 });
 
-vi.mock('../../app/frontend/src/services/loraService', () => ({
-  useAdapterListApi: vi.fn(() => ({
-    adapters: computed(() => adaptersRef.value),
-    error: errorRef,
-    isLoading: loadingRef,
-    fetchData,
-  })),
-}));
+vi.mock('@/services', async () => {
+  const actual = await vi.importActual('@/services');
+  return {
+    ...actual,
+    useAdapterListApi: vi.fn(() => ({
+      adapters: computed(() => adaptersRef.value),
+      error: errorRef,
+      isLoading: loadingRef,
+      fetchData,
+    })),
+  };
+});
 
-import { useAdapterCatalog } from '../../app/frontend/src/composables/useAdapterCatalog';
+import { useAdapterCatalog } from '@/composables/compose/useAdapterCatalog';
 
 type CatalogReturn = ReturnType<typeof useAdapterCatalog>;
 

--- a/tests/vue/useApi.spec.ts
+++ b/tests/vue/useApi.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, afterEach, vi } from 'vitest';
 
-import { useApi, ApiError } from '@/composables/useApi';
+import { useApi, ApiError } from '@/composables/shared/useApi';
 
 const originalFetch = global.fetch;
 

--- a/tests/vue/useBackupWorkflow.spec.ts
+++ b/tests/vue/useBackupWorkflow.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 
-import { useBackupWorkflow } from '../../app/frontend/src/composables/useBackupWorkflow';
+import { useBackupWorkflow } from '../../app/frontend/src/composables/import-export/useBackupWorkflow';
 
 const getJson = vi.fn();
 const postJson = vi.fn();

--- a/tests/vue/useExportWorkflow.spec.ts
+++ b/tests/vue/useExportWorkflow.spec.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { nextTick } from 'vue';
 
-import { useExportWorkflow, type ProgressCallbacks } from '../../app/frontend/src/composables/useExportWorkflow';
+import { useExportWorkflow, type ProgressCallbacks } from '../../app/frontend/src/composables/import-export/useExportWorkflow';
 
 const postJson = vi.fn();
 const requestBlob = vi.fn();

--- a/tests/vue/useHistorySelection.spec.ts
+++ b/tests/vue/useHistorySelection.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 
-import { useHistorySelection } from '../../app/frontend/src/composables/useHistorySelection';
+import { useHistorySelection } from '../../app/frontend/src/composables/history/useHistorySelection';
 
 describe('useHistorySelection', () => {
   it('adds and removes ids from the selection set', () => {

--- a/tests/vue/useHistoryShortcuts.spec.ts
+++ b/tests/vue/useHistoryShortcuts.spec.ts
@@ -3,7 +3,7 @@ import { computed, ref } from 'vue';
 import { createPinia, setActivePinia } from 'pinia';
 
 import { useGenerationResultsStore } from '../../app/frontend/src/stores/generation/results';
-import { useHistoryShortcuts } from '../../app/frontend/src/composables/useHistoryShortcuts';
+import { useHistoryShortcuts } from '../../app/frontend/src/composables/history/useHistoryShortcuts';
 
 describe('useHistoryShortcuts', () => {
   beforeEach(() => {

--- a/tests/vue/useHistoryToast.spec.ts
+++ b/tests/vue/useHistoryToast.spec.ts
@@ -1,6 +1,6 @@
 import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
 
-import { useHistoryToast } from '../../app/frontend/src/composables/useHistoryToast';
+import { useHistoryToast } from '../../app/frontend/src/composables/history/useHistoryToast';
 
 describe('useHistoryToast', () => {
   beforeEach(() => {

--- a/tests/vue/useImportWorkflow.spec.ts
+++ b/tests/vue/useImportWorkflow.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 
-import { useImportWorkflow, type ProgressCallbacks } from '../../app/frontend/src/composables/useImportWorkflow';
+import { useImportWorkflow, type ProgressCallbacks } from '../../app/frontend/src/composables/import-export/useImportWorkflow';
 
 const requestJson = vi.fn();
 

--- a/tests/vue/useLoraSelection.spec.ts
+++ b/tests/vue/useLoraSelection.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 
-import { useLoraSelection } from '../../app/frontend/src/composables/useLoraSelection';
+import { useLoraSelection } from '../../app/frontend/src/composables/lora-gallery/useLoraSelection';
 
 describe('useLoraSelection', () => {
   it('adds and removes ids using payload helper', () => {

--- a/tests/vue/useMigrationWorkflow.spec.ts
+++ b/tests/vue/useMigrationWorkflow.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 
-import { useMigrationWorkflow } from '../../app/frontend/src/composables/useMigrationWorkflow';
+import { useMigrationWorkflow } from '../../app/frontend/src/composables/import-export/useMigrationWorkflow';
 
 describe('useMigrationWorkflow', () => {
   const notify = vi.fn();

--- a/tests/vue/usePolling.spec.ts
+++ b/tests/vue/usePolling.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 
-import { usePolling } from '@/composables/usePolling';
+import { usePolling } from '@/composables/shared/usePolling';
 
 describe('usePolling composable', () => {
   beforeEach(() => {

--- a/tests/vue/usePromptComposition.spec.ts
+++ b/tests/vue/usePromptComposition.spec.ts
@@ -3,9 +3,9 @@ import { computed, nextTick, ref } from 'vue';
 import { mount } from '@vue/test-utils';
 
 import type { AdapterSummary, SavedComposition } from '@/types';
-import type { AdapterCatalogApi } from '../../app/frontend/src/composables/useAdapterCatalog';
+import type { AdapterCatalogApi } from '../../app/frontend/src/composables/compose/useAdapterCatalog';
 
-import { usePromptComposition } from '../../app/frontend/src/composables/usePromptComposition';
+import { usePromptComposition } from '../../app/frontend/src/composables/compose/usePromptComposition';
 import { usePromptCompositionState } from '../../app/frontend/src/composables/prompt-composer/usePromptCompositionState';
 import { usePromptCompositionPersistence } from '../../app/frontend/src/composables/prompt-composer/usePromptCompositionPersistence';
 import { usePromptGenerationActions } from '../../app/frontend/src/composables/prompt-composer/usePromptGenerationActions';
@@ -49,7 +49,7 @@ const catalogModuleMock = vi.hoisted(() => ({
   useAdapterCatalog: vi.fn<[], AdapterCatalogApi>(),
 }));
 
-vi.mock('../../app/frontend/src/composables/useAdapterCatalog', () => catalogModuleMock);
+vi.mock('../../app/frontend/src/composables/compose/useAdapterCatalog', () => catalogModuleMock);
 
 const servicesModuleMock = vi.hoisted(() => {
   const clipboard = { copy: vi.fn(async () => true) };


### PR DESCRIPTION
## Summary
- update Vue unit tests to import components and composables from the new module locations
- mock the consolidated @/services entry points in Lora and adapter specs so calls hit the right functions
- refresh the admin metrics spec to coordinate with the Pinia store and polling helpers

## Testing
- npm run test:unit

------
https://chatgpt.com/codex/tasks/task_e_68d391b53130832996124bbbce58c7d8