### PR TITLE
Fix analytics auth and history routes

### DIFF
--- a/app/frontend/src/services/analytics/analyticsService.ts
+++ b/app/frontend/src/services/analytics/analyticsService.ts
@@ -1,5 +1,6 @@
 import { getFilenameFromContentDisposition, requestBlob } from '@/utils/api';
 import { resolveBackendUrl } from '@/utils/backend';
+import { buildAuthenticatedHeaders } from '@/utils/httpAuth';
 
 import type {
   AnalyticsExportOptions,
@@ -110,7 +111,10 @@ export const fetchPerformanceAnalytics = async (
   const separator = base.includes('?') ? '&' : '?';
   const targetUrl = `${base}${separator}time_range=${encodeURIComponent(timeRange)}`;
 
-  const response = await fetch(targetUrl, { credentials: 'same-origin' });
+  const response = await fetch(targetUrl, {
+    credentials: 'same-origin',
+    headers: buildAuthenticatedHeaders(),
+  });
   if (!response.ok) {
     const error = await response.text().catch(() => response.statusText);
     throw new Error(error || 'Failed to fetch analytics summary');


### PR DESCRIPTION
## Summary
- send the configured API key with analytics summary requests so the secured endpoint loads
- update the history service helpers to call the /generation/results routes that the backend now exposes

## Testing
- npm run test:unit

------
https://chatgpt.com/codex/tasks/task_e_68d4087a77c4832982e9e66aac0b185f