### PR TITLE
refactor: migrate service worker to workbox

### DIFF
--- a/app/frontend/static/sw.js
+++ b/app/frontend/static/sw.js
@@ -1,518 +1,390 @@
 /**
  * LoRA Manager Service Worker
- * Provides offline functionality, caching, and background sync
+ *
+ * The previous implementation manually coordinated multiple cache buckets,
+ * custom fetch handlers, and background sync plumbing. It was powerful but
+ * difficult to evolve safely as new routes or assets were introduced. This
+ * rewrite embraces Workbox so cache names, strategies, and fallbacks live in
+ * one place and are easier to update.
  */
 
-const CACHE_NAME = 'lora-manager-v2.1.0';
-const STATIC_CACHE = 'lora-manager-static-v2.1.0';
-const DYNAMIC_CACHE = 'lora-manager-dynamic-v2.1.0';
-const IMAGES_CACHE = 'lora-manager-images-v2.1.0';
+/* eslint-disable no-undef */
 
-// Files to cache for offline use
+importScripts('https://storage.googleapis.com/workbox-cdn/releases/6.5.4/workbox-sw.js');
+
+// Disable noisy Workbox logs in production builds.
+self.__WB_DISABLE_DEV_LOGS = true;
+
+const SW_VERSION = '2.1.0';
+const CACHE_PREFIX = 'lora-manager';
+
+const OFFLINE_PAGE = '/offline';
 const STATIC_ASSETS = [
-    '/',
-    '/loras',
-    '/recommendations',
-    '/compose',
-    '/generate',
-    '/admin',
-    '/analytics',
-    '/import-export',
-    '/static/images/logo.svg',
-    '/static/manifest.json'
+  '/',
+  '/loras',
+  '/recommendations',
+  '/compose',
+  '/generate',
+  '/admin',
+  '/analytics',
+  '/import-export',
+  '/static/images/logo.svg',
+  '/static/manifest.json',
+  OFFLINE_PAGE,
 ];
 
-// API endpoints that should work offline with cached data
-const OFFLINE_API_ENDPOINTS = [
-    '/api/v1/adapters',
-    '/api/v1/recommendations',
-    '/api/v1/analytics/summary',
-    '/api/v1/system/status'
-];
+const PLACEHOLDER_IMAGE = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==';
 
-// Network-first strategies for these patterns
-const NETWORK_FIRST_PATTERNS = [
-    /\/api\/v1\/generation\//,
-    /\/api\/v1\/workers\//,
-    /\/api\/v1\/system\/real-time/
-];
+if (typeof workbox === 'undefined') {
+  console.error('[SW] Workbox failed to load. Offline support disabled.');
+} else {
+  workbox.setConfig({ debug: false });
+  workbox.core.setCacheNameDetails({
+    prefix: CACHE_PREFIX,
+    suffix: SW_VERSION,
+    precache: 'precache',
+    runtime: 'runtime',
+  });
 
-// Cache-first strategies for these patterns  
-const CACHE_FIRST_PATTERNS = [
-    /\.(?:js|css|png|jpg|jpeg|svg|gif|woff2?|ttf|eot)$/,
-    /\/static\//
-];
+  workbox.core.skipWaiting();
+  workbox.core.clientsClaim();
 
-self.addEventListener('install', (event) => {
-    console.log('[SW] Installing Service Worker');
-    
-    event.waitUntil(
-        Promise.all([
-            // Cache static assets
-            caches.open(STATIC_CACHE).then((cache) => {
-                console.log('[SW] Caching static assets');
-                return cache.addAll(STATIC_ASSETS);
-            }),
-            
-            // Cache offline page
-            caches.open(DYNAMIC_CACHE).then((cache) => {
-                return cache.add('/offline');
-            })
-        ]).then(() => {
-            console.log('[SW] Installation complete');
-            return self.skipWaiting();
-        }).catch((error) => {
-            console.error('[SW] Installation failed:', error);
-        })
-    );
-});
+  const CACHE_NAMES = {
+    precache: workbox.core.cacheNames.precache,
+    runtime: workbox.core.cacheNames.runtime,
+    pages: `${CACHE_PREFIX}-pages-${SW_VERSION}`,
+    api: `${CACHE_PREFIX}-api-${SW_VERSION}`,
+    images: `${CACHE_PREFIX}-images-${SW_VERSION}`,
+  };
 
-self.addEventListener('activate', (event) => {
-    console.log('[SW] Activating Service Worker');
-    
-    event.waitUntil(
-        Promise.all([
-            // Clean up old caches
-            caches.keys().then((cacheNames) => {
-                return Promise.all(
-                    cacheNames.map((cacheName) => {
-                        if (cacheName !== STATIC_CACHE && 
-                            cacheName !== DYNAMIC_CACHE && 
-                            cacheName !== IMAGES_CACHE) {
-                            console.log('[SW] Deleting old cache:', cacheName);
-                            return caches.delete(cacheName);
-                        }
-                    })
-                );
-            }),
-            
-            // Take control of all pages
-            self.clients.claim()
-        ]).then(() => {
-            console.log('[SW] Activation complete');
-        })
-    );
-});
+  const precacheManifest = STATIC_ASSETS.map((url) => ({ url, revision: SW_VERSION }));
+  workbox.precaching.precacheAndRoute(precacheManifest);
+  workbox.precaching.cleanupOutdatedCaches();
 
-self.addEventListener('fetch', (event) => {
+  const pageStrategy = new workbox.strategies.NetworkFirst({
+    cacheName: CACHE_NAMES.pages,
+    networkTimeoutSeconds: 3,
+    plugins: [new workbox.cacheableResponse.CacheableResponsePlugin({ statuses: [200] })],
+  });
+
+  workbox.routing.registerRoute(
+    ({ request }) => request.mode === 'navigate',
+    async ({ event }) => {
+      try {
+        return await pageStrategy.handle({ event, request: event.request });
+      } catch (error) {
+        console.warn('[SW] Falling back to offline page for navigation:', error);
+        return (await caches.match(OFFLINE_PAGE)) || createOfflineResponse();
+      }
+    },
+  );
+
+  const apiStrategy = new workbox.strategies.NetworkFirst({
+    cacheName: CACHE_NAMES.api,
+    networkTimeoutSeconds: 5,
+    plugins: [
+      new workbox.cacheableResponse.CacheableResponsePlugin({ statuses: [0, 200] }),
+      {
+        async handlerDidError({ request }) {
+          return createOfflineAPIResponse(new URL(request.url).pathname);
+        },
+      },
+    ],
+  });
+
+  workbox.routing.registerRoute(
+    ({ url, request }) => url.pathname.startsWith('/api/v1/') && request.method === 'GET',
+    ({ event }) => apiStrategy.handle({ event, request: event.request }),
+  );
+
+  const staticAssetStrategy = new workbox.strategies.StaleWhileRevalidate({
+    cacheName: CACHE_NAMES.runtime,
+    plugins: [new workbox.cacheableResponse.CacheableResponsePlugin({ statuses: [0, 200] })],
+  });
+
+  workbox.routing.registerRoute(
+    ({ request, url }) => {
+      if (request.destination && ['script', 'style', 'font'].includes(request.destination)) {
+        return true;
+      }
+      return url.pathname.startsWith('/static/');
+    },
+    staticAssetStrategy,
+  );
+
+  const imageStrategy = new workbox.strategies.CacheFirst({
+    cacheName: CACHE_NAMES.images,
+    plugins: [
+      new workbox.cacheableResponse.CacheableResponsePlugin({ statuses: [0, 200] }),
+      new workbox.expiration.ExpirationPlugin({ maxEntries: 128, maxAgeSeconds: 30 * 24 * 60 * 60 }),
+      {
+        async handlerDidError() {
+          return createPlaceholderImage();
+        },
+      },
+    ],
+  });
+
+  workbox.routing.registerRoute(({ request }) => request.destination === 'image', imageStrategy);
+
+  workbox.routing.setCatchHandler(async ({ event }) => {
     const { request } = event;
-    const url = new URL(request.url);
-    
-    // Skip non-GET requests and chrome-extension requests
-    if (request.method !== 'GET' || url.protocol === 'chrome-extension:') {
-        return;
-    }
-    
-    // Handle different types of requests
-    if (url.pathname.startsWith('/api/v1/')) {
-        event.respondWith(handleAPIRequest(request));
-    } else if (url.pathname.startsWith('/static/images/')) {
-        event.respondWith(handleImageRequest(request));
-    } else if (isCacheFirstResource(request)) {
-        event.respondWith(handleCacheFirst(request));
-    } else if (isNetworkFirstResource(request)) {
-        event.respondWith(handleNetworkFirst(request));
-    } else {
-        event.respondWith(handlePageRequest(request));
-    }
-});
 
-/**
- * Handle API requests with network-first strategy and offline fallback
- */
-async function handleAPIRequest(request) {
-    const url = new URL(request.url);
-    
-    try {
-        // Try network first
-        const response = await fetch(request);
-        
-        // Cache successful responses
-        if (response.ok) {
-            const cache = await caches.open(DYNAMIC_CACHE);
-            cache.put(request, response.clone());
-        }
-        
-        return response;
-    } catch (error) {
-        // Network failed, try cache
-        const cachedResponse = await caches.match(request);
-        
-        if (cachedResponse) {
-            console.log('[SW] Serving API from cache:', url.pathname);
-            return cachedResponse;
-        }
-        
-        // Return offline API response
-        return createOfflineAPIResponse(url.pathname);
+    if (request.destination === 'document') {
+      return (await caches.match(OFFLINE_PAGE)) || createOfflineResponse();
     }
-}
 
-/**
- * Handle image requests with cache-first strategy
- */
-async function handleImageRequest(request) {
-    const cache = await caches.open(IMAGES_CACHE);
-    const cachedResponse = await cache.match(request);
-    
-    if (cachedResponse) {
-        return cachedResponse;
+    if (request.destination === 'image') {
+      return createPlaceholderImage();
     }
-    
-    try {
-        const response = await fetch(request);
-        if (response.ok) {
-            cache.put(request, response.clone());
-        }
-        return response;
-    } catch (error) {
-        // Return placeholder image for offline
-        return createPlaceholderImage();
+
+    if (request.url.includes('/api/v1/')) {
+      return createOfflineAPIResponse(new URL(request.url).pathname);
     }
-}
 
-/**
- * Handle cache-first resources (CSS, JS, fonts, etc.)
- */
-async function handleCacheFirst(request) {
-    const cachedResponse = await caches.match(request);
-    
-    if (cachedResponse) {
-        return cachedResponse;
-    }
-    
-    try {
-        const response = await fetch(request);
-        if (response.ok) {
-            const cache = await caches.open(STATIC_CACHE);
-            cache.put(request, response.clone());
-        }
-        return response;
-    } catch (error) {
-        console.error('[SW] Failed to fetch cache-first resource:', request.url);
-        throw error;
-    }
-}
+    return createOfflineResponse();
+  });
 
-/**
- * Handle network-first resources (real-time data, etc.)
- */
-async function handleNetworkFirst(request) {
-    try {
-        const response = await fetch(request);
-        
-        if (response.ok) {
-            const cache = await caches.open(DYNAMIC_CACHE);
-            cache.put(request, response.clone());
-        }
-        
-        return response;
-    } catch (error) {
-        const cachedResponse = await caches.match(request);
-        return cachedResponse || createOfflineResponse();
-    }
-}
+  self.addEventListener('activate', (event) => {
+    event.waitUntil(
+      (async () => {
+        const expectedCaches = new Set(Object.values(CACHE_NAMES));
+        const cacheKeys = await caches.keys();
 
-/**
- * Handle page requests with stale-while-revalidate strategy
- */
-async function handlePageRequest(request) {
-    const cache = await caches.open(DYNAMIC_CACHE);
-    const cachedResponse = await cache.match(request);
-    
-    // Return cached version immediately if available
-    if (cachedResponse) {
-        // Update cache in background
-        fetch(request).then((response) => {
-            if (response.ok) {
-                cache.put(request, response.clone());
-            }
-        }).catch(() => {
-            // Ignore network errors for background updates
-        });
-        
-        return cachedResponse;
-    }
-    
-    // No cache, try network
-    try {
-        const response = await fetch(request);
-        
-        if (response.ok) {
-            cache.put(request, response.clone());
-        }
-        
-        return response;
-    } catch (error) {
-        // Network failed and no cache, return offline page
-        return caches.match('/offline') || createOfflineResponse();
-    }
-}
+        await Promise.all(
+          cacheKeys
+            .filter((name) => name.startsWith(`${CACHE_PREFIX}-`) && !expectedCaches.has(name))
+            .map((name) => caches.delete(name)),
+        );
+      })(),
+    );
+  });
 
-/**
- * Check if resource should use cache-first strategy
- */
-function isCacheFirstResource(request) {
-    return CACHE_FIRST_PATTERNS.some(pattern => pattern.test(request.url));
-}
-
-/**
- * Check if resource should use network-first strategy
- */
-function isNetworkFirstResource(request) {
-    return NETWORK_FIRST_PATTERNS.some(pattern => pattern.test(request.url));
-}
-
-/**
- * Create offline API response with cached or default data
- */
-function createOfflineAPIResponse(pathname) {
-    let offlineData = {};
-    
-    switch (pathname) {
-    case '/api/v1/adapters':
-            offlineData = {
-                loras: [],
-                total: 0,
-                message: 'Offline - cached data not available'
-            };
-            break;
-            
-    case '/api/v1/recommendations':
-            offlineData = {
-                recommendations: [],
-                message: 'Offline - recommendations require network connection'
-            };
-            break;
-            
-    case '/api/v1/analytics/summary':
-            offlineData = {
-                metrics: {
-                    total_loras: 0,
-                    total_generations: 0,
-                    cache_hit_rate: 0,
-                    avg_generation_time: 0
-                },
-                message: 'Offline - real-time analytics unavailable'
-            };
-            break;
-            
-    case '/api/v1/system/status':
-            offlineData = {
-                status: 'offline',
-                workers: [],
-                gpu_usage: 0,
-                memory_usage: 0,
-                message: 'System monitoring requires network connection'
-            };
-            break;
-            
-        default:
-            offlineData = {
-                error: 'Offline',
-                message: 'This feature requires an internet connection'
-            };
-    }
-    
-    return new Response(JSON.stringify(offlineData), {
-        status: 200,
-        headers: {
-            'Content-Type': 'application/json',
-            'X-Offline': 'true'
-        }
-    });
-}
-
-/**
- * Create placeholder image for offline use
- */
-function createPlaceholderImage() {
-    // Simple 1x1 transparent PNG
-    const imageData = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==';
-    const bytes = Uint8Array.from(atob(imageData), c => c.charCodeAt(0));
-    
-    return new Response(bytes, {
-        status: 200,
-        headers: {
-            'Content-Type': 'image/png',
-            'X-Offline': 'true'
-        }
-    });
-}
-
-/**
- * Create generic offline response
- */
-function createOfflineResponse() {
-    return new Response('Offline', {
-        status: 503,
-        statusText: 'Service Unavailable',
-        headers: {
-            'Content-Type': 'text/plain',
-            'X-Offline': 'true'
-        }
-    });
-}
-
-// Handle background sync for queued actions
-self.addEventListener('sync', (event) => {
-    console.log('[SW] Background sync triggered:', event.tag);
-    
+  self.addEventListener('sync', (event) => {
     if (event.tag === 'background-sync-loras') {
-        event.waitUntil(syncQueuedActions());
+      event.waitUntil(syncQueuedActions(CACHE_NAMES.runtime));
     }
-});
+  });
 
-/**
- * Sync queued actions when connection is restored
- */
-async function syncQueuedActions() {
-    try {
-        const cache = await caches.open(DYNAMIC_CACHE);
-        const queuedActions = await cache.match('queued-actions');
-        
-        if (queuedActions) {
-            const actions = await queuedActions.json();
-            
-            for (const action of actions) {
-                try {
-                    await fetch(action.url, action.options);
-                    console.log('[SW] Synced queued action:', action.url);
-                } catch (error) {
-                    console.error('[SW] Failed to sync action:', action.url, error);
-                }
-            }
-            
-            // Clear synced actions
-            await cache.delete('queued-actions');
-        }
-    } catch (error) {
-        console.error('[SW] Background sync failed:', error);
-    }
-}
+  self.addEventListener('message', (event) => {
+    const { type, data } = event.data || {};
 
-// Handle push notifications
-self.addEventListener('push', (event) => {
-    if (!event.data) return;
-    
-    const data = event.data.json();
-    const options = {
-        body: data.body,
-        icon: '/static/images/logo.svg',
-        // badge left undefined to avoid missing badge PNG
-        vibrate: [100, 50, 100],
-        data: data.data || {},
-        actions: data.actions || []
-    };
-    
-    event.waitUntil(
-        self.registration.showNotification(data.title, options)
-    );
-});
-
-// Handle notification clicks
-self.addEventListener('notificationclick', (event) => {
-    event.notification.close();
-    
-    const action = event.action;
-    const data = event.notification.data;
-    
-    let url = '/';
-    
-    if (action === 'view') {
-        url = data.url || '/';
-    } else if (action === 'dismiss') {
-        return;
-    }
-    
-    // Use the service worker scoped `self.clients` and guard against missing API
-    event.waitUntil(
-        (async () => {
-            if (self.clients && typeof self.clients.openWindow === 'function') {
-                return self.clients.openWindow(url);
-            }
-            // Fallback: resolve immediately if openWindow isn't available
-            return Promise.resolve();
-        })()
-    );
-});
-
-// Handle messages from main thread
-self.addEventListener('message', (event) => {
-    const { type, data } = event.data;
-    
     switch (type) {
-        case 'SKIP_WAITING':
-            self.skipWaiting();
-            break;
-            
-        case 'QUEUE_ACTION':
-            queueAction(data);
-            break;
-            
-        case 'CLEAR_CACHE':
-            clearAllCaches();
-            break;
-            
-        case 'GET_CACHE_STATUS':
-            getCacheStatus().then(status => {
-                event.ports[0].postMessage(status);
-            });
-            break;
+      case 'SKIP_WAITING':
+        self.skipWaiting();
+        break;
+
+      case 'QUEUE_ACTION':
+        queueAction(data, CACHE_NAMES.runtime);
+        break;
+
+      case 'CLEAR_CACHE':
+        clearAllCaches();
+        break;
+
+      case 'GET_CACHE_STATUS':
+        getCacheStatus().then((status) => {
+          if (event.ports && event.ports[0]) {
+            event.ports[0].postMessage(status);
+          }
+        });
+        break;
+
+      default:
+        break;
     }
+  });
+}
+
+self.addEventListener('push', (event) => {
+  if (!event.data) {
+    return;
+  }
+
+  const data = event.data.json();
+  const options = {
+    body: data.body,
+    icon: '/static/images/logo.svg',
+    vibrate: [100, 50, 100],
+    data: data.data || {},
+    actions: data.actions || [],
+  };
+
+  event.waitUntil(self.registration.showNotification(data.title, options));
 });
 
-/**
- * Queue action for background sync
- */
-async function queueAction(action) {
-    try {
-        const cache = await caches.open(DYNAMIC_CACHE);
-        const existingActions = await cache.match('queued-actions');
-        
-        let actions = [];
-        if (existingActions) {
-            actions = await existingActions.json();
-        }
-        
-        actions.push({
-            ...action,
-            timestamp: Date.now()
-        });
-        
-        await cache.put('queued-actions', new Response(JSON.stringify(actions)));
-        
-        // Register for background sync
-        if ('serviceWorker' in navigator && 'sync' in window.ServiceWorkerRegistration.prototype) {
-            await self.registration.sync.register('background-sync-loras');
-        }
-    } catch (error) {
-        console.error('[SW] Failed to queue action:', error);
-    }
+self.addEventListener('notificationclick', (event) => {
+  event.notification.close();
+
+  const action = event.action;
+  const data = event.notification.data || {};
+
+  let url = '/';
+  if (action === 'view') {
+    url = data.url || '/';
+  } else if (action === 'dismiss') {
+    return;
+  }
+
+  event.waitUntil(
+    (async () => {
+      if (self.clients && typeof self.clients.openWindow === 'function') {
+        return self.clients.openWindow(url);
+      }
+      return Promise.resolve();
+    })(),
+  );
+});
+
+function createOfflineAPIResponse(pathname) {
+  let offlineData = {};
+
+  switch (pathname) {
+    case '/api/v1/adapters':
+      offlineData = {
+        loras: [],
+        total: 0,
+        message: 'Offline - cached data not available',
+      };
+      break;
+
+    case '/api/v1/recommendations':
+      offlineData = {
+        recommendations: [],
+        message: 'Offline - recommendations require network connection',
+      };
+      break;
+
+    case '/api/v1/analytics/summary':
+      offlineData = {
+        metrics: {
+          total_loras: 0,
+          total_generations: 0,
+          cache_hit_rate: 0,
+          avg_generation_time: 0,
+        },
+        message: 'Offline - real-time analytics unavailable',
+      };
+      break;
+
+    case '/api/v1/system/status':
+      offlineData = {
+        status: 'offline',
+        workers: [],
+        gpu_usage: 0,
+        memory_usage: 0,
+        message: 'System monitoring requires network connection',
+      };
+      break;
+
+    default:
+      offlineData = {
+        error: 'Offline',
+        message: 'This feature requires an internet connection',
+      };
+  }
+
+  return new Response(JSON.stringify(offlineData), {
+    status: 200,
+    headers: {
+      'Content-Type': 'application/json',
+      'X-Offline': 'true',
+    },
+  });
 }
 
-/**
- * Clear all caches
- */
+function createPlaceholderImage() {
+  const bytes = Uint8Array.from(atob(PLACEHOLDER_IMAGE), (char) => char.charCodeAt(0));
+  return new Response(bytes, {
+    status: 200,
+    headers: {
+      'Content-Type': 'image/png',
+      'X-Offline': 'true',
+    },
+  });
+}
+
+function createOfflineResponse() {
+  return new Response('Offline', {
+    status: 503,
+    statusText: 'Service Unavailable',
+    headers: {
+      'Content-Type': 'text/plain',
+      'X-Offline': 'true',
+    },
+  });
+}
+
+async function queueAction(action, runtimeCacheName = 'runtime') {
+  if (!action) {
+    return;
+  }
+
+  try {
+    const cache = await caches.open(runtimeCacheName);
+    const existingActions = await cache.match('queued-actions');
+
+    let actions = [];
+    if (existingActions) {
+      actions = await existingActions.json();
+    }
+
+    actions.push({
+      ...action,
+      timestamp: Date.now(),
+    });
+
+    await cache.put('queued-actions', new Response(JSON.stringify(actions)));
+
+    if ('sync' in self.registration) {
+      await self.registration.sync.register('background-sync-loras');
+    }
+  } catch (error) {
+    console.error('[SW] Failed to queue action:', error);
+  }
+}
+
+async function syncQueuedActions(runtimeCacheName = 'runtime') {
+  try {
+    const cache = await caches.open(runtimeCacheName);
+    const queuedActions = await cache.match('queued-actions');
+
+    if (!queuedActions) {
+      return;
+    }
+
+    const actions = await queuedActions.json();
+
+    for (const action of actions) {
+      try {
+        await fetch(action.url, action.options);
+        console.log('[SW] Synced queued action:', action.url);
+      } catch (error) {
+        console.error('[SW] Failed to sync action:', action.url, error);
+      }
+    }
+
+    await cache.delete('queued-actions');
+  } catch (error) {
+    console.error('[SW] Background sync failed:', error);
+  }
+}
+
 async function clearAllCaches() {
-    const cacheNames = await caches.keys();
-    await Promise.all(
-        cacheNames.map(cacheName => caches.delete(cacheName))
-    );
+  const cacheNames = await caches.keys();
+  await Promise.all(cacheNames.map((cacheName) => caches.delete(cacheName)));
 }
 
-/**
- * Get cache status information
- */
 async function getCacheStatus() {
-    const cacheNames = await caches.keys();
-    const status = {};
-    
-    for (const cacheName of cacheNames) {
-        const cache = await caches.open(cacheName);
-        const keys = await cache.keys();
-        status[cacheName] = keys.length;
-    }
-    
-    return status;
+  const cacheNames = await caches.keys();
+  const status = {};
+
+  for (const cacheName of cacheNames) {
+    const cache = await caches.open(cacheName);
+    const keys = await cache.keys();
+    status[cacheName] = keys.length;
+  }
+
+  return status;
 }
+


### PR DESCRIPTION
## Summary
- replace the hand-rolled caching logic with Workbox, centralizing cache naming and strategies for navigation, API, static, and image requests
- keep existing offline fallbacks, push notifications, and queue utilities while cleaning up legacy caches on activation

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d437516e0c8329b6e08bfc317eb3c9