### PR TITLE
Add trigger word recommendation pipeline

### DIFF
--- a/backend/models/recommendations.py
+++ b/backend/models/recommendations.py
@@ -70,6 +70,12 @@ class LoRAEmbedding(SQLModel, table=True):
     popularity_score: Optional[float] = None
     recency_score: Optional[float] = None
     compatibility_score: Optional[float] = None
+    normalized_triggers: list = Field(
+        default_factory=list, sa_column=Column(JSON)
+    )
+    trigger_aliases: dict = Field(default_factory=dict, sa_column=Column(JSON))
+    trigger_embeddings: list = Field(default_factory=list, sa_column=Column(JSON))
+    trigger_metadata: dict = Field(default_factory=dict, sa_column=Column(JSON))
     last_computed: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
     created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
     updated_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))

--- a/backend/schemas/recommendations.py
+++ b/backend/schemas/recommendations.py
@@ -43,6 +43,7 @@ class RecommendationResponse(BaseModel):
 
     target_lora_id: Optional[str] = None
     prompt: Optional[str] = None
+    trigger_query: Optional[str] = None
     recommendations: List[RecommendationItem]
     total_candidates: int
     processing_time_ms: float

--- a/backend/services/providers/recommendations.py
+++ b/backend/services/providers/recommendations.py
@@ -128,6 +128,7 @@ def make_recommendation_service(
         )
     similar_use_case = use_case_bundle.similar_lora
     prompt_use_case = use_case_bundle.prompt_recommendation
+    trigger_use_case = use_case_bundle.trigger_recommendation
 
     embedding_coordinator = embedding_coordinator or EmbeddingCoordinator(
         bootstrap=bootstrap,
@@ -147,6 +148,7 @@ def make_recommendation_service(
         stats_reporter=stats_reporter,
         similar_lora_use_case=similar_use_case,
         prompt_recommendation_use_case=prompt_use_case,
+        trigger_recommendation_use_case=trigger_use_case,
         config=config,
     ).build()
 

--- a/backend/services/recommendations/__init__.py
+++ b/backend/services/recommendations/__init__.py
@@ -24,7 +24,16 @@ from .repository import RecommendationRepository
 from .service import RecommendationService
 from .similarity_index_builder import SimilarityIndexBuilder
 from .stats_reporter import StatsReporter
-from .use_cases import PromptRecommendationUseCase, SimilarLoraUseCase
+from .trigger_engine import (
+    TriggerCandidateResult,
+    TriggerRecommendationEngine,
+    TriggerSearchIndex,
+)
+from .use_cases import (
+    PromptRecommendationUseCase,
+    SimilarLoraUseCase,
+    TriggerRecommendationUseCase,
+)
 
 __all__ = [
     "RecommendationConfig",
@@ -48,6 +57,10 @@ __all__ = [
     "StatsReporter",
     "SimilarLoraUseCase",
     "PromptRecommendationUseCase",
+    "TriggerRecommendationUseCase",
+    "TriggerRecommendationEngine",
+    "TriggerSearchIndex",
+    "TriggerCandidateResult",
     "UseCaseBundle",
     "build_embedding_stack",
     "build_persistence_components",

--- a/backend/services/recommendations/builder.py
+++ b/backend/services/recommendations/builder.py
@@ -10,7 +10,11 @@ from .embedding_coordinator import EmbeddingCoordinator
 from .feedback_manager import FeedbackManager
 from .service import RecommendationService
 from .stats_reporter import StatsReporter
-from .use_cases import PromptRecommendationUseCase, SimilarLoraUseCase
+from .use_cases import (
+    PromptRecommendationUseCase,
+    SimilarLoraUseCase,
+    TriggerRecommendationUseCase,
+)
 
 
 class RecommendationServiceBuilder:
@@ -23,6 +27,7 @@ class RecommendationServiceBuilder:
         self._stats_reporter: Optional[StatsReporter] = None
         self._similar_use_case: Optional[SimilarLoraUseCase] = None
         self._prompt_use_case: Optional[PromptRecommendationUseCase] = None
+        self._trigger_use_case: Optional[TriggerRecommendationUseCase] = None
         self._config: Optional[RecommendationConfig] = None
         self._logger: Optional[logging.Logger] = None
 
@@ -37,6 +42,7 @@ class RecommendationServiceBuilder:
         stats_reporter: StatsReporter,
         similar_lora_use_case: SimilarLoraUseCase,
         prompt_recommendation_use_case: PromptRecommendationUseCase,
+        trigger_recommendation_use_case: TriggerRecommendationUseCase,
         config: RecommendationConfig,
     ) -> "RecommendationServiceBuilder":
         """Set all collaborators explicitly."""
@@ -45,6 +51,7 @@ class RecommendationServiceBuilder:
         self._stats_reporter = stats_reporter
         self._similar_use_case = similar_lora_use_case
         self._prompt_use_case = prompt_recommendation_use_case
+        self._trigger_use_case = trigger_recommendation_use_case
         self._config = config
         return self
 
@@ -70,6 +77,10 @@ class RecommendationServiceBuilder:
             raise ValueError(
                 "prompt_recommendation_use_case must be provided before build()"
             )
+        if self._trigger_use_case is None:
+            raise ValueError(
+                "trigger_recommendation_use_case must be provided before build()"
+            )
         if self._config is None:
             raise ValueError("config must be provided before build()")
 
@@ -79,6 +90,7 @@ class RecommendationServiceBuilder:
             stats_reporter=self._stats_reporter,
             similar_lora_use_case=self._similar_use_case,
             prompt_recommendation_use_case=self._prompt_use_case,
+            trigger_recommendation_use_case=self._trigger_use_case,
             config=self._config,
             logger=self._logger,
         )

--- a/backend/services/recommendations/builders.py
+++ b/backend/services/recommendations/builders.py
@@ -18,7 +18,11 @@ from .interfaces import (
 from .model_registry import RecommendationModelRegistry
 from .persistence_manager import RecommendationPersistenceManager
 from .persistence_service import RecommendationPersistenceService
-from .use_cases import PromptRecommendationUseCase, SimilarLoraUseCase
+from .use_cases import (
+    PromptRecommendationUseCase,
+    SimilarLoraUseCase,
+    TriggerRecommendationUseCase,
+)
 
 
 @dataclass(frozen=True)
@@ -44,6 +48,7 @@ class UseCaseBundle:
 
     similar_lora: SimilarLoraUseCase
     prompt_recommendation: PromptRecommendationUseCase
+    trigger_recommendation: TriggerRecommendationUseCase
 
 
 def build_embedding_stack(
@@ -116,6 +121,7 @@ def build_use_cases(
     device: str,
     similar_use_case: Optional[SimilarLoraUseCase] = None,
     prompt_use_case: Optional[PromptRecommendationUseCase] = None,
+    trigger_use_case: Optional[TriggerRecommendationUseCase] = None,
 ) -> UseCaseBundle:
     """Return high level use cases, defaulting to standard implementations."""
     similar = similar_use_case or SimilarLoraUseCase(
@@ -131,7 +137,14 @@ def build_use_cases(
         device=device,
     )
 
+    trigger = trigger_use_case or TriggerRecommendationUseCase(
+        repository=repository,
+        trigger_engine_provider=model_registry.get_trigger_engine,
+        metrics=metrics_tracker,
+    )
+
     return UseCaseBundle(
         similar_lora=similar,
         prompt_recommendation=prompt,
+        trigger_recommendation=trigger,
     )

--- a/backend/services/recommendations/components/__init__.py
+++ b/backend/services/recommendations/components/__init__.py
@@ -9,6 +9,8 @@ from .interfaces import (
     SemanticEmbedderProtocol,
 )
 from .sentence_transformer_provider import SentenceTransformerProvider
+from .trigger_embedder import TriggerEmbedder
+from .trigger_processing import TriggerResolver
 from .text_payload_builder import MultiModalTextPayloadBuilder
 
 __all__ = [
@@ -20,4 +22,6 @@ __all__ = [
     "LoRASemanticEmbedder",
     "MultiModalTextPayloadBuilder",
     "SentenceTransformerProvider",
+    "TriggerEmbedder",
+    "TriggerResolver",
 ]

--- a/backend/services/recommendations/components/trigger_embedder.py
+++ b/backend/services/recommendations/components/trigger_embedder.py
@@ -1,0 +1,63 @@
+"""Lightweight embedding helper for trigger phrases."""
+
+from __future__ import annotations
+
+import logging
+from typing import Optional, Sequence
+
+import numpy as np
+
+from .sentence_transformer_provider import SentenceTransformerProvider
+
+
+class TriggerEmbedder:
+    """Generate compact embeddings for trigger phrases."""
+
+    MODEL_KEY = "trigger"
+
+    def __init__(
+        self,
+        *,
+        device: str = "cpu",
+        logger: Optional[logging.Logger] = None,
+        provider: Optional[SentenceTransformerProvider] = None,
+    ) -> None:
+        self._logger = logger or logging.getLogger(__name__)
+        configs = {
+            self.MODEL_KEY: {
+                "model_name": "sentence-transformers/all-MiniLM-L6-v2",
+                "default_dim": 384,
+            }
+        }
+        self._provider = provider or SentenceTransformerProvider(
+            device=device,
+            logger=self._logger,
+            force_fallback=False,
+            model_configs=configs,
+        )
+        self.device = self._provider.device
+
+    @property
+    def dimension(self) -> int:
+        """Return the embedding dimension for the trigger encoder."""
+        return int(self._provider.get_dimension(self.MODEL_KEY))
+
+    def encode(self, phrases: Sequence[str]) -> np.ndarray:
+        """Encode ``phrases`` into a 2D numpy array of embeddings."""
+        if not phrases:
+            return np.zeros((0, self.dimension), dtype=np.float32)
+        embeddings = self._provider.encode(self.MODEL_KEY, list(phrases))
+        if embeddings.ndim == 1:
+            embeddings = embeddings.reshape(1, -1)
+        embeddings = np.asarray(embeddings, dtype=np.float32)
+        norms = np.linalg.norm(embeddings, axis=1, keepdims=True)
+        norms[norms == 0] = 1.0
+        return embeddings / norms
+
+    def encode_single(self, phrase: str) -> np.ndarray:
+        """Encode a single phrase returning a 1D vector."""
+        vectors = self.encode([phrase])
+        return vectors[0] if len(vectors) else np.zeros(self.dimension, dtype=np.float32)
+
+
+__all__ = ["TriggerEmbedder"]

--- a/backend/services/recommendations/components/trigger_processing.py
+++ b/backend/services/recommendations/components/trigger_processing.py
@@ -1,0 +1,154 @@
+"""Utilities for normalising and resolving trigger phrases."""
+
+from __future__ import annotations
+
+import re
+import unicodedata
+from collections import Counter, defaultdict
+from dataclasses import dataclass
+from typing import Dict, Iterable, List, Mapping, MutableMapping, Optional, Sequence
+
+DEFAULT_TRIGGER_ALIASES: Mapping[str, str] = {
+    "1girl": "girl",
+    "one girl": "girl",
+    "solo": "solo",
+    "1boy": "boy",
+    "one boy": "boy",
+    "sai": "stable diffusion automatic1111",
+    "sdxl": "stable diffusion xl",
+    "seraphim": "seraph",
+    "angelic": "angel",
+}
+
+
+@dataclass(frozen=True)
+class TriggerCandidate:
+    """Representation of a trigger phrase and its originating source."""
+
+    phrase: str
+    source: str
+
+
+@dataclass(frozen=True)
+class TriggerResolution:
+    """Result of trigger normalisation and alias expansion."""
+
+    canonical: List[str]
+    alias_map: Dict[str, str]
+    confidence: Dict[str, float]
+    sources: Dict[str, List[str]]
+    normalized_query: Optional[str] = None
+
+
+class TriggerResolver:
+    """Normalise trigger phrases and apply alias mappings consistently."""
+
+    def __init__(
+        self,
+        *,
+        alias_overrides: Optional[Mapping[str, str]] = None,
+        minimum_length: int = 2,
+    ) -> None:
+        self._minimum_length = minimum_length
+        self._alias_map: Dict[str, str] = {}
+        self._alias_map.update(DEFAULT_TRIGGER_ALIASES)
+        if alias_overrides:
+            for raw, target in alias_overrides.items():
+                self._alias_map[self._normalise(raw)] = self._normalise(target)
+
+    @staticmethod
+    def _normalise(text: str) -> str:
+        normalized = unicodedata.normalize("NFKC", text or "")
+        normalized = normalized.lower()
+        normalized = re.sub(r"[^a-z0-9\s]+", " ", normalized)
+        normalized = re.sub(r"\s+", " ", normalized).strip()
+        return normalized
+
+    def _filter_phrase(self, phrase: str) -> Optional[str]:
+        cleaned = self._normalise(phrase)
+        if not cleaned:
+            return None
+        if len(cleaned) < self._minimum_length:
+            return None
+        return cleaned
+
+    def resolve(self, candidates: Sequence[TriggerCandidate]) -> TriggerResolution:
+        """Return canonical triggers derived from ``candidates``."""
+        alias_map: Dict[str, str] = {}
+        confidence: Dict[str, float] = {}
+        source_map: MutableMapping[str, List[str]] = defaultdict(list)
+        canonical_counter: Counter[str] = Counter()
+
+        for candidate in candidates:
+            filtered = self._filter_phrase(candidate.phrase)
+            if filtered is None:
+                continue
+            canonical = self._alias_map.get(filtered, filtered)
+            alias_map[filtered] = canonical
+            canonical_counter[canonical] += 1
+            confidence.setdefault(canonical, 0.0)
+            confidence[canonical] = min(1.0, confidence[canonical] + 0.2)
+            source_map[canonical].append(candidate.source)
+
+        ordered_canonical = [
+            trigger
+            for trigger, _ in canonical_counter.most_common()
+        ]
+
+        return TriggerResolution(
+            canonical=ordered_canonical,
+            alias_map=alias_map,
+            confidence={key: round(value or 0.2, 2) for key, value in confidence.items()},
+            sources=dict(source_map),
+        )
+
+    def resolve_query(self, query: str) -> TriggerResolution:
+        """Resolve a user provided query string."""
+        normalized = self._filter_phrase(query)
+        if not normalized:
+            return TriggerResolution(
+                canonical=[], alias_map={}, confidence={}, sources={}, normalized_query=None
+            )
+
+        words = [normalized]
+        if " " in normalized:
+            words.extend(word for word in normalized.split(" ") if len(word) >= self._minimum_length)
+
+        candidates = [TriggerCandidate(phrase=word, source="query") for word in words]
+        resolution = self.resolve(candidates)
+        return TriggerResolution(
+            canonical=resolution.canonical,
+            alias_map=resolution.alias_map,
+            confidence=resolution.confidence,
+            sources=resolution.sources,
+            normalized_query=normalized,
+        )
+
+    def expand_activation_text(self, text: Optional[str]) -> List[TriggerCandidate]:
+        """Split activation text into candidate trigger phrases."""
+        if not text:
+            return []
+        pieces = re.split(r"[\n,;/]+", text)
+        return [TriggerCandidate(phrase=piece.strip(), source="activation_text") for piece in pieces if piece.strip()]
+
+    def build_candidates_from_adapter(
+        self,
+        triggers: Iterable[str],
+        trained_words: Iterable[str],
+        activation_text: Optional[str],
+    ) -> List[TriggerCandidate]:
+        """Collect trigger candidates from adapter metadata."""
+        candidates: List[TriggerCandidate] = []
+        for phrase in triggers:
+            candidates.append(TriggerCandidate(phrase=phrase, source="trigger"))
+        for phrase in trained_words:
+            candidates.append(TriggerCandidate(phrase=phrase, source="trained_word"))
+        candidates.extend(self.expand_activation_text(activation_text))
+        return candidates
+
+
+__all__ = [
+    "TriggerCandidate",
+    "TriggerResolution",
+    "TriggerResolver",
+]

--- a/backend/services/recommendations/embedding_repository.py
+++ b/backend/services/recommendations/embedding_repository.py
@@ -127,4 +127,11 @@ class LoRAEmbeddingRepository:
             "popularity_score": features.get("popularity_score"),
             "recency_score": features.get("recency_score"),
             "compatibility_score": features.get("sd_compatibility_score"),
+            "normalized_triggers": list(features.get("normalized_triggers", [])),
+            "trigger_aliases": dict(features.get("trigger_aliases", {})),
+            "trigger_embeddings": [
+                list(map(float, embedding))
+                for embedding in features.get("trigger_embeddings", [])
+            ],
+            "trigger_metadata": dict(features.get("trigger_metadata", {})),
         }

--- a/backend/services/recommendations/interfaces.py
+++ b/backend/services/recommendations/interfaces.py
@@ -74,6 +74,11 @@ class RecommendationRepository(Protocol):
     def get_embedding(self, adapter_id: str):  # pragma: no cover - Protocol
         """Return the embedding entry for ``adapter_id`` if present."""
 
+    def get_recent_active_adapters(
+        self, limit: int
+    ):  # pragma: no cover - Protocol
+        """Return recently active adapters for deterministic fallbacks."""
+
 
 class EmbeddingWorkflow(Protocol):
     """Contract for embedding computation orchestration."""

--- a/backend/services/recommendations/repository.py
+++ b/backend/services/recommendations/repository.py
@@ -138,6 +138,19 @@ class RecommendationRepository:
         """Return the embedding entry for ``adapter_id`` if present."""
         return self._session.get(LoRAEmbedding, adapter_id)
 
+    def get_recent_active_adapters(self, limit: int) -> List[Adapter]:
+        """Return a deterministic list of recently active adapters."""
+        stmt = (
+            select(Adapter)
+            .where(Adapter.active)
+            .order_by(
+                Adapter.published_at.desc().nullslast(),
+                Adapter.created_at.desc(),
+            )
+            .limit(limit)
+        )
+        return list(self._session.exec(stmt))
+
     def count_active_adapters(self) -> int:
         """Return the number of active adapters."""
         result = self._session.exec(

--- a/backend/services/recommendations/service.py
+++ b/backend/services/recommendations/service.py
@@ -19,6 +19,7 @@ from .stats_reporter import StatsReporter
 from .use_cases import (
     PromptRecommendationUseCase,
     SimilarLoraUseCase,
+    TriggerRecommendationUseCase,
 )
 
 
@@ -33,6 +34,7 @@ class RecommendationService:
         stats_reporter: StatsReporter,
         similar_lora_use_case: SimilarLoraUseCase,
         prompt_recommendation_use_case: PromptRecommendationUseCase,
+        trigger_recommendation_use_case: TriggerRecommendationUseCase,
         config: RecommendationConfig,
         logger: Optional[logging.Logger] = None,
     ) -> None:
@@ -44,6 +46,7 @@ class RecommendationService:
         self._stats_reporter = stats_reporter
         self._similar_lora_use_case = similar_lora_use_case
         self._prompt_recommendation_use_case = prompt_recommendation_use_case
+        self._trigger_recommendation_use_case = trigger_recommendation_use_case
         self._config = config
 
     # ------------------------------------------------------------------
@@ -102,6 +105,18 @@ class RecommendationService:
             limit=limit,
             style_preference=style_preference,
             weights=final_weights,
+        )
+
+    async def recommend_for_trigger(
+        self,
+        *,
+        trigger_query: str,
+        limit: int = 10,
+    ) -> List[RecommendationItem]:
+        """Return LoRA recommendations that match the provided trigger query."""
+        return await self._trigger_recommendation_use_case.execute(
+            trigger_query=trigger_query,
+            limit=limit,
         )
 
     # ------------------------------------------------------------------

--- a/backend/services/recommendations/trigger_engine.py
+++ b/backend/services/recommendations/trigger_engine.py
@@ -1,0 +1,232 @@
+"""Trigger-specific retrieval utilities for the recommendation service."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from threading import RLock
+from typing import Dict, List, Optional, Tuple
+
+import numpy as np
+
+from .components.trigger_embedder import TriggerEmbedder
+from .components.trigger_processing import TriggerResolver
+
+
+@dataclass(frozen=True)
+class TriggerCandidateResult:
+    """Container for intermediate trigger recommendation candidates."""
+
+    adapter_id: str
+    canonical_trigger: Optional[str]
+    final_score: float
+    similarity_score: float
+    explanation: str
+    signals: Dict[str, float]
+
+
+class TriggerSearchIndex:
+    """Maintain an inverted index and embedding cache for triggers."""
+
+    def __init__(
+        self,
+        *,
+        logger: Optional[logging.Logger] = None,
+        max_semantic_candidates: int = 100,
+    ) -> None:
+        self._logger = logger or logging.getLogger(__name__)
+        self._max_semantic_candidates = max_semantic_candidates
+        self._trigger_to_loras: Dict[str, set[str]] = {}
+        self._vector_keys: List[Tuple[str, str]] = []
+        self._vectors: Optional[np.ndarray] = None
+        self._adapter_metadata: Dict[str, Dict[str, object]] = {}
+        self._adapter_count: int = 0
+        self._lock = RLock()
+
+    @property
+    def adapter_metadata(self) -> Dict[str, Dict[str, object]]:
+        """Expose the cached adapter metadata."""
+        return self._adapter_metadata
+
+    def ensure(self, repository, embedder: TriggerEmbedder, resolver: TriggerResolver) -> None:
+        """Ensure the index is populated and in sync with active adapters."""
+        with self._lock:
+            current_count = repository.count_active_adapters()
+            if self._vectors is not None and current_count == self._adapter_count:
+                return
+            self._logger.info("Rebuilding trigger index for %s adapters", current_count)
+            self._rebuild(repository, embedder, resolver)
+            self._adapter_count = current_count
+
+    def _rebuild(self, repository, embedder: TriggerEmbedder, resolver: TriggerResolver) -> None:
+        trigger_to_loras: Dict[str, set[str]] = {}
+        vector_keys: List[Tuple[str, str]] = []
+        vector_payload: List[np.ndarray] = []
+        adapter_metadata: Dict[str, Dict[str, object]] = {}
+
+        records = repository.get_active_loras_with_embeddings()
+        for adapter, embedding in records:
+            triggers = list(getattr(embedding, "normalized_triggers", []) or [])
+            aliases = dict(getattr(embedding, "trigger_aliases", {}) or {})
+            metadata = dict(getattr(embedding, "trigger_metadata", {}) or {})
+            stored_vectors = list(getattr(embedding, "trigger_embeddings", []) or [])
+
+            if not triggers and (adapter.triggers or adapter.activation_text):
+                candidates = resolver.build_candidates_from_adapter(
+                    adapter.triggers or [],
+                    adapter.trained_words or [],
+                    adapter.activation_text,
+                )
+                resolution = resolver.resolve(candidates)
+                triggers = resolution.canonical
+                aliases = resolution.alias_map
+                metadata = {
+                    "confidence": resolution.confidence,
+                    "sources": resolution.sources,
+                }
+
+            if not triggers:
+                continue
+
+            trigger_vectors: List[np.ndarray] = []
+            if stored_vectors and len(stored_vectors) == len(triggers):
+                for vector in stored_vectors:
+                    trigger_vectors.append(np.asarray(vector, dtype=np.float32))
+            else:
+                computed = embedder.encode(triggers)
+                trigger_vectors = [vector for vector in computed]
+
+            for trigger, vector in zip(triggers, trigger_vectors):
+                vector = vector.astype(np.float32)
+                norm = np.linalg.norm(vector)
+                if norm:
+                    vector = vector / norm
+                trigger_to_loras.setdefault(trigger, set()).add(adapter.id)
+                vector_keys.append((adapter.id, trigger))
+                vector_payload.append(vector)
+
+            adapter_metadata[adapter.id] = {
+                "id": adapter.id,
+                "name": adapter.name,
+                "description": adapter.description,
+                "author_username": adapter.author_username,
+                "tags": list(adapter.tags or [])[:5],
+                "sd_version": adapter.sd_version,
+                "nsfw_level": adapter.nsfw_level,
+                "stats": adapter.stats or {},
+                "predicted_style": getattr(embedding, "predicted_style", None),
+                "trigger_aliases": aliases,
+                "trigger_sources": metadata.get("sources", {}),
+                "trigger_confidence": metadata.get("confidence", {}),
+                "normalized_triggers": triggers,
+            }
+
+        if vector_payload:
+            matrix = np.vstack(vector_payload)
+        else:
+            matrix = np.zeros((0, embedder.dimension), dtype=np.float32)
+
+        self._trigger_to_loras = trigger_to_loras
+        self._vector_keys = vector_keys
+        self._vectors = matrix
+        self._adapter_metadata = adapter_metadata
+
+    def search(
+        self,
+        *,
+        query: str,
+        resolver: TriggerResolver,
+        embedder: TriggerEmbedder,
+        limit: int,
+    ) -> List[TriggerCandidateResult]:
+        """Return ranked trigger candidates for ``query``."""
+        if not query:
+            return []
+
+        resolution = resolver.resolve_query(query)
+        scored: Dict[str, TriggerCandidateResult] = {}
+
+        for canonical in resolution.canonical:
+            matches = self._trigger_to_loras.get(canonical, set())
+            for adapter_id in matches:
+                confidence = resolution.confidence.get(canonical, 1.0)
+                explanation = f"Exact trigger match: '{canonical}'"
+                result = TriggerCandidateResult(
+                    adapter_id=adapter_id,
+                    canonical_trigger=canonical,
+                    final_score=1.0 * confidence,
+                    similarity_score=1.0,
+                    explanation=explanation,
+                    signals={"exact": confidence},
+                )
+                existing = scored.get(adapter_id)
+                if existing is None or result.final_score > existing.final_score:
+                    scored[adapter_id] = result
+
+        need_semantic = len(scored) < limit
+        if need_semantic and resolution.normalized_query:
+            query_vector = embedder.encode_single(resolution.normalized_query)
+            if self._vectors is not None and len(self._vectors):
+                similarities = np.dot(self._vectors, query_vector)
+                top_indices = np.argsort(similarities)[::-1][: self._max_semantic_candidates]
+                for idx in top_indices:
+                    adapter_id, trigger = self._vector_keys[idx]
+                    if adapter_id in scored and scored[adapter_id].signals.get("exact"):
+                        continue
+                    similarity = float(similarities[idx])
+                    if similarity <= 0:
+                        continue
+                    explanation = f"Semantic trigger similarity: {similarity:.2f}"
+                    result = TriggerCandidateResult(
+                        adapter_id=adapter_id,
+                        canonical_trigger=trigger,
+                        final_score=similarity,
+                        similarity_score=similarity,
+                        explanation=explanation,
+                        signals={"semantic": similarity},
+                    )
+                    existing = scored.get(adapter_id)
+                    if existing is None or result.final_score > existing.final_score:
+                        scored[adapter_id] = result
+
+        ranked = sorted(scored.values(), key=lambda item: item.final_score, reverse=True)
+        return ranked[:limit]
+
+
+class TriggerRecommendationEngine:
+    """High level trigger recommendation helper with cached index."""
+
+    def __init__(
+        self,
+        *,
+        resolver: TriggerResolver,
+        embedder: TriggerEmbedder,
+        index: TriggerSearchIndex,
+        logger: Optional[logging.Logger] = None,
+    ) -> None:
+        self._resolver = resolver
+        self._embedder = embedder
+        self._index = index
+        self._logger = logger or logging.getLogger(__name__)
+
+    def search(self, repository, query: str, limit: int) -> List[TriggerCandidateResult]:
+        """Return trigger candidates ensuring caches are populated."""
+        self._index.ensure(repository, self._embedder, self._resolver)
+        return self._index.search(
+            query=query,
+            resolver=self._resolver,
+            embedder=self._embedder,
+            limit=limit,
+        )
+
+    @property
+    def metadata(self) -> Dict[str, Dict[str, object]]:
+        """Expose cached adapter metadata for explanation generation."""
+        return self._index.adapter_metadata
+
+
+__all__ = [
+    "TriggerCandidateResult",
+    "TriggerRecommendationEngine",
+    "TriggerSearchIndex",
+]

--- a/tests/recommendations/test_service.py
+++ b/tests/recommendations/test_service.py
@@ -72,6 +72,8 @@ class TestRecommendationService:
         similar_use_case.execute = AsyncMock(return_value=[MagicMock()])
         prompt_use_case = MagicMock()
         prompt_use_case.execute = AsyncMock(return_value=[MagicMock()])
+        trigger_use_case = MagicMock()
+        trigger_use_case.execute = AsyncMock(return_value=[MagicMock()])
 
         config = RecommendationConfig(persistence_service)
 
@@ -83,6 +85,7 @@ class TestRecommendationService:
                 stats_reporter=stats_reporter,
                 similar_lora_use_case=similar_use_case,
                 prompt_recommendation_use_case=prompt_use_case,
+                trigger_recommendation_use_case=trigger_use_case,
                 config=config,
             )
             .build()
@@ -106,6 +109,9 @@ class TestRecommendationService:
 
         await service.recommend_for_prompt(prompt="hello", active_loras=["a"], limit=1)
         assert prompt_use_case.execute.await_count == 1
+
+        await service.recommend_for_trigger(trigger_query="angel", limit=2)
+        assert trigger_use_case.execute.await_count == 1
 
         await service.embeddings.compute_for_lora("adapter-1", force_recompute=True)
         embedding_workflow.compute_embeddings_for_lora.assert_awaited_with(
@@ -186,9 +192,11 @@ class TestRecommendationService:
 
         similar_use_case = MagicMock()
         prompt_use_case = MagicMock()
+        trigger_use_case = MagicMock()
         use_case_bundle = UseCaseBundle(
             similar_lora=similar_use_case,
             prompt_recommendation=prompt_use_case,
+            trigger_recommendation=trigger_use_case,
         )
 
         embedding_coordinator = MagicMock()
@@ -225,6 +233,7 @@ class TestRecommendationService:
             stats_reporter=stats_reporter,
             similar_lora_use_case=similar_use_case,
             prompt_recommendation_use_case=prompt_use_case,
+            trigger_recommendation_use_case=trigger_use_case,
             config=persistence_components.config,
         )
         builder.build.assert_called_once_with()

--- a/tests/test_service_providers.py
+++ b/tests/test_service_providers.py
@@ -1,6 +1,6 @@
 from dataclasses import replace
 from types import SimpleNamespace
-from unittest.mock import MagicMock
+from unittest.mock import ANY, MagicMock
 
 from backend.services import get_service_container_builder
 from backend.services.adapters.service import AdapterService
@@ -202,6 +202,7 @@ def test_make_recommendation_service_uses_custom_components():
         stats_reporter=stats_reporter,
         similar_lora_use_case=similar_use_case,
         prompt_recommendation_use_case=prompt_use_case,
+        trigger_recommendation_use_case=ANY,
         config=config,
     )
     builder.build.assert_called_once_with()
@@ -229,6 +230,7 @@ def test_make_recommendation_service_accepts_prebuilt_bundles():
     use_case_bundle = UseCaseBundle(
         similar_lora=MagicMock(),
         prompt_recommendation=MagicMock(),
+        trigger_recommendation=MagicMock(),
     )
 
     embedding_coordinator = MagicMock()
@@ -262,6 +264,7 @@ def test_make_recommendation_service_accepts_prebuilt_bundles():
         stats_reporter=stats_reporter,
         similar_lora_use_case=use_case_bundle.similar_lora,
         prompt_recommendation_use_case=use_case_bundle.prompt_recommendation,
+        trigger_recommendation_use_case=use_case_bundle.trigger_recommendation,
         config=persistence_components.config,
     )
     builder.build.assert_called_once_with()


### PR DESCRIPTION
## Summary
- extend the recommendation data model and feature extraction to persist normalized trigger phrases, aliases, and lightweight embeddings
- add a cached trigger search engine with inverted index and semantic fallback plus a new API endpoint and use case for trigger-based queries
- improve explainability and fallback behavior while updating tests and builders for the new trigger workflow

## Testing
- pytest tests/recommendations/test_service.py tests/test_service_providers.py

------
https://chatgpt.com/codex/tasks/task_e_68d43ccda540832991eebec398620fee