### PR TITLE
Adjust importer status logic and restore import/export tests

### DIFF
--- a/tests/integration/test_import_export_routes.py
+++ b/tests/integration/test_import_export_routes.py
@@ -37,21 +37,126 @@ def _build_archive_bytes(db_session) -> bytes:
 
 
 def test_export_endpoint_streams_archive(client, db_session, tmp_path, dist_dir):
+    weights_path = tmp_path / "alpha.safetensors"
+    weights_path.write_bytes(b"alpha-weights")
+    _create_adapter(db_session, weights_path)
+
+    response = client.post(
+        "/api/v1/export",
+        json={"loras": True, "format": "zip"},
+    )
+
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("application/zip")
+    assert "Content-Disposition" in response.headers
+
+    archive = zipfile.ZipFile(io.BytesIO(response.content))
+    names = archive.namelist()
+    assert "manifest.json" in names
+
+    manifest = json.loads(archive.read("manifest.json"))
+    assert manifest["adapter_count"] == 1
+    assert manifest["adapters"]
+    assert any(name.endswith("alpha.safetensors") for name in names)
 
 
 def test_export_estimate_endpoint_reflects_current_data(
     client, db_session, tmp_path, dist_dir
 ):
+    weights_path = tmp_path / "beta.safetensors"
+    weights_path.write_bytes(b"beta-weights")
+    _create_adapter(db_session, weights_path)
+
+    response = client.post(
+        "/api/v1/export/estimate",
+        json={"loras": True, "format": "zip"},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["size"]
+    assert payload["size"] != "0 Bytes"
+    assert payload["time"] != "0 seconds"
 
 
 def test_import_endpoint_creates_adapter(
     client, db_session, tmp_path, monkeypatch, dist_dir
 ):
+    monkeypatch.setattr(settings, "IMPORT_PATH", str(dist_dir))
+
+    weights_path = tmp_path / "gamma.safetensors"
+    weights_path.write_bytes(b"gamma-weights")
+    original = _create_adapter(db_session, weights_path)
+    archive_bytes = _build_archive_bytes(db_session)
+
+    # Simulate importing into an empty database
+    for adapter in db_session.exec(select(Adapter)).all():
+        db_session.delete(adapter)
+    db_session.commit()
+
+    files = [
+        ("files", ("export.zip", io.BytesIO(archive_bytes), "application/zip")),
+    ]
+    data = {
+        "config": json.dumps(
+            {"mode": "merge", "validate": True, "backup_before": False}
+        )
+    }
+
+    response = client.post(
+        "/api/v1/import",
+        files=files,
+        data=data,
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["success"] is True
+    assert payload["processed_files"] == 1
+    assert payload["results"][0]["status"] == "imported"
+
+    adapters = db_session.exec(select(Adapter)).all()
+    assert len(adapters) == 1
+    stored = adapters[0]
+    assert stored.name == original.name
+    assert stored.primary_file_local_path
+    extracted_path = Path(stored.primary_file_local_path)
+    assert extracted_path.exists()
+    assert dist_dir in extracted_path.parents
 
 
 def test_import_endpoint_rejects_invalid_archive(
     client, db_session, tmp_path, monkeypatch, dist_dir
 ):
+    monkeypatch.setattr(settings, "IMPORT_PATH", str(dist_dir))
+
+    invalid_stream = io.BytesIO()
+    with zipfile.ZipFile(invalid_stream, "w") as archive:
+        archive.writestr("README.txt", "missing manifest")
+    invalid_stream.seek(0)
+
+    files = [
+        ("files", ("invalid.zip", invalid_stream, "application/zip")),
+    ]
+    data = {
+        "config": json.dumps(
+            {"mode": "merge", "validate": True, "backup_before": False}
+        )
+    }
+
+    response = client.post(
+        "/api/v1/import",
+        files=files,
+        data=data,
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["success"] is False
+    assert payload["processed_files"] == 0
+    assert payload["results"][0]["status"] == "error"
+    assert "manifest" in payload["results"][0]["detail"].lower()
+    assert db_session.exec(select(Adapter)).all() == []
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary
- soften importer staleness checks by tracking recent activity counts and allowing a grace buffer before flagging inactivity
- restore the import/export integration suite to hit the live API, using the `dist_dir` fixture and covering export streaming, estimate responses, successful imports, and invalid archives

## Testing
- pytest tests/services/test_system_service.py::test_system_status_reports_extended_fields -q
- pytest tests/integration/test_import_export_routes.py -q

------
https://chatgpt.com/codex/tasks/task_e_68d4267a0e6c83298b4a148d0c4bd761