### PR TITLE
chore: align frontend models with backend schemas

### DIFF
--- a/app/frontend/src/composables/generation/useJobQueuePolling.ts
+++ b/app/frontend/src/composables/generation/useJobQueuePolling.ts
@@ -1,12 +1,12 @@
 import { onBeforeUnmount, onMounted, ref, watch, type ComputedRef } from 'vue';
 
-import type { JobQueueRecord } from '@/composables/generation';
+import type { GenerationJobStatus } from '@/types';
 
 export interface UseJobQueuePollingOptions {
   disabled: ComputedRef<boolean>;
   pollInterval: ComputedRef<number>;
-  fetchJobs: () => Promise<JobQueueRecord[] | null>;
-  onRecord: (record: JobQueueRecord) => void;
+  fetchJobs: () => Promise<GenerationJobStatus[] | null>;
+  onRecord: (record: GenerationJobStatus) => void;
 }
 
 export const useJobQueuePolling = ({
@@ -19,7 +19,7 @@ export const useJobQueuePolling = ({
   const isPolling = ref(false);
   const pollTimer = ref<ReturnType<typeof setInterval> | null>(null);
 
-  const applyRecords = (records: JobQueueRecord[] | null | undefined): void => {
+  const applyRecords = (records: GenerationJobStatus[] | null | undefined): void => {
     if (!Array.isArray(records) || records.length === 0) {
       return;
     }

--- a/app/frontend/src/composables/generation/useJobQueueTransport.ts
+++ b/app/frontend/src/composables/generation/useJobQueueTransport.ts
@@ -2,15 +2,14 @@ import { ref, unref, type MaybeRefOrGetter, type Ref } from 'vue';
 
 import { fetchActiveGenerationJobs } from '@/services';
 import { DEFAULT_BACKEND_BASE } from '@/utils/backend';
-
-export type JobQueueRecord = Record<string, unknown>;
+import type { GenerationJobStatus } from '@/types';
 
 export interface UseJobQueueTransportOptions {
   backendBase: MaybeRefOrGetter<string>;
 }
 
 export interface UseJobQueueTransportReturn {
-  fetchJobs: () => Promise<JobQueueRecord[] | null>;
+  fetchJobs: () => Promise<GenerationJobStatus[] | null>;
   apiAvailable: Ref<boolean>;
 }
 
@@ -35,7 +34,7 @@ export const useJobQueueTransport = (
 ): UseJobQueueTransportReturn => {
   const apiAvailable = ref(true);
 
-  const fetchJobs = async (): Promise<JobQueueRecord[] | null> => {
+  const fetchJobs = async (): Promise<GenerationJobStatus[] | null> => {
     const backendBase = resolveBackendBase(options.backendBase);
 
     try {

--- a/app/frontend/src/composables/history/useGenerationHistory.ts
+++ b/app/frontend/src/composables/history/useGenerationHistory.ts
@@ -7,6 +7,7 @@ import type {
   GenerationHistoryQuery,
   GenerationHistoryResult,
   GenerationHistoryStats,
+  JsonObject,
 } from '@/types';
 
 export type HistorySortOption = 'created_at' | 'created_at_asc' | 'prompt' | 'rating';
@@ -100,10 +101,10 @@ export const useGenerationHistory = ({
       0,
     );
     const totalSize = results.reduce((sum, result) => {
-      const metadata = result.metadata;
-      if (metadata && typeof metadata === 'object') {
-        const record = metadata as Record<string, unknown>;
-        const sizeCandidate = record.size_bytes ?? record.file_size ?? record.byte_size;
+      const metadata = result.metadata as JsonObject | null;
+      if (metadata) {
+        const sizeCandidate =
+          metadata.size_bytes ?? metadata.file_size ?? metadata.byte_size ?? metadata.size;
         if (typeof sizeCandidate === 'number' && Number.isFinite(sizeCandidate)) {
           return sum + sizeCandidate;
         }

--- a/app/frontend/src/composables/import-export/useExportWorkflow.ts
+++ b/app/frontend/src/composables/import-export/useExportWorkflow.ts
@@ -3,6 +3,7 @@ import { computed, reactive, ref, watch, type ComputedRef } from 'vue';
 import { ensureData, getFilenameFromContentDisposition, postJson, requestBlob } from '@/utils/api';
 import { downloadFile } from '@/utils/browser';
 import { formatFileSize as formatBytes } from '@/utils/format';
+import type { ExportConfig, ExportEstimate } from '@/types';
 
 export type NotifyType = 'success' | 'error' | 'warning' | 'info';
 export type NotifyFn = (message: string, type?: NotifyType) => void;
@@ -17,26 +18,6 @@ export interface ProgressCallbacks {
   begin: () => void;
   update: (update: ProgressUpdate) => void;
   end: () => void;
-}
-
-export interface ExportConfig {
-  loras: boolean;
-  lora_files: boolean;
-  lora_metadata: boolean;
-  lora_embeddings: boolean;
-  generations: boolean;
-  generation_range: 'all' | 'date_range';
-  date_from: string;
-  date_to: string;
-  user_data: boolean;
-  system_config: boolean;
-  analytics: boolean;
-  format: 'zip' | 'tar.gz' | 'json';
-  compression: 'none' | 'fast' | 'balanced' | 'maximum';
-  split_archives: boolean;
-  max_size_mb: number;
-  encrypt: boolean;
-  password: string;
 }
 
 interface UseExportWorkflowOptions {
@@ -158,11 +139,11 @@ export function useExportWorkflow(options: UseExportWorkflowOptions): UseExportW
   const updateEstimates = async () => {
     try {
       const estimates = ensureData(
-        await postJson('/api/v1/export/estimate', { ...exportConfig })
+        await postJson<ExportEstimate, ExportConfig>('/api/v1/export/estimate', { ...exportConfig })
       );
 
       if (estimates && typeof estimates === 'object') {
-        const { size, time } = estimates as Record<string, unknown>;
+        const { size, time } = estimates;
         if (typeof size === 'string') {
           estimatedSize.value = size;
         }

--- a/app/frontend/src/composables/import-export/useImportWorkflow.ts
+++ b/app/frontend/src/composables/import-export/useImportWorkflow.ts
@@ -1,18 +1,8 @@
 import { computed, reactive, ref, type ComputedRef } from 'vue';
 
 import { ensureData, requestJson } from '@/utils/api';
+import type { ImportConfig, ImportMode } from '@/types';
 import type { NotifyFn, ProgressCallbacks } from './useExportWorkflow';
-
-export type ImportMode = 'merge' | 'replace' | 'skip';
-export type ConflictResolution = 'ask' | 'keep_existing' | 'overwrite' | 'rename';
-
-export interface ImportConfig {
-  mode: ImportMode;
-  conflict_resolution: ConflictResolution;
-  validate: boolean;
-  backup_before: boolean;
-  password: string;
-}
 
 export interface ImportPreviewItem {
   id: string;

--- a/app/frontend/src/services/generation/generationService.ts
+++ b/app/frontend/src/services/generation/generationService.ts
@@ -3,6 +3,7 @@ import type {
   GenerationCancelResponse,
   GenerationDownloadMetadata,
   GenerationFormState,
+  GenerationJobStatus,
   GenerationRequestPayload,
   GenerationStartResponse,
   SDNextGenerationParams,
@@ -34,8 +35,6 @@ export const resolveGenerationBaseUrl = (baseOverride?: string | null): string =
   resolveBackendBaseUrl(baseOverride);
 
 export { resolveBackendUrlHelper as resolveBackendUrl };
-
-type JobStatusRecord = Record<string, unknown>;
 
 export const resolveGenerationRoute = (path: string, baseOverride?: string | null): string =>
   resolveBackendUrlHelper(`/generation/${trimLeadingSlash(path)}`, baseOverride);
@@ -70,8 +69,8 @@ export const requestGeneration = async (
 
 export const fetchActiveGenerationJobs = async (
   baseUrl?: string | null,
-): Promise<JobStatusRecord[]> => {
-  const result = await requestJson<JobStatusRecord[]>(
+): Promise<GenerationJobStatus[]> => {
+  const result = await requestJson<GenerationJobStatus[]>(
     resolveGenerationRoute('jobs/active', baseUrl),
     { credentials: 'same-origin' },
   );

--- a/app/frontend/src/types/app.ts
+++ b/app/frontend/src/types/app.ts
@@ -3,6 +3,7 @@
  */
 
 import type { GeneratedNormalizedJobStatus } from '@/constants/generated/jobStatuses';
+import type { JsonObject } from './json';
 
 export interface FrontendRuntimeSettings {
   backendUrl: string;
@@ -53,12 +54,9 @@ export interface GenerationJob {
   steps?: number;
   cfg_scale?: number;
   seed?: number | null;
-  params?: Record<string, unknown> & {
-    width?: number;
-    height?: number;
-    steps?: number;
-  };
-  [key: string]: unknown;
+  params?: JsonObject | null;
+  result?: JsonObject | null;
+  error?: string | null;
 }
 
 export interface GenerationResult {
@@ -75,7 +73,9 @@ export interface GenerationResult {
   cfg_scale?: number;
   seed?: number | null;
   created_at?: string;
-  [key: string]: unknown;
+  finished_at?: string | null;
+  status?: JobStatus | string;
+  generation_info?: JsonObject | null;
 }
 
 export type NotificationType = 'info' | 'success' | 'error' | 'warning';

--- a/app/frontend/src/types/deliveries.ts
+++ b/app/frontend/src/types/deliveries.ts
@@ -3,6 +3,7 @@
  */
 
 import type { ComposeDeliverySDNext } from './generation';
+import type { JsonObject } from './json';
 
 export interface ComposeDeliveryHTTP {
   host: string;
@@ -42,23 +43,15 @@ export interface ComposeRequest {
 export interface DeliveryCreate {
   prompt: string;
   mode: string;
-  /**
-   * Backend accepts arbitrary parameter dictionaries for different delivery engines.
-   * TODO: tighten this definition when concrete parameter schemas are published.
-   */
-  params?: Record<string, unknown> | null;
+  params?: JsonObject | null;
 }
 
 export interface DeliveryRead {
   id: string;
   prompt: string;
   mode: string;
-  params: Record<string, unknown>;
-  /**
-   * Delivery result varies per delivery type (image URLs, metadata, errors, ...).
-   * TODO: introduce discriminated unions once backend standardises result payloads.
-   */
-  result?: unknown;
+  params: JsonObject;
+  result?: JsonObject | null;
   status: string;
   created_at: string;
   started_at?: string | null;

--- a/app/frontend/src/types/generation.ts
+++ b/app/frontend/src/types/generation.ts
@@ -3,6 +3,7 @@
  */
 
 import type { GenerationJob, NormalizedJobStatus } from './app';
+import type { JsonObject } from './json';
 import type { SystemStatusPayload } from './system';
 
 export interface GenerationFormState {
@@ -33,20 +34,22 @@ export interface SDNextGenerationParams {
   denoising_strength?: number | null;
 }
 
+export type GenerationMode = 'immediate' | 'deferred';
+
+export type GenerationResultFormat = 'base64' | 'file_path' | 'url';
+
 export interface ComposeDeliverySDNext {
   generation_params: SDNextGenerationParams;
-  mode?: string;
+  mode?: GenerationMode;
   save_images?: boolean;
-  return_format?: string;
+  return_format?: GenerationResultFormat;
 }
 
 export interface SDNextDeliveryParams {
   generation_params: SDNextGenerationParams;
-  /** One of "immediate" or "deferred". */
-  mode?: string;
+  mode?: GenerationMode;
   save_images?: boolean;
-  /** One of "base64", "url", or "file_path". */
-  return_format?: string;
+  return_format?: GenerationResultFormat;
 }
 
 export interface SDNextGenerationResult {
@@ -58,11 +61,7 @@ export interface SDNextGenerationResult {
   /** 0.0–1.0 progress indicator. */
   progress?: number | null;
   error_message?: string | null;
-  /**
-   * Backend emits engine-specific metadata here.
-   * TODO: update once generation_info payload is formalised.
-   */
-  generation_info?: Record<string, unknown> | null;
+  generation_info?: JsonObject | null;
 }
 
 export interface GenerationLoraReference {
@@ -71,38 +70,49 @@ export interface GenerationLoraReference {
   version?: string | null;
   weight?: number | null;
   adapter_id?: string | null;
-  /** Additional metadata attached to the LoRA reference. */
-  extra?: Record<string, unknown> | null;
+  extra?: JsonObject | null;
+}
+
+export interface GenerationJobStatus {
+  id: string;
+  jobId?: string | null;
+  prompt?: string | null;
+  status: NormalizedJobStatus | string;
+  progress: number;
+  message?: string | null;
+  error?: string | null;
+  params?: JsonObject;
+  created_at: string;
+  startTime?: string | null;
+  finished_at?: string | null;
+  result?: JsonObject | null;
 }
 
 export interface GenerationHistoryResult {
   id: string | number;
-  job_id?: string | null;
-  prompt: string;
+  job_id?: string;
+  prompt?: string | null;
   negative_prompt?: string | null;
-  image_url: string;
+  status?: NormalizedJobStatus | string | null;
+  image_url?: string | null;
   thumbnail_url?: string | null;
   created_at: string;
+  finished_at?: string | null;
   updated_at?: string | null;
-  width: number;
-  height: number;
-  steps: number;
-  cfg_scale: number;
+  width?: number | null;
+  height?: number | null;
+  steps?: number | null;
+  cfg_scale?: number | null;
   seed?: number | null;
   sampler_name?: string | null;
   model_name?: string | null;
-  status?: string | null;
   rating?: number | null;
   is_favorite?: boolean;
   rating_updated_at?: string | null;
   favorite_updated_at?: string | null;
+  generation_info?: JsonObject | null;
+  metadata?: JsonObject | null;
   loras?: GenerationLoraReference[] | null;
-  metadata?: Record<string, unknown> | null;
-  /**
-   * Backend may return additional engine-specific fields.
-   * Consumers should narrow this record when stricter typing becomes available.
-   */
-  [key: string]: unknown;
 }
 
 export type GenerationHistoryEntry = GenerationHistoryResult;
@@ -145,7 +155,7 @@ export interface GenerationHistoryQuery {
   height?: number;
   start_date?: string;
   end_date?: string;
-  [key: string]: unknown;
+  date_filter?: string;
 }
 
 export interface GenerationRatingUpdate {
@@ -181,10 +191,9 @@ export type GenerationRequestPayload = SDNextGenerationParams;
 export type GenerationStartResponse = SDNextGenerationResult;
 
 export interface GenerationCancelResponse {
-  success?: boolean;
-  status?: string;
+  success: boolean;
+  status: string;
   message?: string | null;
-  [key: string]: unknown;
 }
 
 export interface ProgressUpdate {
@@ -212,11 +221,7 @@ export interface GenerationComplete {
   images?: string[] | null;
   error_message?: string | null;
   total_duration?: number | null;
-  /**
-   * Backend emits engine-specific metadata here.
-   * TODO: align once generation_info gains a stable contract.
-   */
-  generation_info?: Record<string, unknown> | null;
+  generation_info?: JsonObject | null;
 }
 
 export interface GenerationProgressMessage extends ProgressUpdate {

--- a/app/frontend/src/types/importExport.ts
+++ b/app/frontend/src/types/importExport.ts
@@ -1,0 +1,58 @@
+/**
+ * Types derived from backend/schemas/import_export.py for backup, export and import flows.
+ */
+
+export type ExportGenerationRange = 'all' | 'date_range';
+
+export type ExportFormat = 'zip' | 'tar.gz' | 'json';
+
+export type ExportCompression = 'none' | 'fast' | 'balanced' | 'maximum';
+
+export interface ExportConfig {
+  loras: boolean;
+  lora_files: boolean;
+  lora_metadata: boolean;
+  lora_embeddings: boolean;
+  generations: boolean;
+  generation_range: ExportGenerationRange;
+  date_from: string;
+  date_to: string;
+  user_data: boolean;
+  system_config: boolean;
+  analytics: boolean;
+  format: ExportFormat;
+  compression: ExportCompression;
+  split_archives: boolean;
+  max_size_mb: number;
+  encrypt: boolean;
+  password: string;
+}
+
+export interface ExportEstimate {
+  size: string;
+  time: string;
+}
+
+export type ImportMode = 'merge' | 'replace' | 'skip';
+
+export type ImportConflictResolution = 'ask' | 'keep_existing' | 'overwrite' | 'rename';
+
+export interface ImportConfig {
+  mode: ImportMode;
+  conflict_resolution: ImportConflictResolution;
+  validate: boolean;
+  backup_before: boolean;
+  password: string;
+}
+
+export interface BackupHistoryItem {
+  id: string;
+  created_at: string;
+  type: string;
+  size?: number | null;
+  status: string;
+}
+
+export interface BackupCreateRequest {
+  backup_type: string;
+}

--- a/app/frontend/src/types/index.ts
+++ b/app/frontend/src/types/index.ts
@@ -7,3 +7,5 @@ export * from './api';
 export * from './system';
 export * from './promptComposer';
 export * from './analytics';
+export * from './json';
+export * from './importExport';

--- a/app/frontend/src/types/json.ts
+++ b/app/frontend/src/types/json.ts
@@ -1,0 +1,14 @@
+/**
+ * Shared JSON-compatible primitives reused across API payload types.
+ */
+
+/** Primitive JSON scalar values. */
+export type JsonPrimitive = string | number | boolean | null;
+
+/** JSON object map keyed by strings. */
+export interface JsonObject {
+  [key: string]: JsonValue;
+}
+
+/** Any JSON-compatible value (object, array, or primitive). */
+export type JsonValue = JsonPrimitive | JsonObject | JsonValue[];

--- a/app/frontend/src/types/lora.ts
+++ b/app/frontend/src/types/lora.ts
@@ -2,10 +2,7 @@
  * Type definitions mirroring backend/schemas/adapters.py.
  */
 
-type JsonPrimitive = string | number | boolean | null;
-
-/** JSON-compatible value used for metadata payloads. */
-export type JsonValue = JsonPrimitive | JsonValue[] | { [key: string]: JsonValue };
+import type { JsonObject, JsonValue } from './json';
 
 export type AdapterStatsMetric =
   | 'downloadCount'
@@ -53,7 +50,7 @@ export interface AdapterMetadata {
   activation_text?: string | null;
   stats?: AdapterStats | null;
   preview_image?: string | null;
-  unmapped?: { [key: string]: JsonValue } | null;
+  unmapped?: JsonObject | null;
 }
 
 /** Request payload for creating a new adapter. */

--- a/app/frontend/src/types/recommendations.ts
+++ b/app/frontend/src/types/recommendations.ts
@@ -2,6 +2,8 @@
  * Type definitions mirroring backend/schemas/recommendations.py.
  */
 
+import type { JsonObject } from './json';
+
 export interface RecommendationRequest {
   target_lora_id?: string | null;
   prompt?: string | null;
@@ -9,11 +11,7 @@ export interface RecommendationRequest {
   limit?: number;
   include_explanations?: boolean;
   weights?: Record<string, number> | null;
-  /**
-   * Filter structure is backend-defined and may evolve.
-   * TODO: sync with backend filter schema when documented.
-   */
-  filters?: Record<string, unknown> | null;
+  filters?: JsonObject | null;
 }
 
 export interface RecommendationItem {
@@ -29,11 +27,7 @@ export interface RecommendationItem {
   quality_boost?: number | null;
   popularity_boost?: number | null;
   recency_boost?: number | null;
-  /**
-   * Recommendation engine attaches contextual metadata here.
-   * TODO: capture specific keys when backend payload stabilises.
-   */
-  metadata?: Record<string, unknown> | null;
+  metadata?: JsonObject | null;
 }
 
 export interface RecommendationResponse {
@@ -42,11 +36,7 @@ export interface RecommendationResponse {
   recommendations: RecommendationItem[];
   total_candidates: number;
   processing_time_ms: number;
-  /**
-   * Backend emits configuration details for debugging.
-   * TODO: document expected shape and replace with strong types.
-   */
-  recommendation_config: Record<string, unknown>;
+  recommendation_config: JsonObject;
   generated_at: string;
 }
 
@@ -56,7 +46,7 @@ export interface PromptRecommendationRequest {
   limit?: number;
   include_explanations?: boolean;
   style_preference?: string | null;
-  technical_requirements?: Record<string, unknown> | null;
+  technical_requirements?: JsonObject | null;
 }
 
 export interface SimilarityRequest {


### PR DESCRIPTION
## Summary
- add shared JSON primitives and update generation/delivery types to mirror backend schemas
- introduce import/export and backup history types and refactor related workflows to use typed payloads
- tighten job queue transport/polling to consume typed GenerationJobStatus records from the API

## Testing
- npm run test:unit

------
https://chatgpt.com/codex/tasks/task_e_68d3af070b848329b45e6129f7d36a17