### PR TITLE
Add schema validation for adapter patch endpoint

### DIFF
--- a/backend/schemas/__init__.py
+++ b/backend/schemas/__init__.py
@@ -3,6 +3,7 @@
 from .adapters import (
     AdapterCreate,
     AdapterListResponse,
+    AdapterPatch,
     AdapterRead,
     AdapterWrapper,
 )
@@ -79,6 +80,7 @@ __all__ = [
     "AdapterRead",
     "AdapterWrapper",
     "AdapterListResponse",
+    "AdapterPatch",
     # Analytics
     "PerformanceAnalyticsSummary",
     "PerformanceAnalyticsCharts",

--- a/backend/schemas/adapters.py
+++ b/backend/schemas/adapters.py
@@ -3,7 +3,14 @@
 from datetime import datetime
 from typing import Any, Dict, List, Optional
 
-from pydantic import BaseModel, field_validator
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    StrictBool,
+    StrictFloat,
+    StrictInt,
+    field_validator,
+)
 
 
 class AdapterCreate(BaseModel):
@@ -114,3 +121,35 @@ class AdapterListResponse(BaseModel):
     page: int
     pages: int
     per_page: int
+
+
+class AdapterPatch(BaseModel):
+    """Partial update payload for adapter resources."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    weight: Optional[StrictFloat | StrictInt] = None
+    active: Optional[StrictBool] = None
+    ordinal: Optional[StrictInt] = None
+    tags: Optional[List[str]] = None
+    description: Optional[str] = None
+    activation_text: Optional[str] = None
+    trained_words: Optional[List[str]] = None
+    triggers: Optional[List[str]] = None
+    archetype: Optional[str] = None
+    archetype_confidence: Optional[StrictFloat] = None
+    visibility: Optional[str] = None
+    nsfw_level: Optional[StrictInt] = None
+    supports_generation: Optional[StrictBool] = None
+    sd_version: Optional[str] = None
+
+    @field_validator("tags", "trained_words", "triggers", mode="before")
+    @classmethod
+    def _validate_string_list(cls, value):
+        """Ensure list-based fields receive iterable collections."""
+
+        if value is None:
+            return value
+        if isinstance(value, list):
+            return value
+        raise TypeError("value must be a list of strings")

--- a/tests/api/test_adapters.py
+++ b/tests/api/test_adapters.py
@@ -1,9 +1,13 @@
 """Adapter API integration tests."""
 
 import uuid
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 from fastapi.testclient import TestClient
+
+from app.main import backend_app
+from backend.api.v1 import adapters as adapters_router
 
 
 def test_adapter_lifecycle(
@@ -78,3 +82,75 @@ def test_create_adapters_allows_same_name_with_different_versions(
         body.get("detail") == "adapter with this name and version already exists"
         or body.get("title") == "adapter with this name and version already exists"
     )
+
+
+def test_patch_adapter_rejects_invalid_payloads(
+    client: TestClient,
+    mock_storage: MagicMock,
+):
+    """Request validation rejects unsupported keys and incorrect types."""
+
+    mock_storage.exists.return_value = True
+
+    name = "patch-invalid-" + uuid.uuid4().hex
+    payload = {
+        "name": name,
+        "version": "v1",
+        "file_path": "/fake/path",
+        "weight": 1.0,
+    }
+    creation = client.post("/api/v1/adapters", json=payload)
+    creation.raise_for_status()
+    adapter_id = creation.json()["adapter"]["id"]
+
+    sentinel_services = SimpleNamespace(adapters=MagicMock())
+    backend_app.dependency_overrides[
+        adapters_router.get_domain_services
+    ] = lambda: sentinel_services
+    try:
+        response_type_error = client.patch(
+            f"/api/v1/adapters/{adapter_id}",
+            json={"weight": "heavy"},
+        )
+        assert response_type_error.status_code == 422
+
+        response_unknown_key = client.patch(
+            f"/api/v1/adapters/{adapter_id}",
+            json={"unknown": 1},
+        )
+        assert response_unknown_key.status_code == 422
+
+        assert sentinel_services.adapters.patch_adapter.call_count == 0
+    finally:
+        backend_app.dependency_overrides.pop(
+            adapters_router.get_domain_services, None
+        )
+
+
+def test_patch_adapter_applies_valid_partial_update(
+    client: TestClient,
+    mock_storage: MagicMock,
+):
+    """Valid patch payload updates the adapter using service rules."""
+
+    mock_storage.exists.return_value = True
+
+    name = "patch-valid-" + uuid.uuid4().hex
+    creation_payload = {
+        "name": name,
+        "version": "v1",
+        "file_path": "/fake/path",
+        "weight": 1.0,
+    }
+    creation = client.post("/api/v1/adapters", json=creation_payload)
+    creation.raise_for_status()
+    adapter_id = creation.json()["adapter"]["id"]
+
+    patch_response = client.patch(
+        f"/api/v1/adapters/{adapter_id}",
+        json={"weight": 0.5, "active": True},
+    )
+    assert patch_response.status_code == 200
+    patched_adapter = patch_response.json()["adapter"]
+    assert patched_adapter["weight"] == 0.5
+    assert patched_adapter["active"] is True


### PR DESCRIPTION
## Summary
- add an `AdapterPatch` schema with strict typing and list validation for PATCH payloads
- update the adapter PATCH route to use the new schema and document the validation behaviour
- extend API tests to cover invalid payload rejection and successful partial updates

## Testing
- pytest tests/api/test_adapters.py tests/services/test_adapter_service.py

------
https://chatgpt.com/codex/tasks/task_e_68d3a698099c8329838679c520e72edf