### PR TITLE
refactor: centralize navigation icons

### DIFF
--- a/app/frontend/src/components/layout/MainNavigation.vue
+++ b/app/frontend/src/components/layout/MainNavigation.vue
@@ -68,58 +68,7 @@
           :class="{ active: currentPath === item.path }"
         >
           <span class="inline-flex items-center gap-2">
-            <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor">
-              <path
-                v-if="item.icon === 'dashboard'"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-                d="M3 12V7a2 2 0 0 1 2-2h3l2-2h4l2 2h3a2 2 0 0 1 2 2v5"
-              />
-              <path
-                v-else-if="item.icon === 'grid'"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-                d="M4 6h7v7H4zM13 6h7v7h-7zM4 15h7v7H4zM13 15h7v7h-7z"
-              />
-              <path
-                v-else-if="item.icon === 'spark'"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-                d="m5 3 7 7-7 7m8-12 6 6-6 6"
-              />
-              <path
-                v-else-if="item.icon === 'compose'"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-                d="M11 5H6a2 2 0 0 0-2 2v11a2 2 0 0 0 2 2h11a2 2 0 0 0 2-2v-5M15 3l6 6M8 13h4"
-              />
-              <path
-                v-else-if="item.icon === 'wand'"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-                d="m15 7-1 4-4 1 1-4 4-1ZM3 21l6-6"
-              />
-              <path
-                v-else-if="item.icon === 'admin'"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-                d="M12 12a4 4 0 1 0-4-4 4 4 0 0 0 4 4Zm-8 8a8 8 0 0 1 16 0"
-              />
-              <path
-                v-else-if="item.icon === 'bars'"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-                d="M9 19v-6a2 2 0 0 0-2-2H5a2 2 0 0 0-2 2v6m8 0V9a2 2 0 0 1 2-2h2a2 2 0 0 1 2 2v10"
-              />
-              <path v-else stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
-            </svg>
+            <NavigationIcon class="h-4 w-4" :icon="item.icon" />
             {{ item.label }}
           </span>
         </RouterLink>
@@ -135,6 +84,8 @@ import { useRoute, useRouter, RouterLink } from 'vue-router';
 import { useAppStore } from '@/stores';
 import { useTheme } from '@/composables/shared';
 import { NAVIGATION_ITEMS } from '@/config/navigation';
+
+import NavigationIcon from './NavigationIcon.vue';
 
 const appStore = useAppStore();
 const router = useRouter();

--- a/app/frontend/src/components/layout/MobileNav.vue
+++ b/app/frontend/src/components/layout/MobileNav.vue
@@ -48,58 +48,7 @@
           @click="closeMenu"
         >
           <span class="inline-flex items-center">
-            <svg class="w-5 h-5 mr-3 inline" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path
-                v-if="item.icon === 'dashboard'"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-                d="M3 12l2-2m0 0 7-7 7 7M13 5v6a2 2 0 0 0 2 2h6"
-              />
-              <path
-                v-else-if="item.icon === 'grid'"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-                d="M4 6h7v7H4V6zm9 0h7v7h-7V6zM4 15h7v7H4v-7zm9 0h7v7h-7v-7z"
-              />
-              <path
-                v-else-if="item.icon === 'spark'"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-                d="M5 3l7 7-7 7m8-12 6 6-6 6"
-              />
-              <path
-                v-else-if="item.icon === 'compose'"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-                d="M11 5H6a2 2 0 0 0-2 2v11a2 2 0 0 0 2 2h11a2 2 0 0 0 2-2v-5M15 3l6 6M8 13h4"
-              />
-              <path
-                v-else-if="item.icon === 'wand'"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-                d="m15 7-1 4-4 1 1-4 4-1ZM3 21l6-6"
-              />
-              <path
-                v-else-if="item.icon === 'admin'"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-                d="M12 12c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zM4 20a8 8 0 0 1 16 0"
-              />
-              <path
-                v-else-if="item.icon === 'bars'"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-                d="M9 19v-6a2 2 0 0 0-2-2H5a2 2 0 0 0-2 2v6m8 0V9a2 2 0 0 1 2-2h2a2 2 0 0 1 2 2v10"
-              />
-              <path v-else stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
-            </svg>
+            <NavigationIcon class="w-5 h-5 mr-3 inline" :icon="item.icon" />
             {{ item.label }}
           </span>
         </RouterLink>
@@ -117,6 +66,8 @@ import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue';
 import { RouterLink, useRoute } from 'vue-router';
 
 import { NAVIGATION_ITEMS } from '@/config/navigation';
+
+import NavigationIcon from './NavigationIcon.vue';
 
 const isOpen = ref(false);
 const items = NAVIGATION_ITEMS;

--- a/app/frontend/src/components/layout/NavigationIcon.vue
+++ b/app/frontend/src/components/layout/NavigationIcon.vue
@@ -1,0 +1,39 @@
+<template>
+  <svg v-bind="$attrs" viewBox="0 0 24 24" fill="none" stroke="currentColor">
+    <path
+      :d="iconPath"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      stroke-width="2"
+    />
+  </svg>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue';
+
+import type { NavigationIconKey } from '@/config/navigation';
+
+const props = defineProps<{
+  icon?: NavigationIconKey | null;
+}>();
+
+const ICON_PATHS: Record<NavigationIconKey | 'default', string> = {
+  dashboard: 'M3 12V7a2 2 0 0 1 2-2h3l2-2h4l2 2h3a2 2 0 0 1 2 2v5',
+  grid: 'M4 6h7v7H4zM13 6h7v7h-7zM4 15h7v7H4zM13 15h7v7h-7z',
+  spark: 'm5 3 7 7-7 7m8-12 6 6-6 6',
+  compose: 'M11 5H6a2 2 0 0 0-2 2v11a2 2 0 0 0 2 2h11a2 2 0 0 0 2-2v-5M15 3l6 6M8 13h4',
+  wand: 'm15 7-1 4-4 1 1-4 4-1ZM3 21l6-6',
+  admin: 'M12 12a4 4 0 1 0-4-4 4 4 0 0 0 4 4Zm-8 8a8 8 0 0 1 16 0',
+  bars: 'M9 19v-6a2 2 0 0 0-2-2H5a2 2 0 0 0-2 2v6m8 0V9a2 2 0 0 1 2-2h2a2 2 0 0 1 2 2v10',
+  default: 'M4 6h16M4 12h16M4 18h16',
+};
+
+const iconPath = computed(() => {
+  if (!props.icon) {
+    return ICON_PATHS.default;
+  }
+
+  return ICON_PATHS[props.icon] ?? ICON_PATHS.default;
+});
+</script>


### PR DESCRIPTION
## Summary
- add a reusable NavigationIcon component to render shared navigation SVG paths
- update main and mobile navigation components to consume the shared icon renderer and keep existing styling

## Testing
- npm run lint -- --max-warnings=0 *(fails: existing restricted import rules unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68d9e36d689483298dbb0b58d1cdd640