### PR TITLE
refactor: centralize navigation menu config

### DIFF
--- a/app/frontend/src/components/layout/MainNavigation.vue
+++ b/app/frontend/src/components/layout/MainNavigation.vue
@@ -139,30 +139,7 @@ import { useRoute, useRouter, RouterLink } from 'vue-router';
 
 import { useAppStore } from '@/stores';
 import { useTheme } from '@/composables/shared';
-
-interface NavItem {
-  path: string;
-  label: string;
-  icon:
-    | 'dashboard'
-    | 'grid'
-    | 'spark'
-    | 'compose'
-    | 'wand'
-    | 'admin'
-    | 'bars';
-}
-
-const NAV_ITEMS: readonly NavItem[] = [
-  { path: '/', label: 'Dashboard', icon: 'dashboard' },
-  { path: '/loras', label: 'LoRAs', icon: 'grid' },
-  { path: '/recommendations', label: 'Recommendations', icon: 'spark' },
-  { path: '/compose', label: 'Compose', icon: 'compose' },
-  { path: '/generate', label: 'Generate', icon: 'wand' },
-  { path: '/admin', label: 'Admin', icon: 'admin' },
-  { path: '/analytics', label: 'Analytics', icon: 'bars' },
-  { path: '/import-export', label: 'Import/Export', icon: 'grid' },
-];
+import { NAVIGATION_ITEMS } from '@/config/navigation';
 
 const appStore = useAppStore();
 const router = useRouter();
@@ -170,7 +147,7 @@ const route = useRoute();
 const { currentTheme, toggleTheme } = useTheme();
 
 const searchQuery = ref('');
-const items = NAV_ITEMS;
+const items = NAVIGATION_ITEMS;
 
 const currentPath = computed(() => route.path.replace(/\/+$/, '') || '/');
 const canSearch = computed(() => searchQuery.value.trim().length > 1);

--- a/app/frontend/src/components/layout/MobileNav.vue
+++ b/app/frontend/src/components/layout/MobileNav.vue
@@ -116,27 +116,10 @@
 import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue';
 import { RouterLink, useRoute } from 'vue-router';
 
-type NavIcon = 'dashboard' | 'grid' | 'spark' | 'compose' | 'wand' | 'admin' | 'bars';
-
-interface NavItem {
-  path: string;
-  label: string;
-  icon: NavIcon;
-}
-
-const NAV_ITEMS: readonly NavItem[] = [
-  { path: '/', label: 'Dashboard', icon: 'dashboard' },
-  { path: '/loras', label: 'LoRAs', icon: 'grid' },
-  { path: '/recommendations', label: 'Recommendations', icon: 'spark' },
-  { path: '/compose', label: 'Compose', icon: 'compose' },
-  { path: '/generate', label: 'Generate', icon: 'wand' },
-  { path: '/admin', label: 'Admin', icon: 'admin' },
-  { path: '/analytics', label: 'Analytics', icon: 'bars' },
-  { path: '/import-export', label: 'Import/Export', icon: 'grid' },
-];
+import { NAVIGATION_ITEMS } from '@/config/navigation';
 
 const isOpen = ref(false);
-const items = NAV_ITEMS;
+const items = NAVIGATION_ITEMS;
 const route = useRoute();
 
 const currentPath = computed(() => route.path.replace(/\/+$/, '') || '/');

--- a/app/frontend/src/config/navigation.ts
+++ b/app/frontend/src/config/navigation.ts
@@ -1,0 +1,35 @@
+export const NAVIGATION_ICON_KEYS = [
+  'dashboard',
+  'grid',
+  'spark',
+  'compose',
+  'wand',
+  'admin',
+  'bars',
+] as const;
+
+export type NavigationIconKey = (typeof NAVIGATION_ICON_KEYS)[number];
+
+export interface NavigationSecondaryAction {
+  label: string;
+  to: string;
+  icon?: NavigationIconKey;
+}
+
+export interface NavigationItem {
+  path: string;
+  label: string;
+  icon: NavigationIconKey;
+  secondaryAction?: NavigationSecondaryAction;
+}
+
+export const NAVIGATION_ITEMS: readonly NavigationItem[] = [
+  { path: '/', label: 'Dashboard', icon: 'dashboard' },
+  { path: '/loras', label: 'LoRAs', icon: 'grid' },
+  { path: '/recommendations', label: 'Recommendations', icon: 'spark' },
+  { path: '/compose', label: 'Compose', icon: 'compose' },
+  { path: '/generate', label: 'Generate', icon: 'wand' },
+  { path: '/admin', label: 'Admin', icon: 'admin' },
+  { path: '/analytics', label: 'Analytics', icon: 'bars' },
+  { path: '/import-export', label: 'Import/Export', icon: 'grid' },
+] as const;

--- a/tests/vue/config/navigation.spec.ts
+++ b/tests/vue/config/navigation.spec.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+
+import { NAVIGATION_ICON_KEYS, NAVIGATION_ITEMS } from '@/config/navigation';
+
+describe('navigation config', () => {
+  it('matches the expected navigation structure', () => {
+    expect(NAVIGATION_ITEMS).toMatchInlineSnapshot(`
+      [
+        {
+          "icon": "dashboard",
+          "label": "Dashboard",
+          "path": "/",
+        },
+        {
+          "icon": "grid",
+          "label": "LoRAs",
+          "path": "/loras",
+        },
+        {
+          "icon": "spark",
+          "label": "Recommendations",
+          "path": "/recommendations",
+        },
+        {
+          "icon": "compose",
+          "label": "Compose",
+          "path": "/compose",
+        },
+        {
+          "icon": "wand",
+          "label": "Generate",
+          "path": "/generate",
+        },
+        {
+          "icon": "admin",
+          "label": "Admin",
+          "path": "/admin",
+        },
+        {
+          "icon": "bars",
+          "label": "Analytics",
+          "path": "/analytics",
+        },
+        {
+          "icon": "grid",
+          "label": "Import/Export",
+          "path": "/import-export",
+        },
+      ]
+    `);
+  });
+
+  it('keeps icon keys in sync with navigation items', () => {
+    const iconSet = new Set(NAVIGATION_ICON_KEYS);
+    const invalidIcons = NAVIGATION_ITEMS.filter((item) => !iconSet.has(item.icon));
+
+    expect(invalidIcons).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary
- centralize the shared navigation menu metadata, including icon keys, in a dedicated config module
- update the desktop and mobile navigation components to source links from the shared configuration
- add a vitest snapshot to guard the navigation structure and icon list

## Testing
- npm run test:unit -- tests/vue/config/navigation.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68d9d352664c832987b554ff05466a55