### PR TITLE
Clarify experimental areas in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,17 +32,28 @@ experience comes from enabling the optional dependencies:
 - **Prompt composition** – Compose active adapters into prompts with optional
   delivery orchestration.【F:backend/api/v1/compose.py†L1-L45】【F:backend/services/composition.py†L1-L128】
 - **Generation pipeline** – Immediate and queued SDNext jobs with WebSocket
-  telemetry and history presenters.【F:backend/api/v1/generation.py†L1-L373】【F:backend/services/generation/__init__.py†L1-L92】【F:backend/api/v1/websocket.py†L1-L55】
+  telemetry and history presenters.【F:backend/api/v1/generation/__init__.py†L1-L11】【F:backend/api/v1/generation/jobs.py†L1-L52】【F:backend/api/v1/generation/results.py†L1-L63】【F:backend/services/generation/__init__.py†L1-L93】
 - **Import/export and backups** – Estimate, stream, and ingest archives plus
   backup scheduling helpers exposed through dedicated endpoints.【F:backend/api/v1/import_export.py†L1-L115】【F:backend/services/archive/__init__.py†L1-L84】
 - **Analytics dashboard data** – Aggregated KPIs, error breakdowns, and time
   series built from delivery history.【F:backend/api/v1/analytics.py†L1-L48】【F:backend/services/analytics/service.py†L1-L129】
 - **AI-powered recommendations** – Similar-LoRA and prompt-based suggestions via
-  the recommendation service facade.【F:backend/services/recommendations/service.py†L1-L111】【F:backend/api/v1/recommendations.py†L1-L134】
+  the recommendation service facade.【F:backend/services/recommendations/service.py†L1-L119】【F:backend/api/v1/recommendations.py†L1-L118】
 - **Vue 3 SPA** – Route-based views for dashboards, galleries, history, and
   admin panels backed by Pinia stores and composables.【F:app/frontend/src/router/index.ts†L1-L54】【F:app/frontend/src/views/DashboardView.vue†L1-L49】
 - **Offline-friendly frontend** – A service worker caches the compiled SPA for
-  basic offline support.【F:app/frontend/static/sw.js†L1-L88】
+  basic offline support.【F:app/frontend/static/sw.js†L1-L90】
+
+## Experimental features
+
+- **Real-time progress WebSocket** – `/api/v1/ws/progress` broadcasts job
+  updates through a dedicated WebSocket service, but the feature still lacks
+  broad load testing and hardened error recovery, so treat it as
+  experimental.【F:backend/api/v1/websocket.py†L1-L43】【F:backend/services/websocket/service.py†L1-L95】【F:docs/WEBSOCKET_IMPLEMENTATION.md†L120-L149】
+- **Recommendation pipeline** – Endpoints are wired to the async recommendation
+  service, yet production-quality behaviour depends on optional GPU-accelerated
+  embeddings and several manual setup steps described in the design doc. Expect
+  degraded results without that configuration.【F:backend/services/recommendations/service.py†L1-L119】【F:docs/RECOMMENDATION_MODEL_DESIGN.md†L7-L24】
 
 ## Getting started
 

--- a/docs/IMPLEMENTATION_COMPLETE.md
+++ b/docs/IMPLEMENTATION_COMPLETE.md
@@ -13,7 +13,7 @@ that are tracked for future work.
   activation workflows exposed via the adapter router and service facade.【F:backend/models/adapters.py†L1-L46】【F:backend/api/v1/adapters.py†L1-L151】
 - **Prompt composition & generation** – Composition helpers and SDNext-backed
   generation endpoints handle immediate and queued jobs with WebSocket
-  broadcasting and presenter utilities for history/results views.【F:backend/services/composition.py†L1-L128】【F:backend/api/v1/generation.py†L1-L373】【F:backend/api/v1/websocket.py†L1-L55】
+  broadcasting and presenter utilities for history/results views.【F:backend/services/composition.py†L1-L128】【F:backend/api/v1/generation/__init__.py†L1-L11】【F:backend/api/v1/generation/live.py†L1-L60】【F:backend/api/v1/generation/jobs.py†L1-L52】【F:backend/api/v1/generation/results.py†L1-L63】【F:backend/api/v1/websocket.py†L1-L43】
 - **Import/export & backups** – Archive planner/executor, import validation, and
   backup helpers surface through the `/v1/export`, `/v1/import`, and `/v1/backups`
   endpoints.【F:backend/services/archive/__init__.py†L1-L84】【F:backend/api/v1/import_export.py†L1-L115】
@@ -25,7 +25,7 @@ that are tracked for future work.
   update management.【F:app/frontend/src/router/index.ts†L1-L54】【F:app/frontend/src/views/DashboardView.vue†L1-L49】【F:app/frontend/static/sw.js†L1-L88】
 - **Testing scaffolding** – Pytest suites cover services and APIs, Vitest covers
   components/composables, and Playwright exercises end-to-end flows. Commands
-  live in `package.json` and `tests/README.md`.【F:package.json†L5-L31】【F:tests/README.md†L70-L140】
+  live in `package.json` and `tests/README.md`.【F:package.json†L5-L31】【F:tests/README.md†L70-L138】
 
 ## Requires configuration or optional dependencies
 
@@ -50,7 +50,8 @@ that are tracked for future work.
 - **Extended SDNext features** – img2img, ControlNet, retries, and richer error
   handling are future targets for the generation pipeline.【F:backend/delivery/sdnext.py†L52-L138】
 - **Recommendation persistence** – Feedback endpoints and advanced analytics are
-  scaffolds awaiting backing stores and ML fine-tuning.
+  scaffolds awaiting backing stores and ML fine-tuning; the ML pipeline still
+  requires manual configuration to hit production targets.【F:docs/RECOMMENDATION_MODEL_DESIGN.md†L7-L24】
 - **Operational hardening** – Production runbooks should cover Redis, SDNext,
   worker processes, and monitoring/alerting integrations.
 - **Test coverage tuning** – Several suites depend on optional infrastructure;

--- a/docs/RECOMMENDATION_MODEL_DESIGN.md
+++ b/docs/RECOMMENDATION_MODEL_DESIGN.md
@@ -6,7 +6,7 @@ This document outlines the architecture for an intelligent LoRA recommendation s
 
 The system uses a multi-stage, GPU-accelerated pipeline to generate, analyze, and compare LoRA embeddings, providing fast and accurate recommendations.
 
-> **Reality check:** The live codebase only implements a subset of this plan. The `RecommendationService` stubs out many of these steps and requires manual model setup; production performance numbers listed here are design targets rather than measured results.【F:backend/services/recommendations/service.py†L1-L153】
+> **Reality check:** The live codebase only implements a subset of this plan. The `RecommendationService` stubs out many of these steps and requires manual model setup; production performance numbers listed here are design targets rather than measured results.【F:backend/services/recommendations/service.py†L1-L119】
 
 ---
 

--- a/docs/WEBSOCKET_IMPLEMENTATION.md
+++ b/docs/WEBSOCKET_IMPLEMENTATION.md
@@ -18,12 +18,12 @@ The WebSocket implementation provides a way for clients to receive live updates 
 
 The implementation consists of three main components:
 
-1.  **`ConnectionManager` (`backend/services/websocket.py`)**:
+1.  **`ConnectionManager` (`backend/services/websocket/connection_manager.py`)**:
     -   Manages all active WebSocket connections.
     -   Handles client subscriptions to specific job IDs.
     -   Broadcasts messages to relevant subscribed clients.
 
-2.  **`WebSocketService` (`backend/services/websocket.py`)**:
+2.  **`WebSocketService` (`backend/services/websocket/service.py`)**:
     -   The core service that orchestrates WebSocket functionality.
     -   Starts and stops background tasks to poll for job progress from the SD.Next API.
     -   Handles incoming client messages (e.g., subscription requests).
@@ -139,7 +139,7 @@ delivery infrastructure is hardened.
   via the main app) delegate to the shared `WebSocketService`, which subscribes
   to delivery and generation updates.【F:backend/api/v1/websocket.py†L1-L43】
 - ✅ The service layer can start and stop job monitors, broadcasting structured
-  events as jobs transition states.【F:backend/services/websocket.py†L1-L200】
+  events as jobs transition states.【F:backend/services/websocket/service.py†L1-L95】【F:backend/services/websocket/job_monitor.py†L1-L120】
 - ⚠️ Load and failure-mode testing is limited; queue backpressure and
   disconnect handling still need real-world validation alongside the delivery
   worker.【F:backend/services/deliveries.py†L16-L205】


### PR DESCRIPTION
## Summary
- update README feature list to reference the current generation modules and call out experimental WebSocket and recommendation areas
- align implementation status and design docs with the updated module layout and recommendation reality check
- fix WebSocket documentation paths and cite the correct service and monitor modules

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68d4320d9d1c8329bab032f5dc469b59