### PR TITLE
Create adapter catalog store for cached adapter listings

### DIFF
--- a/app/frontend/src/stores/adapterCatalog.ts
+++ b/app/frontend/src/stores/adapterCatalog.ts
@@ -1,0 +1,98 @@
+import { computed, ref } from 'vue';
+import { defineStore } from 'pinia';
+
+import { useAdapterListApi } from '@/composables/shared';
+
+import type { AdapterListQuery, AdapterSummary, LoraListItem } from '@/types';
+
+const DEFAULT_QUERY: AdapterListQuery = { page: 1, perPage: 200 };
+
+const toSummary = (item: LoraListItem): AdapterSummary => ({
+  id: item.id,
+  name: item.name,
+  description: item.description,
+  active: item.active ?? true,
+});
+
+const hasQueryChanged = (current: AdapterListQuery, next: AdapterListQuery): boolean =>
+  Object.entries(next).some(([key, value]) => {
+    if (value == null) {
+      return false;
+    }
+    const typedKey = key as keyof AdapterListQuery;
+    return current[typedKey] !== value;
+  });
+
+export const useAdapterCatalogStore = defineStore('adapterCatalog', () => {
+  const pendingFetch = ref<Promise<AdapterSummary[]> | null>(null);
+  const lastFetchedAt = ref<number | null>(null);
+
+  const api = useAdapterListApi({ ...DEFAULT_QUERY });
+
+  const query = api.query;
+  const adapters = computed<AdapterSummary[]>(() => api.adapters.value.map(toSummary));
+  const error = api.error;
+  const isLoading = api.isLoading;
+
+  const runFetch = async (overrides: AdapterListQuery = {}): Promise<AdapterSummary[]> => {
+    if (pendingFetch.value) {
+      return pendingFetch.value;
+    }
+
+    const request = (async () => {
+      try {
+        await api.fetchData(overrides);
+        lastFetchedAt.value = Date.now();
+      } finally {
+        pendingFetch.value = null;
+      }
+
+      return adapters.value;
+    })();
+
+    pendingFetch.value = request;
+    return request;
+  };
+
+  const ensureLoaded = async (overrides: AdapterListQuery = {}): Promise<AdapterSummary[]> => {
+    if (pendingFetch.value) {
+      await pendingFetch.value;
+      return adapters.value;
+    }
+
+    const shouldReload = lastFetchedAt.value == null || hasQueryChanged(query, overrides);
+
+    if (!shouldReload) {
+      return adapters.value;
+    }
+
+    await runFetch(overrides);
+    return adapters.value;
+  };
+
+  const refresh = async (overrides: AdapterListQuery = {}): Promise<AdapterSummary[]> => {
+    await runFetch(overrides);
+    return adapters.value;
+  };
+
+  const reset = () => {
+    pendingFetch.value = null;
+    lastFetchedAt.value = null;
+    api.data.value = null;
+    api.error.value = null;
+    api.isLoading.value = false;
+  };
+
+  return {
+    adapters,
+    error,
+    isLoading,
+    query,
+    lastFetchedAt,
+    ensureLoaded,
+    refresh,
+    reset,
+  };
+});
+
+export type AdapterCatalogStore = ReturnType<typeof useAdapterCatalogStore>;

--- a/app/frontend/src/stores/index.ts
+++ b/app/frontend/src/stores/index.ts
@@ -2,4 +2,5 @@ export * from './settings';
 export * from './app';
 export * from './adminMetrics';
 export * from './generation';
+export * from './adapterCatalog';
 

--- a/tests/vue/PromptComposer.spec.js
+++ b/tests/vue/PromptComposer.spec.js
@@ -3,6 +3,7 @@ import { nextTick } from 'vue';
 
 import PromptComposer from '../../app/frontend/src/components/compose/PromptComposer.vue';
 import { useAppStore } from '../../app/frontend/src/stores/app';
+import { useAdapterCatalogStore } from '../../app/frontend/src/stores/adapterCatalog';
 
 const flush = async () => {
   await Promise.resolve();
@@ -14,6 +15,7 @@ const flush = async () => {
 describe('PromptComposer.vue', () => {
   beforeEach(() => {
     useAppStore().$reset();
+    useAdapterCatalogStore().reset();
     const jsonResponse = (payload) => ({
       ok: true,
       status: 200,

--- a/tests/vue/RecommendationsPanel.spec.js
+++ b/tests/vue/RecommendationsPanel.spec.js
@@ -3,6 +3,7 @@ import { nextTick } from 'vue';
 
 import RecommendationsPanel from '../../app/frontend/src/components/recommendations/RecommendationsPanel.vue';
 import { useAppStore } from '../../app/frontend/src/stores/app';
+import { useAdapterCatalogStore } from '../../app/frontend/src/stores/adapterCatalog';
 
 const flush = async () => {
   await Promise.resolve();
@@ -14,6 +15,7 @@ const flush = async () => {
 describe('RecommendationsPanel.vue', () => {
   beforeEach(() => {
     useAppStore().$reset();
+    useAdapterCatalogStore().reset();
     const jsonResponse = (payload) => ({
       ok: true,
       status: 200,

--- a/tests/vue/useAdapterCatalog.spec.ts
+++ b/tests/vue/useAdapterCatalog.spec.ts
@@ -1,16 +1,21 @@
-import { describe, expect, beforeEach, it, vi } from 'vitest';
-import { computed, nextTick, ref } from 'vue';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { computed, nextTick, reactive, ref } from 'vue';
 import { mount } from '@vue/test-utils';
+import { createPinia, setActivePinia } from 'pinia';
 
 const adaptersRef = ref([] as any[]);
 const errorRef = ref<unknown>(null);
 const loadingRef = ref(false);
+const queryState = reactive({ page: 1, perPage: 200 });
 
-const fetchData = vi.fn(async () => {
+const fetchData = vi.fn(async (overrides: Record<string, unknown> = {}) => {
+  loadingRef.value = true;
+  Object.assign(queryState, overrides);
   adaptersRef.value = [
     { id: 'alpha', name: 'Alpha', description: 'First adapter', active: true },
     { id: 'beta', name: 'Beta', description: 'Second adapter', active: false },
   ];
+  loadingRef.value = false;
   return adaptersRef.value;
 });
 
@@ -21,14 +26,14 @@ vi.mock('@/composables/shared', async () => {
     useAdapterListApi: vi.fn(() => ({
       adapters: computed(() => adaptersRef.value),
       error: errorRef,
-      isLoading: loadingRef,
+      isLoading: computed(() => loadingRef.value),
       fetchData,
+      query: queryState,
     })),
   };
 });
 
 import { useAdapterCatalog } from '@/composables/compose/useAdapterCatalog';
-
 type CatalogReturn = ReturnType<typeof useAdapterCatalog>;
 
 const flush = async () => {
@@ -52,9 +57,12 @@ const withSetup = () => {
 
 describe('useAdapterCatalog', () => {
   beforeEach(() => {
+    setActivePinia(createPinia());
     adaptersRef.value = [];
     errorRef.value = null;
     loadingRef.value = false;
+    queryState.page = 1;
+    queryState.perPage = 200;
     fetchData.mockClear();
   });
 
@@ -62,7 +70,7 @@ describe('useAdapterCatalog', () => {
     const state = withSetup();
     await flush();
 
-    expect(fetchData).toHaveBeenCalled();
+    expect(fetchData).toHaveBeenCalledTimes(1);
     expect(state.adapters.value).toHaveLength(2);
     expect(state.adapters.value[1].active).toBe(false);
 
@@ -89,5 +97,17 @@ describe('useAdapterCatalog', () => {
 
     await state.refresh();
     expect(fetchData).toHaveBeenCalledTimes(2);
+  });
+
+  it('only fetches once for multiple subscribers', async () => {
+    const first = withSetup();
+    await flush();
+
+    const second = withSetup();
+    await flush();
+
+    expect(fetchData).toHaveBeenCalledTimes(1);
+    expect(first.adapters.value).toHaveLength(2);
+    expect(second.adapters.value).toHaveLength(2);
   });
 });


### PR DESCRIPTION
## Summary
- add a Pinia adapter catalog store that wraps useAdapterListApi, caches results, and exposes refresh/reset helpers
- refactor useAdapterCatalog and recommendations UI to reuse the shared store instead of local adapter refs
- extend frontend tests to cover cached fetching behaviour and reset the catalog store between specs

## Testing
- npm run test -- useAdapterCatalog.spec.ts
- npx vitest run tests/vue/RecommendationsPanel.spec.js tests/vue/PromptComposer.spec.js

------
https://chatgpt.com/codex/tasks/task_e_68d9d9a7ca508329b4b157971983fbd0