### PR TITLE
refactor: use direct service imports in frontend

### DIFF
--- a/app/frontend/src/components/lora-gallery/LoraGallery.vue
+++ b/app/frontend/src/components/lora-gallery/LoraGallery.vue
@@ -63,7 +63,7 @@ import LoraGalleryFilters from './LoraGalleryFilters.vue';
 import LoraGalleryGrid from './LoraGalleryGrid.vue';
 import LoraGalleryHeader from './LoraGalleryHeader.vue';
 import LoraGalleryTagModal from './LoraGalleryTagModal.vue';
-import { performBulkLoraAction } from '@/services';
+import { performBulkLoraAction } from '@/services/lora/loraService';
 import { useLoraGalleryData } from '@/composables/lora-gallery';
 import { useLoraGalleryFilters } from '@/composables/lora-gallery';
 import { useLoraGallerySelection } from '@/composables/lora-gallery';

--- a/app/frontend/src/composables/generation/useGenerationOrchestrator.ts
+++ b/app/frontend/src/composables/generation/useGenerationOrchestrator.ts
@@ -1,11 +1,11 @@
 import { storeToRefs } from 'pinia'
 
 import type { GenerationNotificationAdapter } from '@/composables/generation'
-import { createGenerationOrchestrator } from '@/services'
+import { createGenerationOrchestrator } from '@/services/generation/orchestrator'
 import type {
   GenerationQueueClient,
   GenerationWebSocketManager,
-} from '@/services'
+} from '@/services/generation/updates'
 import {
   useGenerationConnectionStore,
   useGenerationFormStore,

--- a/app/frontend/src/composables/generation/useGenerationQueueClient.ts
+++ b/app/frontend/src/composables/generation/useGenerationQueueClient.ts
@@ -4,7 +4,7 @@ import {
   createGenerationQueueClient,
   DEFAULT_POLL_INTERVAL,
   type GenerationQueueClient,
-} from '@/services';
+} from '@/services/generation/updates';
 import type {
   GenerationRequestPayload,
   GenerationResult,

--- a/app/frontend/src/composables/generation/useGenerationSocketBridge.ts
+++ b/app/frontend/src/composables/generation/useGenerationSocketBridge.ts
@@ -3,7 +3,7 @@ import { shallowRef } from 'vue';
 import {
   createGenerationWebSocketManager,
   type GenerationWebSocketManager,
-} from '@/services';
+} from '@/services/generation/updates';
 import type {
   GenerationCompleteMessage,
   GenerationErrorMessage,

--- a/app/frontend/src/composables/generation/useGenerationStudio.ts
+++ b/app/frontend/src/composables/generation/useGenerationStudio.ts
@@ -4,7 +4,7 @@ import { useGenerationPersistence } from '@/composables/generation'
 import { useGenerationOrchestrator } from '@/composables/generation'
 import { useGenerationUI } from '@/composables/generation'
 import { useNotifications } from '@/composables/shared'
-import { toGenerationRequestPayload } from '@/services'
+import { toGenerationRequestPayload } from '@/services/generation/generationService'
 import { useGenerationFormStore } from '@/stores/generation'
 import type { NotificationType } from '@/types'
 

--- a/app/frontend/src/composables/generation/useGenerationTransport.ts
+++ b/app/frontend/src/composables/generation/useGenerationTransport.ts
@@ -1,4 +1,8 @@
-import { extractGenerationErrorMessage, type GenerationQueueClient, type GenerationWebSocketManager } from '@/services';
+import {
+  extractGenerationErrorMessage,
+  type GenerationQueueClient,
+  type GenerationWebSocketManager,
+} from '@/services/generation/updates';
 import type {
   GenerationCompleteMessage,
   GenerationErrorMessage,

--- a/app/frontend/src/composables/generation/useGenerationUpdates.ts
+++ b/app/frontend/src/composables/generation/useGenerationUpdates.ts
@@ -7,11 +7,11 @@ import {
   useGenerationQueueStore,
   useGenerationResultsStore,
 } from '@/stores/generation';
-import { createGenerationOrchestrator } from '@/services';
+import { createGenerationOrchestrator } from '@/services/generation/orchestrator';
 import type {
   GenerationQueueClient,
   GenerationWebSocketManager,
-} from '@/services';
+} from '@/services/generation/updates';
 import type {
   GenerationJob,
   GenerationRequestPayload,

--- a/app/frontend/src/composables/generation/useJobQueueActions.ts
+++ b/app/frontend/src/composables/generation/useJobQueueActions.ts
@@ -1,7 +1,7 @@
 import { ref, unref, type MaybeRefOrGetter } from 'vue';
 import { storeToRefs } from 'pinia';
 
-import { cancelGenerationJob } from '@/services';
+import { cancelGenerationJob } from '@/services/generation/generationService';
 import { useGenerationQueueStore } from '@/stores/generation';
 import { useToast } from '@/composables/shared';
 import { useBackendBase } from '@/utils/backend';

--- a/app/frontend/src/composables/generation/useJobQueueTransport.ts
+++ b/app/frontend/src/composables/generation/useJobQueueTransport.ts
@@ -1,6 +1,6 @@
 import { ref, unref, type MaybeRefOrGetter, type Ref } from 'vue';
 
-import { fetchActiveGenerationJobs } from '@/services';
+import { fetchActiveGenerationJobs } from '@/services/generation/generationService';
 import { DEFAULT_BACKEND_BASE } from '@/utils/backend';
 import type { GenerationJobStatus } from '@/types';
 

--- a/app/frontend/src/composables/history/useGenerationHistory.ts
+++ b/app/frontend/src/composables/history/useGenerationHistory.ts
@@ -2,7 +2,7 @@ import { computed, ref, unref, type ComputedRef } from 'vue';
 import type { MaybeRefOrGetter } from 'vue';
 
 import { debounce, type DebouncedFunction } from '@/utils/async';
-import { listResults as listHistoryResults } from '@/services';
+import { listResults as listHistoryResults } from '@/services/history/historyService';
 import type {
   GenerationHistoryQuery,
   GenerationHistoryResult,

--- a/app/frontend/src/composables/history/useHistoryActions.ts
+++ b/app/frontend/src/composables/history/useHistoryActions.ts
@@ -12,7 +12,7 @@ import {
   favoriteResult as favoriteHistoryResult,
   favoriteResults as favoriteHistoryResults,
   rateResult as rateHistoryResult,
-} from '@/services';
+} from '@/services/history/historyService';
 import type { GenerationHistoryResult, NotificationType } from '@/types';
 
 export interface UseHistoryActionsOptions {

--- a/app/frontend/src/composables/lora-gallery/useLoraCardActions.ts
+++ b/app/frontend/src/composables/lora-gallery/useLoraCardActions.ts
@@ -9,7 +9,7 @@ import {
   toggleLoraActiveState,
   triggerPreviewGeneration,
   updateLoraWeight,
-} from '@/services';
+} from '@/services/lora/loraService';
 import type { LoraListItem, LoraUpdatePayload } from '@/types';
 
 type UseLoraCardActionsOptions = {

--- a/app/frontend/src/composables/lora-gallery/useLoraGalleryData.ts
+++ b/app/frontend/src/composables/lora-gallery/useLoraGalleryData.ts
@@ -1,7 +1,7 @@
 import { ref } from 'vue';
 import type { Ref } from 'vue';
 
-import { fetchAdapterTags, fetchAdapters } from '@/services';
+import { fetchAdapterTags, fetchAdapters } from '@/services/lora/loraService';
 import type { GalleryLora } from '@/types';
 
 export function useLoraGalleryData(apiBaseUrl: Ref<string>) {

--- a/app/frontend/src/composables/system/useSystemStatus.ts
+++ b/app/frontend/src/composables/system/useSystemStatus.ts
@@ -2,7 +2,7 @@ import { computed, onBeforeUnmount, onMounted, ref } from 'vue';
 import { storeToRefs } from 'pinia';
 
 import { ApiError } from '@/composables/shared';
-import { fetchSystemStatus } from '@/services';
+import { fetchSystemStatus } from '@/services/system/systemService';
 import { useGenerationConnectionStore } from '@/stores/generation';
 import { useBackendBase } from '@/utils/backend';
 

--- a/app/frontend/src/composables/usePerformanceAnalytics.ts
+++ b/app/frontend/src/composables/usePerformanceAnalytics.ts
@@ -6,8 +6,11 @@
 
 import { ref } from 'vue';
 
-import { exportAnalyticsReport, fetchPerformanceAnalytics } from '@/services';
-import { fetchTopAdapters } from '@/services';
+import {
+  exportAnalyticsReport,
+  fetchPerformanceAnalytics,
+} from '@/services/analytics/analyticsService';
+import { fetchTopAdapters } from '@/services/lora/loraService';
 import { useBackendBase } from '@/utils/backend';
 import { formatDuration as formatDurationLabel } from '@/utils/format';
 

--- a/app/frontend/src/services/generation/orchestrator.ts
+++ b/app/frontend/src/services/generation/orchestrator.ts
@@ -14,7 +14,7 @@ import type {
 import type {
   GenerationQueueClient,
   GenerationWebSocketManager,
-} from '@/services';
+} from './updates';
 import type {
   GenerationJob,
   GenerationRequestPayload,

--- a/app/frontend/src/services/generation/updates.ts
+++ b/app/frontend/src/services/generation/updates.ts
@@ -5,7 +5,7 @@ import {
   resolveGenerationBaseUrl,
   resolveGenerationRoute,
   startGeneration,
-} from '@/services';
+} from './generationService';
 import { requestJson } from '@/utils/api';
 import { normalizeJobStatus } from '@/utils/status';
 import type {

--- a/app/frontend/src/services/history/historyService.ts
+++ b/app/frontend/src/services/history/historyService.ts
@@ -4,7 +4,7 @@ import type { MaybeRefOrGetter } from 'vue';
 import { useApi } from '@/composables/shared';
 import { DEFAULT_BACKEND_BASE } from '@/config/runtime';
 import { getFilenameFromContentDisposition, requestBlob } from '@/utils/api';
-import { resolveGenerationRoute } from '@/services';
+import { resolveGenerationRoute } from '@/services/generation/generationService';
 
 import type {
   GenerationBulkDeleteRequest,

--- a/app/frontend/src/stores/adminMetrics.ts
+++ b/app/frontend/src/stores/adminMetrics.ts
@@ -5,7 +5,7 @@ import {
   deriveMetricsFromDashboard,
   emptyMetricsSnapshot,
   fetchDashboardStats,
-} from '@/services';
+} from '@/services/system/systemService';
 import { useBackendBase } from '@/utils/backend';
 import {
   buildResourceStats,

--- a/app/frontend/src/stores/generation/connection.ts
+++ b/app/frontend/src/stores/generation/connection.ts
@@ -1,7 +1,7 @@
 import { reactive, ref } from 'vue';
 import { defineStore } from 'pinia';
 
-import { DEFAULT_POLL_INTERVAL } from '@/services';
+import { DEFAULT_POLL_INTERVAL } from '@/services/generation/updates';
 import type { SystemStatusPayload, SystemStatusState } from '@/types';
 
 export const DEFAULT_SYSTEM_STATUS: SystemStatusState = {

--- a/app/frontend/src/stores/settings.ts
+++ b/app/frontend/src/stores/settings.ts
@@ -1,6 +1,6 @@
 import { defineStore } from 'pinia';
 
-import { loadFrontendSettings } from '@/services';
+import { loadFrontendSettings } from '@/services/system/systemService';
 import type { FrontendRuntimeSettings, SettingsState } from '@/types';
 
 const normalizeBackendUrl = (value?: string | null): string => {

--- a/app/frontend/src/utils/promptGeneration.ts
+++ b/app/frontend/src/utils/promptGeneration.ts
@@ -1,4 +1,4 @@
-import { createGenerationParams, requestGeneration } from '@/services';
+import { createGenerationParams, requestGeneration } from '@/services/generation/generationService';
 
 import type { CompositionEntry } from '@/types';
 


### PR DESCRIPTION
## Summary
- replace internal `@/services` barrel imports with domain-specific service entry points across generation, history, analytics, and lora modules
- update generation queue utilities and stores to reference local generation service helpers directly
- ensure components and composables rely on concrete services to prevent circular dependencies

## Testing
- npm run type-check *(fails: existing vite.config.ts alias typing expects string and rejects regex)*

------
https://chatgpt.com/codex/tasks/task_e_68d9c46269f88329b35cd29a3ff5a3bc