### PR TITLE
Remove unused account navigation link

### DIFF
--- a/app/frontend/src/components/layout/MainNavigation.vue
+++ b/app/frontend/src/components/layout/MainNavigation.vue
@@ -56,11 +56,6 @@
             <span class="sr-only">Toggle theme</span>
           </button>
 
-          <RouterLink to="/account" class="btn btn-icon" aria-label="Account">
-            <svg class="h-6 w-6" viewBox="0 0 24 24" fill="none" stroke="currentColor">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 12a4 4 0 1 0 0-8 4 4 0 0 0 0 8ZM4 20a8 8 0 0 1 16 0" />
-            </svg>
-          </RouterLink>
         </div>
       </div>
 


### PR DESCRIPTION
## Summary
- remove the broken account link from the desktop main navigation to match the available routes

## Testing
- npm run lint *(fails: pre-existing restricted import violations unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68d9d5eb7b0c8329ad05b9b52b067f98