### PR TITLE
refactor: centralize system api clients

### DIFF
--- a/app/frontend/src/composables/shared/apiClients.ts
+++ b/app/frontend/src/composables/shared/apiClients.ts
@@ -7,9 +7,9 @@ import type {
   GenerationJob,
   GenerationResult,
   RecommendationResponse,
-  SystemStatusPayload,
 } from '@/types';
 import { buildAdapterListQuery } from '@/services/lora/loraService';
+import { useDashboardStatsApi, useSystemStatusApi } from '@/services/system';
 import { resolveBackendUrl } from '@/utils/backend';
 
 export type DashboardStatsResponse = DashboardStatsSummary;
@@ -24,12 +24,6 @@ export const useRecommendationApi = (
   init: RequestInit = {},
 ) => useApi<RecommendationResponse>(url, withCredentials(init));
 
-export const useDashboardStatsApi = () =>
-  useApi<DashboardStatsResponse>(() => resolveBackendUrl('/dashboard/stats'));
-
-export const useSystemStatusApi = () =>
-  useApi<SystemStatusPayload>(() => resolveBackendUrl('/system/status'));
-
 export const useActiveJobsApi = () =>
   useApi<Partial<GenerationJob>[]>(() => resolveBackendUrl('/generation/jobs/active'));
 
@@ -38,4 +32,4 @@ export const useRecentResultsApi = (
   init: RequestInit = {},
 ) => useApi<GenerationResult[]>(url, withCredentials(init));
 
-export { buildAdapterListQuery, useAdapterListApi };
+export { buildAdapterListQuery, useAdapterListApi, useDashboardStatsApi, useSystemStatusApi };

--- a/tests/vue/apiClients.spec.ts
+++ b/tests/vue/apiClients.spec.ts
@@ -1,11 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import {
-  useActiveJobsApi,
-  useAdapterListApi,
-  useDashboardStatsApi,
-  useSystemStatusApi,
-} from '../../app/frontend/src/composables/shared/apiClients';
+import { useActiveJobsApi, useAdapterListApi } from '../../app/frontend/src/composables/shared/apiClients';
+import { useDashboardStatsApi, useSystemStatusApi } from '../../app/frontend/src/services/system';
 import { useSettingsStore } from '../../app/frontend/src/stores/settings';
 
 const createJsonResponse = (payload: unknown): Response => ({


### PR DESCRIPTION
## Summary
- re-export the dashboard and system status helpers from the central system service
- update the unit test imports to use the consolidated module

## Testing
- npm run test -- tests/vue/apiClients.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68d9c19b08dc832982df54cfc08b7b2b