### PR TITLE
Refine system status defaults and align admin metrics

### DIFF
--- a/app/frontend/src/components/system/SystemAdminStatusCard.vue
+++ b/app/frontend/src/components/system/SystemAdminStatusCard.vue
@@ -145,15 +145,23 @@
             </div>
             <div class="text-sm text-gray-500">Overall Status</div>
           </div>
-          <div class="text-center">
-            <div class="text-2xl font-bold text-blue-600">{{ systemStats.active_workers }}</div>
+          <div v-if="hasWorkerStats" class="text-center">
+            <div class="text-2xl font-bold text-blue-600">{{ activeWorkersLabel }}</div>
             <div class="text-sm text-gray-600">Active Workers</div>
-            <div class="text-xs text-gray-500">{{ systemStats.total_workers }} total</div>
+            <div class="text-xs text-gray-500">{{ totalWorkersLabel }}</div>
           </div>
-          <div class="text-center">
-            <div class="text-2xl font-bold text-purple-600">{{ formatSize(systemStats.database_size) }}</div>
+          <div v-else class="text-center text-gray-500">
+            <div class="text-lg font-semibold">N/A</div>
+            <div class="text-sm">Worker metrics unavailable</div>
+          </div>
+          <div v-if="hasDatabaseStats" class="text-center">
+            <div class="text-2xl font-bold text-purple-600">{{ databaseSizeLabel }}</div>
             <div class="text-sm text-gray-600">Database Size</div>
-            <div class="text-xs text-gray-500">{{ systemStats.total_records }} records</div>
+            <div class="text-xs text-gray-500">{{ totalRecordsLabel }}</div>
+          </div>
+          <div v-else class="text-center text-gray-500">
+            <div class="text-lg font-semibold">N/A</div>
+            <div class="text-sm">Database metrics unavailable</div>
           </div>
         </div>
       </div>
@@ -192,8 +200,8 @@ const statusLevel = computed<SystemStatusLevel>(() => status.value ?? 'unknown')
 const errorMessage = computed(() => (error.value ? error.value.message : null));
 
 const formatSize = (bytes: number | null | undefined): string => {
-  if (!bytes || bytes <= 0) {
-    return '0 Bytes';
+  if (typeof bytes !== 'number' || !Number.isFinite(bytes) || bytes <= 0) {
+    return 'N/A';
   }
   const k = 1024;
   const sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB'];
@@ -201,6 +209,36 @@ const formatSize = (bytes: number | null | undefined): string => {
   const value = bytes / k ** i;
   return `${value.toFixed(2)} ${sizes[i]}`;
 };
+
+const hasWorkerStats = computed(() => {
+  const value = systemStats.value;
+  return value.active_workers != null || value.total_workers != null;
+});
+
+const hasDatabaseStats = computed(() => {
+  const value = systemStats.value;
+  return value.database_size != null || value.total_records != null;
+});
+
+const activeWorkersLabel = computed(() =>
+  systemStats.value.active_workers != null ? systemStats.value.active_workers : 'N/A',
+);
+
+const totalWorkersLabel = computed(() => {
+  if (systemStats.value.total_workers == null) {
+    return 'N/A';
+  }
+  return `${systemStats.value.total_workers} total`;
+});
+
+const databaseSizeLabel = computed(() => formatSize(systemStats.value.database_size));
+
+const totalRecordsLabel = computed(() => {
+  if (systemStats.value.total_records == null) {
+    return 'N/A';
+  }
+  return `${systemStats.value.total_records} records`;
+});
 
 const getStatusIcon = (status: SystemStatusLevel): string => {
   switch (status) {

--- a/app/frontend/src/stores/generation/connection.ts
+++ b/app/frontend/src/stores/generation/connection.ts
@@ -5,16 +5,20 @@ import { DEFAULT_POLL_INTERVAL } from '@/services';
 import type { SystemStatusPayload, SystemStatusState } from '@/types';
 
 export const DEFAULT_SYSTEM_STATUS: SystemStatusState = {
-  gpu_available: true,
+  gpu_available: false,
   queue_length: 0,
-  status: 'healthy',
-  gpu_status: 'Available',
+  status: 'unknown',
+  gpu_status: 'Unknown',
   memory_used: 0,
-  memory_total: 8192,
+  memory_total: 0,
 };
 
+export const createDefaultSystemStatus = (): SystemStatusState => ({
+  ...DEFAULT_SYSTEM_STATUS,
+});
+
 export const useGenerationConnectionStore = defineStore('generation-connection', () => {
-  const systemStatus = reactive<SystemStatusState>({ ...DEFAULT_SYSTEM_STATUS });
+  const systemStatus = reactive<SystemStatusState>(createDefaultSystemStatus());
   const isConnected = ref(false);
   const pollIntervalMs = ref(DEFAULT_POLL_INTERVAL);
 
@@ -32,7 +36,7 @@ export const useGenerationConnectionStore = defineStore('generation-connection',
   }
 
   function resetSystemStatus(): void {
-    Object.assign(systemStatus, { ...DEFAULT_SYSTEM_STATUS });
+    Object.assign(systemStatus, createDefaultSystemStatus());
   }
 
   function applySystemStatusPayload(payload: SystemStatusPayload | Partial<SystemStatusState>): void {

--- a/app/frontend/src/types/system.ts
+++ b/app/frontend/src/types/system.ts
@@ -80,10 +80,10 @@ export interface SystemStatusOverview {
 
 export interface SystemResourceStatsSummary {
   uptime: string;
-  active_workers: number;
-  total_workers: number;
-  database_size: number;
-  total_records: number;
+  active_workers: number | null;
+  total_workers: number | null;
+  database_size: number | null;
+  total_records: number | null;
   gpu_memory_used: string;
   gpu_memory_total: string;
 }

--- a/app/frontend/src/utils/systemMetrics.ts
+++ b/app/frontend/src/utils/systemMetrics.ts
@@ -9,10 +9,10 @@ const BYTE_UNITS = ['Bytes', 'KB', 'MB', 'GB', 'TB'];
 const DEFAULT_STATUS: SystemStatusLevel = 'unknown';
 const DEFAULT_STATS: SystemResourceStatsSummary = {
   uptime: 'N/A',
-  active_workers: 0,
-  total_workers: 0,
-  database_size: 0,
-  total_records: 0,
+  active_workers: null,
+  total_workers: null,
+  database_size: null,
+  total_records: null,
   gpu_memory_used: 'N/A',
   gpu_memory_total: 'N/A',
 };
@@ -98,6 +98,14 @@ export const mergeStatusLevels = (
   return DEFAULT_STATUS;
 };
 
+const toOptionalNumber = (value: unknown): number | null => {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    return null;
+  }
+
+  return value;
+};
+
 export const buildResourceStats = (
   summary: DashboardStatsSummary | null,
   metrics: SystemMetricsSnapshot,
@@ -105,10 +113,10 @@ export const buildResourceStats = (
   const next: SystemResourceStatsSummary = { ...DEFAULT_STATS };
   const stats = summary?.stats ?? null;
 
-  next.total_records = stats?.total_loras ?? 0;
-  next.active_workers = (stats as Record<string, number | undefined>)?.active_workers ?? 0;
-  next.total_workers = (stats as Record<string, number | undefined>)?.total_workers ?? 0;
-  next.database_size = (stats as Record<string, number | undefined>)?.database_size ?? 0;
+  next.total_records = toOptionalNumber((stats as Record<string, unknown>)?.total_loras);
+  next.active_workers = toOptionalNumber((stats as Record<string, unknown>)?.active_workers);
+  next.total_workers = toOptionalNumber((stats as Record<string, unknown>)?.total_workers);
+  next.database_size = toOptionalNumber((stats as Record<string, unknown>)?.database_size);
   next.gpu_memory_used = formatBytes(metrics.memory_used);
   next.gpu_memory_total = formatBytes(metrics.memory_total);
 

--- a/tests/vue/SystemStatusCard.spec.js
+++ b/tests/vue/SystemStatusCard.spec.js
@@ -58,7 +58,7 @@ describe('SystemStatusCard.vue', () => {
     expect(wrapper.text()).toContain('Real-time status is unavailable; showing default values.');
     expect(wrapper.text()).toContain('Last update:');
     expect(wrapper.text()).toContain('0 jobs');
-    expect(wrapper.text()).toContain('2.0GB / 8.0GB (25%)');
+    expect(wrapper.text()).toContain('Unknown');
 
     wrapper.unmount();
   });


### PR DESCRIPTION
## Summary
- centralize the generation system status defaults in the Pinia store and update the polling composable to reset to neutral values when the backend is unavailable
- adjust the admin status card to hide worker/database slots when data is missing and format unknown sizes as N/A rather than optimistic numbers
- relax admin metric typings/utilities and refresh the system status card test expectations for the new fallback behaviour

## Testing
- npm run test:unit

------
https://chatgpt.com/codex/tasks/task_e_68d42f343ed08329880b359625450152