### PR TITLE
Fix history filter emit typings

### DIFF
--- a/app/frontend/src/components/history/HistoryFilters.vue
+++ b/app/frontend/src/components/history/HistoryFilters.vue
@@ -50,18 +50,48 @@
 </template>
 
 <script setup lang="ts">
+import type {
+  DateFilterOption,
+  DimensionFilterOption,
+  RatingFilterOption,
+} from '@/composables/history';
+
+const DATE_FILTER_OPTIONS = ['all', 'today', 'week', 'month'] as const;
+const RATING_FILTER_OPTIONS = [0, 1, 2, 3, 4, 5] as const;
+const DIMENSION_FILTER_OPTIONS = ['all', '512x512', '768x768', '1024x1024'] as const;
+
+const isDateFilterOption = (value: string): value is DateFilterOption =>
+  DATE_FILTER_OPTIONS.includes(value as DateFilterOption);
+
+const isRatingFilterOption = (value: number): value is RatingFilterOption =>
+  RATING_FILTER_OPTIONS.includes(value as RatingFilterOption);
+
+const isDimensionFilterOption = (value: string): value is DimensionFilterOption =>
+  DIMENSION_FILTER_OPTIONS.includes(value as DimensionFilterOption);
+
+const toDateFilterOption = (value: string): DateFilterOption =>
+  isDateFilterOption(value) ? value : 'all';
+
+const toRatingFilterOption = (value: string): RatingFilterOption => {
+  const numeric = Number(value);
+  return Number.isFinite(numeric) && isRatingFilterOption(numeric) ? numeric : 0;
+};
+
+const toDimensionFilterOption = (value: string): DimensionFilterOption =>
+  isDimensionFilterOption(value) ? value : 'all';
+
 defineProps<{
   searchTerm: string;
-  dateFilter: string;
-  ratingFilter: string | number;
-  dimensionFilter: string;
+  dateFilter: DateFilterOption;
+  ratingFilter: RatingFilterOption;
+  dimensionFilter: DimensionFilterOption;
 }>();
 
 const emit = defineEmits<{
   (e: 'update:searchTerm', value: string): void;
-  (e: 'update:dateFilter', value: string): void;
-  (e: 'update:ratingFilter', value: number): void;
-  (e: 'update:dimensionFilter', value: string): void;
+  (e: 'update:dateFilter', value: DateFilterOption): void;
+  (e: 'update:ratingFilter', value: RatingFilterOption): void;
+  (e: 'update:dimensionFilter', value: DimensionFilterOption): void;
   (e: 'search'): void;
   (e: 'change'): void;
 }>();
@@ -74,19 +104,19 @@ const onSearchInput = (event: Event): void => {
 
 const onDateChange = (event: Event): void => {
   const value = (event.target as HTMLSelectElement).value;
-  emit('update:dateFilter', value);
+  emit('update:dateFilter', toDateFilterOption(value));
   emit('change');
 };
 
 const onRatingChange = (event: Event): void => {
-  const value = Number((event.target as HTMLSelectElement).value);
-  emit('update:ratingFilter', value);
+  const value = (event.target as HTMLSelectElement).value;
+  emit('update:ratingFilter', toRatingFilterOption(value));
   emit('change');
 };
 
 const onDimensionChange = (event: Event): void => {
   const value = (event.target as HTMLSelectElement).value;
-  emit('update:dimensionFilter', value);
+  emit('update:dimensionFilter', toDimensionFilterOption(value));
   emit('change');
 };
 </script>


### PR DESCRIPTION
## Summary
- align `HistoryFilters` props and emits with the typed filter option unions
- guard select change handlers so emitted values always match the expected option types

## Testing
- npm run type-check

------
https://chatgpt.com/codex/tasks/task_e_68d39eb93f9c8329bef0b666c48a5f1b