### PR TITLE
Fix vue-virtual-scroller alias resolution for runtime builds

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -81,6 +81,30 @@ export default defineConfig(({ mode }) => {
     ? websocketTargetCandidate.replace(/^http/i, 'ws')
     : websocketTargetCandidate;
 
+  const alias = [
+    {
+      find: '@',
+      replacement: srcDirectory,
+    },
+  ];
+
+  if (mode === 'test') {
+    alias.unshift(
+      {
+        find: /^vue-virtual-scroller\/dist\/vue-virtual-scroller\.css$/,
+        replacement: fileURLToPath(
+          new URL('./app/frontend/src/vendor/vue-virtual-scroller.css', import.meta.url),
+        ),
+      },
+      {
+        find: /^vue-virtual-scroller$/,
+        replacement: fileURLToPath(
+          new URL('./app/frontend/src/vendor/vue-virtual-scroller.ts', import.meta.url),
+        ),
+      },
+    );
+  }
+
   return {
     plugins: [vue()],
     root: './app/frontend',
@@ -100,25 +124,7 @@ export default defineConfig(({ mode }) => {
       }
     },
     resolve: {
-      alias: [
-        // CSS must come first to avoid path appending on the TS alias
-        {
-          find: /^vue-virtual-scroller\/dist\/vue-virtual-scroller\.css$/,
-          replacement: fileURLToPath(
-            new URL('./app/frontend/src/vendor/vue-virtual-scroller.css', import.meta.url),
-          ),
-        },
-        {
-          find: /^vue-virtual-scroller$/,
-          replacement: fileURLToPath(
-            new URL('./app/frontend/src/vendor/vue-virtual-scroller.ts', import.meta.url),
-          ),
-        },
-        {
-          find: '@',
-          replacement: srcDirectory,
-        },
-      ],
+      alias,
     },
     build: {
       outDir: '../dist',

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -2,14 +2,18 @@ import { resolve } from 'path';
 import { defineConfig } from 'vitest/config';
 import vue from '@vitejs/plugin-vue';
 
+const frontendSrc = resolve(__dirname, 'app/frontend/src');
+const vendorDir = resolve(frontendSrc, 'vendor');
+
 export default defineConfig({
   plugins: [vue()],
   resolve: {
     alias: {
-      '@': resolve(__dirname, 'app/frontend/src'),
-      'vue-virtual-scroller': resolve(
-        __dirname,
-        'tests/mocks/vueVirtualScrollerStub.ts'
+      '@': frontendSrc,
+      'vue-virtual-scroller': resolve(vendorDir, 'vue-virtual-scroller.ts'),
+      'vue-virtual-scroller/dist/vue-virtual-scroller.css': resolve(
+        vendorDir,
+        'vue-virtual-scroller.css',
       ),
     },
   },


### PR DESCRIPTION
## Summary
- make the vue-virtual-scroller stub alias opt-in for test mode so production builds use the real package
- point Vitest aliases to the local stub and stylesheet for unit tests only
- refine the stub to render only a limited subset of items so virtualization-oriented tests still pass

## Testing
- npm run test:unit

------
https://chatgpt.com/codex/tasks/task_e_68d98ce870148329a14058ea93911491