### PR TITLE
Refactor LoRA gallery to share adapter catalog store

### DIFF
--- a/app/frontend/src/stores/adapterCatalog.ts
+++ b/app/frontend/src/stores/adapterCatalog.ts
@@ -2,8 +2,17 @@ import { computed, ref } from 'vue';
 import { defineStore } from 'pinia';
 
 import { useAdapterListApi } from '@/composables/shared';
+import { fetchAdapterTags, performBulkLoraAction } from '@/services/lora/loraService';
+import { useBackendBase } from '@/utils/backend';
 
-import type { AdapterListQuery, AdapterSummary, LoraListItem } from '@/types';
+import type {
+  AdapterListQuery,
+  AdapterSummary,
+  GalleryLora,
+  LoraBulkAction,
+  LoraListItem,
+  LoraUpdatePayload,
+} from '@/types';
 
 const DEFAULT_QUERY: AdapterListQuery = { page: 1, perPage: 200 };
 
@@ -26,13 +35,86 @@ const hasQueryChanged = (current: AdapterListQuery, next: AdapterListQuery): boo
 export const useAdapterCatalogStore = defineStore('adapterCatalog', () => {
   const pendingFetch = ref<Promise<AdapterSummary[]> | null>(null);
   const lastFetchedAt = ref<number | null>(null);
+  const pendingTagFetch = ref<Promise<string[]> | null>(null);
+  const isInitialized = ref(false);
+  const availableTags = ref<string[]>([]);
+  const tagError = ref<unknown>(null);
 
   const api = useAdapterListApi({ ...DEFAULT_QUERY });
+  const backendBase = useBackendBase();
 
   const query = api.query;
-  const adapters = computed<AdapterSummary[]>(() => api.adapters.value.map(toSummary));
+  const loras = computed<GalleryLora[]>(() => api.adapters.value as GalleryLora[]);
+  const adapters = computed<AdapterSummary[]>(() => loras.value.map(toSummary));
   const error = api.error;
   const isLoading = api.isLoading;
+  const areTagsLoading = computed(() => pendingTagFetch.value !== null);
+
+  const updateListData = (mutator: (draft: GalleryLora[]) => boolean): boolean => {
+    const payload = api.data.value;
+    if (!payload) {
+      return false;
+    }
+
+    if (Array.isArray(payload)) {
+      const draft = [...(payload as GalleryLora[])];
+      const changed = mutator(draft);
+      if (!changed) {
+        return false;
+      }
+      api.data.value = draft as typeof payload;
+      return true;
+    }
+
+    const items = Array.isArray(payload.items) ? [...(payload.items as GalleryLora[])] : [];
+    const changed = mutator(items);
+    if (!changed) {
+      return false;
+    }
+    api.data.value = { ...payload, items } as typeof payload;
+    return true;
+  };
+
+  const applyLoraUpdate = (payload: LoraUpdatePayload): boolean => {
+    const { id, type } = payload;
+    if (!id) {
+      return false;
+    }
+
+    if (type === 'weight' && payload.weight !== undefined) {
+      return updateListData((draft) => {
+        const index = draft.findIndex((item) => item.id === id);
+        if (index === -1) {
+          return false;
+        }
+        draft[index] = { ...draft[index], weight: payload.weight };
+        return true;
+      });
+    }
+
+    if (type === 'active' && payload.active !== undefined) {
+      return updateListData((draft) => {
+        const index = draft.findIndex((item) => item.id === id);
+        if (index === -1) {
+          return false;
+        }
+        draft[index] = { ...draft[index], active: payload.active };
+        return true;
+      });
+    }
+
+    return false;
+  };
+
+  const removeLora = (id: string): boolean =>
+    updateListData((draft) => {
+      const index = draft.findIndex((item) => item.id === id);
+      if (index === -1) {
+        return false;
+      }
+      draft.splice(index, 1);
+      return true;
+    });
 
   const runFetch = async (overrides: AdapterListQuery = {}): Promise<AdapterSummary[]> => {
     if (pendingFetch.value) {
@@ -70,27 +152,97 @@ export const useAdapterCatalogStore = defineStore('adapterCatalog', () => {
     return adapters.value;
   };
 
+  const loadLoras = async (overrides: AdapterListQuery = {}): Promise<GalleryLora[]> => {
+    await ensureLoaded(overrides);
+    return loras.value;
+  };
+
   const refresh = async (overrides: AdapterListQuery = {}): Promise<AdapterSummary[]> => {
     await runFetch(overrides);
     return adapters.value;
   };
 
+  const fetchTags = async (): Promise<string[]> => {
+    if (pendingTagFetch.value) {
+      return pendingTagFetch.value;
+    }
+
+    const request = (async () => {
+      try {
+        const tags = await fetchAdapterTags(backendBase.value);
+        availableTags.value = tags;
+        tagError.value = null;
+        return tags;
+      } catch (err) {
+        console.error('Error fetching adapter tags:', err);
+        availableTags.value = [];
+        tagError.value = err;
+        return [];
+      } finally {
+        pendingTagFetch.value = null;
+      }
+    })();
+
+    pendingTagFetch.value = request;
+    return request;
+  };
+
+  const initialize = async (overrides: AdapterListQuery = {}): Promise<void> => {
+    try {
+      await Promise.all([
+        ensureLoaded(overrides).catch(() => adapters.value),
+        fetchTags(),
+      ]);
+    } finally {
+      isInitialized.value = true;
+    }
+  };
+
+  const performBulkAction = async (action: LoraBulkAction, loraIds: string[]): Promise<void> => {
+    if (!loraIds.length) {
+      return;
+    }
+
+    await performBulkLoraAction(backendBase.value, {
+      action,
+      lora_ids: loraIds,
+    });
+
+    await refresh();
+    await fetchTags();
+  };
+
   const reset = () => {
     pendingFetch.value = null;
     lastFetchedAt.value = null;
+    pendingTagFetch.value = null;
+    isInitialized.value = false;
     api.data.value = null;
     api.error.value = null;
     api.isLoading.value = false;
+    availableTags.value = [];
+    tagError.value = null;
   };
 
   return {
+    isInitialized,
     adapters,
+    loras,
     error,
     isLoading,
     query,
     lastFetchedAt,
     ensureLoaded,
+    loadLoras,
     refresh,
+    initialize,
+    availableTags,
+    areTagsLoading,
+    tagError,
+    fetchTags,
+    performBulkAction,
+    applyLoraUpdate,
+    removeLora,
     reset,
   };
 });


### PR DESCRIPTION
## Summary
- extend the adapter catalog store to expose full gallery records, tag caching, bulk actions, and local update helpers
- refactor the LoRA gallery composable to proxy state and actions through the shared store
- update the gallery component to call the store-driven helpers so prompt composer and other consumers stay in sync

## Testing
- npm run lint *(fails: existing no-restricted-imports violations in unrelated modules)*

------
https://chatgpt.com/codex/tasks/task_e_68d9e366cb448329bbe78ae589981f94