### PR TITLE
Refactor performance analytics service to use API client

### DIFF
--- a/app/frontend/src/services/analytics/analyticsService.ts
+++ b/app/frontend/src/services/analytics/analyticsService.ts
@@ -1,6 +1,5 @@
-import { getFilenameFromContentDisposition, requestBlob } from '@/services/apiClient';
+import { getFilenameFromContentDisposition, getJson, requestBlob } from '@/services/apiClient';
 import { resolveBackendUrl } from '@/utils/backend';
-import { buildAuthenticatedHeaders } from '@/utils/httpAuth';
 
 import type {
   AnalyticsExportOptions,
@@ -111,16 +110,8 @@ export const fetchPerformanceAnalytics = async (
   const separator = base.includes('?') ? '&' : '?';
   const targetUrl = `${base}${separator}time_range=${encodeURIComponent(timeRange)}`;
 
-  const response = await fetch(targetUrl, {
-    credentials: 'same-origin',
-    headers: buildAuthenticatedHeaders(),
-  });
-  if (!response.ok) {
-    const error = await response.text().catch(() => response.statusText);
-    throw new Error(error || 'Failed to fetch analytics summary');
-  }
-
-  const payload = (await response.json()) as PerformanceAnalyticsSummaryApi | null;
+  const { data } = await getJson<PerformanceAnalyticsSummaryApi>(targetUrl);
+  const payload = data ?? null;
 
   return {
     timeRange: payload?.time_range ?? timeRange,


### PR DESCRIPTION
## Summary
- refactor the performance analytics fetcher to use the shared api client with centralized error handling

## Testing
- npm run test -- --run usePerformanceAnalytics *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_68d9d5f0ba848329a0574dbb938ce19f