### PR TITLE
Optimize active generation job listing

### DIFF
--- a/backend/services/deliveries.py
+++ b/backend/services/deliveries.py
@@ -108,6 +108,12 @@ class DeliveryService:
         """List delivery jobs with optional filtering and pagination."""
         return self._repository.list_jobs(status=status, limit=limit, offset=offset)
 
+    def list_jobs_by_statuses(
+        self, statuses: Sequence[str], *, limit: int
+    ) -> List[DeliveryJob]:
+        """List delivery jobs matching any of ``statuses`` ordered by recency."""
+        return self._repository.list_jobs_by_statuses(statuses, limit=limit)
+
     def count_active_jobs(self) -> int:
         """Return the number of jobs currently in flight."""
         return self._repository.count_active_jobs()


### PR DESCRIPTION
## Summary
- add a repository helper to fetch jobs by multiple statuses in a single ordered query
- update the generation controller to rely on the new delivery service method and include retrying jobs
- cover multi-status filtering and ordering through delivery service and API tests

## Testing
- pytest tests/services/test_delivery_service.py tests/generation/test_jobs.py

------
https://chatgpt.com/codex/tasks/task_e_68d39fa23b188329b2d24a55718e18d2