### PR TITLE
Lazy load analytics component in dashboard and admin views

### DIFF
--- a/app/frontend/src/views/AdminView.vue
+++ b/app/frontend/src/views/AdminView.vue
@@ -28,11 +28,16 @@
 <script setup lang="ts">
 import { RouterLink } from 'vue-router';
 
+import { defineAsyncComponent } from 'vue';
+
 import ImportExportContainer from '@/components/import-export/ImportExportContainer.vue';
 import JobQueue from '@/components/shared/JobQueue.vue';
 import PageHeader from '@/components/layout/PageHeader.vue';
-import PerformanceAnalytics from '@/views/analytics/PerformanceAnalyticsPage.vue';
 import RecommendationsPanel from '@/components/recommendations/RecommendationsPanel.vue';
 import SystemAdminStatusCard from '@/components/system/SystemAdminStatusCard.vue';
 import SystemStatusPanel from '@/components/system/SystemStatusPanel.vue';
+
+const PerformanceAnalytics = defineAsyncComponent(
+  () => import('@/views/analytics/PerformanceAnalyticsPage.vue'),
+);
 </script>

--- a/app/frontend/src/views/DashboardView.vue
+++ b/app/frontend/src/views/DashboardView.vue
@@ -45,16 +45,21 @@
 <script setup lang="ts">
 import { RouterLink } from 'vue-router';
 
+import { defineAsyncComponent } from 'vue';
+
 import GenerationHistory from '@/components/history/GenerationHistory.vue';
 import GenerationStudio from '@/components/generation/GenerationStudio.vue';
 import ImportExportContainer from '@/components/import-export/ImportExportContainer.vue';
 import JobQueue from '@/components/shared/JobQueue.vue';
 import LoraGallery from '@/components/lora-gallery/LoraGallery.vue';
 import PageHeader from '@/components/layout/PageHeader.vue';
-import PerformanceAnalytics from '@/views/analytics/PerformanceAnalyticsPage.vue';
 import PromptComposer from '@/components/compose/PromptComposer.vue';
 import RecommendationsPanel from '@/components/recommendations/RecommendationsPanel.vue';
 import SystemAdminStatusCard from '@/components/system/SystemAdminStatusCard.vue';
 import SystemStatusCard from '@/components/system/SystemStatusCard.vue';
 import SystemStatusPanel from '@/components/system/SystemStatusPanel.vue';
+
+const PerformanceAnalytics = defineAsyncComponent(
+  () => import('@/views/analytics/PerformanceAnalyticsPage.vue'),
+);
 </script>


### PR DESCRIPTION
## Summary
- lazy load the PerformanceAnalytics page component in the dashboard and admin views so the heavy analytics chunk only loads on demand

## Testing
- npm run test -- --run tests/vue/PerformanceAnalytics.spec.js

------
https://chatgpt.com/codex/tasks/task_e_68d9d5f07e8483299487ef4cfdfb7b33