### PR TITLE
Refactor generation studio composition and add integration tests

### DIFF
--- a/app/frontend/src/composables/generation/index.ts
+++ b/app/frontend/src/composables/generation/index.ts
@@ -1,4 +1,5 @@
 export * from './useGenerationStudio';
+export * from './useGenerationStudioController';
 export * from './useGenerationTransport';
 export * from './useGenerationUI';
 export * from './useGenerationUpdates';

--- a/app/frontend/src/composables/generation/useGenerationPersistence.ts
+++ b/app/frontend/src/composables/generation/useGenerationPersistence.ts
@@ -19,8 +19,8 @@ interface UseGenerationPersistenceOptions {
 }
 
 export interface UseGenerationPersistenceReturn {
-  loadSavedParams: () => void
-  saveParams: (value?: GenerationFormState) => void
+  load: () => void
+  save: (value?: GenerationFormState) => void
   savePreset: () => void
   loadFromComposer: () => void
   useRandomPrompt: () => void
@@ -30,7 +30,7 @@ export const useGenerationPersistence = ({
   params,
   showToast,
 }: UseGenerationPersistenceOptions): UseGenerationPersistenceReturn => {
-  const loadSavedParams = (): void => {
+  const load = (): void => {
     try {
       const urlParams = new URLSearchParams(window.location.search)
       const prompt = urlParams.get('prompt')
@@ -58,7 +58,7 @@ export const useGenerationPersistence = ({
 
   let saveDebounceTimeout: ReturnType<typeof setTimeout> | null = null
 
-  const scheduleSaveParams = (value: GenerationFormState = params.value): void => {
+  const scheduleSave = (value: GenerationFormState = params.value): void => {
     if (saveDebounceTimeout) {
       clearTimeout(saveDebounceTimeout)
     }
@@ -69,7 +69,7 @@ export const useGenerationPersistence = ({
     }, 200)
   }
 
-  const saveParams = (value: GenerationFormState = params.value): void => {
+  const save = (value: GenerationFormState = params.value): void => {
     if (saveDebounceTimeout) {
       clearTimeout(saveDebounceTimeout)
       saveDebounceTimeout = null
@@ -121,9 +121,13 @@ export const useGenerationPersistence = ({
     showToast('Random prompt generated', 'success')
   }
 
-  const stopWatching = watch(params, (newParams) => {
-    scheduleSaveParams(newParams)
-  }, { deep: true })
+  const stopWatching = watch(
+    params,
+    (newParams) => {
+      scheduleSave(newParams)
+    },
+    { deep: true },
+  )
 
   onUnmounted(() => {
     if (saveDebounceTimeout) {
@@ -135,8 +139,8 @@ export const useGenerationPersistence = ({
   })
 
   return {
-    loadSavedParams,
-    saveParams,
+    load,
+    save,
     savePreset,
     loadFromComposer,
     useRandomPrompt,

--- a/app/frontend/src/composables/generation/useGenerationStudioController.ts
+++ b/app/frontend/src/composables/generation/useGenerationStudioController.ts
@@ -1,0 +1,73 @@
+import type { Ref } from 'vue'
+
+import { toGenerationRequestPayload } from '@/services/generation/generationService'
+import { useGenerationOrchestrator } from '@/composables/generation/useGenerationOrchestrator'
+import { useGenerationFormStore } from '@/stores/generation'
+import type { GenerationFormState, NotificationType } from '@/types'
+
+export interface UseGenerationStudioControllerOptions {
+  params: Ref<GenerationFormState>
+  notify: (message: string, type?: NotificationType) => void
+  debug?: (...args: unknown[]) => void
+  onAfterStart?: (params: GenerationFormState) => void
+}
+
+export const useGenerationStudioController = ({
+  params,
+  notify,
+  debug,
+  onAfterStart,
+}: UseGenerationStudioControllerOptions) => {
+  const formStore = useGenerationFormStore()
+
+  const orchestrator = useGenerationOrchestrator({
+    notify,
+    debug,
+  })
+
+  const initialize = async (): Promise<void> => {
+    debug?.('Initializing generation controller...')
+    await orchestrator.initialize()
+  }
+
+  const startGeneration = async (): Promise<boolean> => {
+    const trimmedPrompt = params.value.prompt.trim()
+    if (!trimmedPrompt) {
+      notify('Please enter a prompt', 'error')
+      return false
+    }
+
+    formStore.setGenerating(true)
+
+    try {
+      params.value.prompt = trimmedPrompt
+      const payload = toGenerationRequestPayload({ ...params.value, prompt: trimmedPrompt })
+      await orchestrator.startGeneration(payload)
+      onAfterStart?.({ ...params.value })
+      return true
+    } finally {
+      formStore.setGenerating(false)
+    }
+  }
+
+  const refreshResults = async (notifySuccess = true): Promise<void> => {
+    await orchestrator.refreshResults(notifySuccess)
+  }
+
+  return {
+    activeJobs: orchestrator.activeJobs,
+    sortedActiveJobs: orchestrator.sortedActiveJobs,
+    recentResults: orchestrator.recentResults,
+    systemStatus: orchestrator.systemStatus,
+    isConnected: orchestrator.isConnected,
+    initialize,
+    startGeneration,
+    cancelJob: orchestrator.cancelJob,
+    clearQueue: orchestrator.clearQueue,
+    refreshResults,
+    deleteResult: orchestrator.deleteResult,
+    canCancelJob: orchestrator.canCancelJob,
+  }
+}
+
+export type UseGenerationStudioControllerReturn = ReturnType<typeof useGenerationStudioController>

--- a/tests/vue/composables/useGenerationStudio.integration.spec.ts
+++ b/tests/vue/composables/useGenerationStudio.integration.spec.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, beforeEach, afterEach, vi, type Mock } from 'vitest'
+import { defineComponent } from 'vue'
+import { mount, flushPromises } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+
+import { useGenerationStudio } from '@/composables/generation/useGenerationStudio'
+import { useGenerationFormStore } from '@/stores/generation'
+import type { UseGenerationStudioReturn } from '@/composables/generation'
+
+const orchestratorMocks = vi.hoisted(() => {
+  const { ref } = require('vue')
+
+  return {
+    activeJobs: ref([] as unknown[]),
+    sortedActiveJobs: ref([] as unknown[]),
+    recentResults: ref([] as unknown[]),
+    systemStatus: ref({ status: 'healthy' }),
+    isConnected: ref(true),
+    initialize: vi.fn().mockResolvedValue(undefined),
+    startGeneration: vi.fn().mockResolvedValue(undefined),
+    cancelJob: vi.fn().mockResolvedValue(undefined),
+    clearQueue: vi.fn().mockResolvedValue(undefined),
+    refreshResults: vi.fn().mockResolvedValue(undefined),
+    deleteResult: vi.fn().mockResolvedValue(undefined),
+    canCancelJob: vi.fn().mockReturnValue(true),
+  }
+})
+
+vi.mock('@/composables/generation/useGenerationOrchestrator', () => ({
+  useGenerationOrchestrator: vi.fn(() => orchestratorMocks),
+}))
+
+const localStorageMock = {
+  getItem: vi.fn(),
+  setItem: vi.fn(),
+  removeItem: vi.fn(),
+  clear: vi.fn(),
+}
+
+const mountComposable = async () => {
+  const TestComponent = defineComponent({
+    setup(_, { expose }) {
+      const studio = useGenerationStudio()
+      expose({ studio })
+      return () => null
+    },
+  })
+
+  const wrapper = mount(TestComponent)
+  await flushPromises()
+
+  return wrapper as typeof wrapper & { vm: { studio: UseGenerationStudioReturn } }
+}
+
+describe('useGenerationStudio integration', () => {
+  let wrapper: Awaited<ReturnType<typeof mountComposable>>
+
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    setActivePinia(createPinia())
+    Object.defineProperty(window, 'localStorage', {
+      value: localStorageMock,
+      configurable: true,
+    })
+    Object.defineProperty(window, 'confirm', {
+      value: vi.fn().mockReturnValue(true),
+      configurable: true,
+    })
+    localStorageMock.getItem.mockReturnValue(null)
+    wrapper = await mountComposable()
+  })
+
+  afterEach(() => {
+    if (wrapper) {
+      wrapper.unmount()
+    }
+  })
+
+  it('initializes the controller on mount', () => {
+    expect(orchestratorMocks.initialize).toHaveBeenCalled()
+  })
+
+  it('starts a generation job and persists parameters', async () => {
+    const formStore = useGenerationFormStore()
+    formStore.params.prompt = '  integration test prompt  '
+
+    await wrapper.vm.studio.startGeneration()
+
+    expect(orchestratorMocks.startGeneration).toHaveBeenCalledTimes(1)
+    const payload = orchestratorMocks.startGeneration.mock.calls[0][0]
+    expect(payload.prompt).toBe('integration test prompt')
+    expect(localStorageMock.setItem).toHaveBeenCalledWith(
+      'generation_params',
+      expect.stringContaining('"integration test prompt"'),
+    )
+    expect(formStore.isGenerating).toBe(false)
+  })
+
+  it('forwards cancel actions to the controller', async () => {
+    await wrapper.vm.studio.cancelJob('job-456')
+
+    expect(orchestratorMocks.cancelJob).toHaveBeenCalledWith('job-456')
+  })
+
+  it('confirms before deleting results and forwards the action', async () => {
+    const confirmSpy = window.confirm as unknown as Mock
+    confirmSpy.mockReturnValueOnce(true)
+
+    await wrapper.vm.studio.deleteResult('result-789')
+
+    expect(confirmSpy).toHaveBeenCalled()
+    expect(orchestratorMocks.deleteResult).toHaveBeenCalledWith('result-789')
+  })
+})


### PR DESCRIPTION
## Summary
- extract the generation studio transport lifecycle into a dedicated `useGenerationStudioController`
- streamline persistence helpers with a clear load/save interface and compose them inside `useGenerationStudio`
- add integration coverage for start, cancel, and delete flows against the new controller/persistence composition

## Testing
- npm run test -- tests/vue/composables/useGenerationStudio.integration.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68d9df5a56a083299ad1f55796091adc