### PR TITLE
Centralize system status polling in controller

### DIFF
--- a/app/frontend/src/stores/generation/index.ts
+++ b/app/frontend/src/stores/generation/index.ts
@@ -2,3 +2,4 @@ export * from './queue';
 export * from './results';
 export * from './connection';
 export * from './form';
+export * from './systemStatusController';

--- a/app/frontend/src/stores/generation/systemStatusController.ts
+++ b/app/frontend/src/stores/generation/systemStatusController.ts
@@ -1,0 +1,110 @@
+import { computed, ref, type ComputedRef } from 'vue';
+import { storeToRefs } from 'pinia';
+
+import { ApiError } from '@/composables/shared';
+import { fetchSystemStatus } from '@/services/system/systemService';
+import { useGenerationConnectionStore } from '@/stores/generation/connection';
+import { useBackendBase } from '@/utils/backend';
+
+const DEFAULT_POLL_INTERVAL = 10_000;
+
+export interface SystemStatusController {
+  readonly isPolling: ComputedRef<boolean>;
+  ensureHydrated: () => Promise<void>;
+  refresh: () => Promise<void>;
+  start: () => void;
+  stop: () => void;
+}
+
+let singleton: SystemStatusController | null = null;
+
+export const useSystemStatusController = (): SystemStatusController => {
+  if (singleton) {
+    return singleton;
+  }
+
+  const connectionStore = useGenerationConnectionStore();
+  const { systemStatusReady } = storeToRefs(connectionStore);
+  const backendBase = useBackendBase();
+  const pollHandle = ref<ReturnType<typeof setInterval> | null>(null);
+  const inFlight = ref<Promise<void> | null>(null);
+
+  const stop = (): void => {
+    if (pollHandle.value) {
+      clearInterval(pollHandle.value);
+      pollHandle.value = null;
+    }
+  };
+
+  const refresh = async (): Promise<void> => {
+    if (inFlight.value) {
+      return inFlight.value;
+    }
+
+    const run = (async () => {
+      try {
+        const payload = await fetchSystemStatus(backendBase.value);
+        connectionStore.resetSystemStatus();
+
+        if (payload) {
+          connectionStore.applySystemStatusPayload(payload);
+          return;
+        }
+
+        connectionStore.markSystemStatusHydrated(new Date());
+      } catch (error: unknown) {
+        if (error instanceof ApiError && error.status === 404) {
+          connectionStore.resetSystemStatus();
+          connectionStore.markSystemStatusUnavailable(new Date());
+          stop();
+          return;
+        }
+
+        connectionStore.resetSystemStatus();
+        connectionStore.updateSystemStatus({ status: 'error', gpu_status: 'Unknown' });
+        connectionStore.markSystemStatusHydrated(new Date());
+
+        if (import.meta.env.DEV) {
+          console.error('Failed to load system status', error);
+        }
+      } finally {
+        inFlight.value = null;
+      }
+    })();
+
+    inFlight.value = run;
+    await run;
+  };
+
+  const start = (): void => {
+    if (pollHandle.value) {
+      return;
+    }
+
+    pollHandle.value = setInterval(() => {
+      void refresh();
+    }, DEFAULT_POLL_INTERVAL);
+  };
+
+  const ensureHydrated = async (): Promise<void> => {
+    if (!systemStatusReady.value) {
+      await refresh();
+    }
+
+    start();
+  };
+
+  const isPolling = computed(() => pollHandle.value != null);
+
+  singleton = {
+    isPolling,
+    ensureHydrated,
+    refresh,
+    start,
+    stop,
+  };
+
+  return singleton;
+};
+
+export default useSystemStatusController;

--- a/tests/vue/SystemStatusCard.spec.js
+++ b/tests/vue/SystemStatusCard.spec.js
@@ -1,37 +1,54 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { mount } from '@vue/test-utils';
 import { nextTick } from 'vue';
 
 import SystemStatusCard from '../../app/frontend/src/components/system/SystemStatusCard.vue';
 import { useGenerationConnectionStore } from '../../app/frontend/src/stores/generation';
 
+const mockController = {
+  ensureHydrated: vi.fn().mockResolvedValue(undefined),
+  refresh: vi.fn().mockResolvedValue(undefined),
+  start: vi.fn(),
+  stop: vi.fn(),
+  isPolling: { value: false },
+};
+
+vi.mock('../../app/frontend/src/stores/generation/systemStatusController', () => ({
+  useSystemStatusController: () => mockController,
+}));
+
 const flush = async () => {
   await Promise.resolve();
   await nextTick();
-  await new Promise((resolve) => setTimeout(resolve, 0));
+  await Promise.resolve();
   await nextTick();
 };
 
 describe('SystemStatusCard.vue', () => {
   beforeEach(() => {
-    useGenerationConnectionStore().reset();
+    const store = useGenerationConnectionStore();
+    store.reset();
+    mockController.ensureHydrated.mockClear();
+    mockController.refresh.mockClear();
+    mockController.start.mockClear();
+    mockController.stop.mockClear();
+    mockController.isPolling.value = false;
   });
 
   afterEach(() => {
-    vi.restoreAllMocks();
+    vi.clearAllMocks();
   });
 
-  it('renders system status from the API for the simple variant', async () => {
-    global.fetch = vi.fn(async () => ({
-      ok: true,
-      status: 200,
-      json: async () => ({
-        gpu_status: 'Available',
-        queue_length: 3,
-        memory_used: 4096,
-        memory_total: 8192,
-        status: 'healthy',
-      }),
-    }));
+  it('renders system status using shared store data (simple variant)', async () => {
+    const store = useGenerationConnectionStore();
+    store.updateSystemStatus({
+      gpu_status: 'Available',
+      queue_length: 3,
+      memory_used: 4096,
+      memory_total: 8192,
+      status: 'healthy',
+    });
+    store.markSystemStatusHydrated(new Date('2024-01-01T00:00:00Z'));
 
     const wrapper = mount(SystemStatusCard);
     await flush();
@@ -45,13 +62,14 @@ describe('SystemStatusCard.vue', () => {
     wrapper.unmount();
   });
 
-  it('shows fallback messaging when the API is unavailable (detailed variant)', async () => {
-    global.fetch = vi.fn(async () => ({ ok: false, status: 404 }));
+  it('shows fallback messaging when real-time status is unavailable (detailed variant)', async () => {
+    const store = useGenerationConnectionStore();
+    store.resetSystemStatus();
+    store.markSystemStatusUnavailable(new Date('2024-01-01T00:00:00Z'));
 
     const wrapper = mount(SystemStatusCard, { props: { variant: 'detailed' } });
     await flush();
 
-    // Expand the detailed view
     await wrapper.find('.card-header').trigger('click');
     await flush();
 


### PR DESCRIPTION
## Summary
- introduce a shared system status controller that manages polling and updates the generation connection store
- refactor `useSystemStatus` to format reactive store data from the controller and remove redundant timers
- update generation queue client and card tests to rely on the shared store while avoiding duplicate polling

## Testing
- npm run test -- SystemStatusCard

------
https://chatgpt.com/codex/tasks/task_e_68d9c771fc888329aab7c483dd7fe445