### PR TITLE
Add dashboard summaries and lazy-loaded modules

### DIFF
--- a/app/frontend/src/components/dashboard/DashboardGenerationSummary.vue
+++ b/app/frontend/src/components/dashboard/DashboardGenerationSummary.vue
@@ -1,0 +1,163 @@
+<template>
+  <div class="card h-full">
+    <div class="card-body flex flex-col gap-6">
+      <div class="flex items-center justify-between gap-3">
+        <div>
+          <h3 class="text-lg font-semibold text-gray-900">Generation Snapshot</h3>
+          <p class="text-sm text-gray-500">Recent jobs and high-level metrics from your history.</p>
+        </div>
+        <div class="flex flex-col gap-2 sm:flex-row sm:items-center">
+          <RouterLink class="btn btn-secondary btn-sm" to="/generate">
+            Start new job
+          </RouterLink>
+          <RouterLink class="btn btn-ghost btn-sm" to="/history">
+            View history
+          </RouterLink>
+        </div>
+      </div>
+
+      <div class="grid grid-cols-2 gap-3 text-center sm:grid-cols-4">
+        <div class="rounded-lg border border-gray-200 bg-gray-50 p-3">
+          <div class="text-xl font-semibold text-gray-900">{{ stats.total_results }}</div>
+          <div class="text-xs uppercase tracking-wide text-gray-500">Images</div>
+        </div>
+        <div class="rounded-lg border border-gray-200 bg-emerald-50 p-3">
+          <div class="text-xl font-semibold text-emerald-700">{{ formattedAverage }}</div>
+          <div class="text-xs uppercase tracking-wide text-emerald-700">Avg rating</div>
+        </div>
+        <div class="rounded-lg border border-gray-200 bg-indigo-50 p-3">
+          <div class="text-xl font-semibold text-indigo-700">{{ stats.total_favorites }}</div>
+          <div class="text-xs uppercase tracking-wide text-indigo-700">Favorites</div>
+        </div>
+        <div class="rounded-lg border border-gray-200 bg-sky-50 p-3">
+          <div class="text-xl font-semibold text-sky-700">{{ formattedSize }}</div>
+          <div class="text-xs uppercase tracking-wide text-sky-700">Storage</div>
+        </div>
+      </div>
+
+      <div>
+        <div class="flex items-center justify-between">
+          <h4 class="text-sm font-semibold text-gray-700">Latest results</h4>
+          <button
+            type="button"
+            class="btn btn-ghost btn-xs"
+            :disabled="isLoading"
+            @click="refresh"
+          >
+            <span v-if="isLoading" class="flex items-center gap-2">
+              <span class="loading loading-spinner loading-xs"></span>
+              Updating…
+            </span>
+            <span v-else>Refresh</span>
+          </button>
+        </div>
+        <ul v-if="recentResults.length" class="mt-3 space-y-2">
+          <li
+            v-for="item in recentResults"
+            :key="item.id"
+            class="flex items-start justify-between gap-3 rounded-lg border border-gray-200 p-3"
+          >
+            <div>
+              <p class="font-medium text-gray-900">
+                {{ item.prompt ? truncate(item.prompt, 100) : 'Untitled generation' }}
+              </p>
+              <p class="text-xs text-gray-500">
+                {{ item.width ?? '—' }}×{{ item.height ?? '—' }} · CFG {{ item.cfg_scale ?? '—' }}
+              </p>
+            </div>
+            <div class="shrink-0 text-right text-xs text-gray-500">
+              <div>{{ formatRelativeTime(item.created_at ?? '') }}</div>
+              <div v-if="item.rating != null" class="text-amber-600">
+                ★ {{ Number(item.rating).toFixed(1) }}
+              </div>
+              <div v-else-if="item.is_favorite" class="text-indigo-600">
+                Favorited
+              </div>
+            </div>
+          </li>
+        </ul>
+        <div v-else-if="isLoading" class="mt-3 flex flex-col items-center gap-2 text-sm text-gray-500">
+          <span class="loading loading-spinner loading-sm"></span>
+          Loading generation history…
+        </div>
+        <div v-else class="mt-3 rounded-md border border-dashed border-gray-200 bg-gray-50 p-4 text-sm text-gray-500">
+          No generation history is available yet. Launch a new job to populate this feed.
+        </div>
+      </div>
+
+      <p v-if="error" class="rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-700">
+        Unable to refresh generation summary. {{ errorMessage }}
+      </p>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, ref } from 'vue';
+import { storeToRefs } from 'pinia';
+import { RouterLink } from 'vue-router';
+
+import { useGenerationHistoryApi } from '@/services';
+import { useGenerationResultsStore } from '@/stores/generation';
+import { useBackendBase } from '@/utils/backend';
+import { formatFileSize, formatRelativeTime } from '@/utils/format';
+import type { GenerationHistoryResult, GenerationHistoryStats } from '@/types';
+
+const SUMMARY_QUERY = Object.freeze({ page_size: 4, sort: 'created_at_desc' as const });
+
+const backendBase = useBackendBase();
+const historyApi = useGenerationHistoryApi(backendBase, { ...SUMMARY_QUERY });
+const resultsStore = useGenerationResultsStore();
+const { recentResults: storeResults } = storeToRefs(resultsStore);
+
+const stats = ref<GenerationHistoryStats>({
+  total_results: 0,
+  avg_rating: 0,
+  total_favorites: 0,
+  total_size: 0,
+});
+
+const fetchedResults = ref<GenerationHistoryResult[]>([]);
+
+const isLoading = computed(() => historyApi.isLoading.value);
+const error = computed(() => historyApi.error.value);
+const errorMessage = computed(() => (error.value instanceof Error ? error.value.message : 'Please try again.'));
+
+const formattedAverage = computed(() => stats.value.avg_rating.toFixed(1));
+const formattedSize = computed(() => formatFileSize(stats.value.total_size));
+
+const recentResults = computed(() => {
+  const limit = SUMMARY_QUERY.page_size ?? 4;
+  if (fetchedResults.value.length) {
+    return fetchedResults.value.slice(0, limit);
+  }
+  if (storeResults.value.length) {
+    return storeResults.value.slice(0, limit);
+  }
+  return historyApi.results.value.slice(0, limit);
+});
+
+const truncate = (value: string, maxLength: number) => {
+  if (!value || value.length <= maxLength) {
+    return value;
+  }
+  return `${value.slice(0, maxLength)}…`;
+};
+
+const refresh = async () => {
+  try {
+    const output = await historyApi.fetchPage({ ...SUMMARY_QUERY });
+    stats.value = output.stats;
+    fetchedResults.value = output.results;
+    if (!storeResults.value.length && output.results.length) {
+      resultsStore.setResults(output.results);
+    }
+  } catch (err) {
+    console.error('Failed to refresh generation summary', err);
+  }
+};
+
+onMounted(async () => {
+  await refresh();
+});
+</script>

--- a/app/frontend/src/components/dashboard/DashboardLazyModuleCard.vue
+++ b/app/frontend/src/components/dashboard/DashboardLazyModuleCard.vue
@@ -1,0 +1,85 @@
+<template>
+  <div class="card h-full">
+    <div class="card-body flex flex-col gap-4">
+      <div class="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+        <div class="space-y-1">
+          <h3 class="text-lg font-semibold text-gray-900">{{ title }}</h3>
+          <p class="text-sm text-gray-500">{{ description }}</p>
+        </div>
+        <div class="flex flex-col gap-2 sm:flex-row sm:items-center">
+          <RouterLink
+            v-if="route"
+            :to="route"
+            class="btn btn-secondary btn-sm"
+          >
+            {{ ctaLabel }}
+          </RouterLink>
+          <button
+            type="button"
+            class="btn btn-primary btn-sm"
+            :class="{ 'btn-outline': isActive }"
+            :disabled="isLoading"
+            @click="$emit('toggle')"
+          >
+            <span v-if="isLoading" class="flex items-center gap-2">
+              <span class="loading loading-spinner loading-xs"></span>
+              Loading…
+            </span>
+            <span v-else-if="isActive">
+              Hide module
+            </span>
+            <span v-else>
+              {{ loadLabel }}
+            </span>
+          </button>
+        </div>
+      </div>
+
+      <div v-if="isActive" class="border-t border-gray-200 pt-4">
+        <slot />
+      </div>
+      <div v-else class="rounded-md border border-dashed border-gray-200 bg-gray-50 p-4 text-sm text-gray-500">
+        <slot name="placeholder">
+          Activate this panel to work with the full module without leaving the dashboard.
+        </slot>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { RouterLink } from 'vue-router';
+
+defineProps({
+  title: {
+    type: String,
+    required: true,
+  },
+  description: {
+    type: String,
+    required: true,
+  },
+  route: {
+    type: String,
+    default: '',
+  },
+  ctaLabel: {
+    type: String,
+    default: 'Open full page',
+  },
+  loadLabel: {
+    type: String,
+    default: 'Load inline',
+  },
+  isActive: {
+    type: Boolean,
+    default: false,
+  },
+  isLoading: {
+    type: Boolean,
+    default: false,
+  },
+});
+
+defineEmits<{ (event: 'toggle'): void }>();
+</script>

--- a/app/frontend/src/components/dashboard/DashboardLoraSummary.vue
+++ b/app/frontend/src/components/dashboard/DashboardLoraSummary.vue
@@ -1,0 +1,128 @@
+<template>
+  <div class="card h-full">
+    <div class="card-body flex flex-col gap-6">
+      <div class="flex flex-col gap-2">
+        <div class="flex items-center justify-between gap-3">
+          <div>
+            <h3 class="text-lg font-semibold text-gray-900">LoRA Catalog Snapshot</h3>
+            <p class="text-sm text-gray-500">Latest adapters and their activity status.</p>
+          </div>
+          <RouterLink class="btn btn-secondary btn-sm" to="/loras">
+            Manage LoRAs
+          </RouterLink>
+        </div>
+        <div class="grid grid-cols-3 gap-3 text-center">
+          <div class="rounded-lg border border-gray-200 bg-gray-50 p-3">
+            <div class="text-2xl font-semibold text-gray-900">{{ totalLoras }}</div>
+            <div class="text-xs uppercase tracking-wide text-gray-500">Total</div>
+          </div>
+          <div class="rounded-lg border border-gray-200 bg-emerald-50 p-3">
+            <div class="text-2xl font-semibold text-emerald-700">{{ activeLoras }}</div>
+            <div class="text-xs uppercase tracking-wide text-emerald-700">Active</div>
+          </div>
+          <div class="rounded-lg border border-gray-200 bg-amber-50 p-3">
+            <div class="text-2xl font-semibold text-amber-700">{{ inactiveLoras }}</div>
+            <div class="text-xs uppercase tracking-wide text-amber-700">Inactive</div>
+          </div>
+        </div>
+      </div>
+
+      <div>
+        <div class="flex items-center justify-between">
+          <h4 class="text-sm font-semibold text-gray-700">Recently updated</h4>
+          <button
+            type="button"
+            class="btn btn-ghost btn-xs"
+            :disabled="isLoading"
+            @click="refresh"
+          >
+            <span v-if="isLoading" class="flex items-center gap-2">
+              <span class="loading loading-spinner loading-xs"></span>
+              Updating…
+            </span>
+            <span v-else>
+              Refresh
+            </span>
+          </button>
+        </div>
+        <ul v-if="recentLoras.length" class="mt-3 space-y-2">
+          <li
+            v-for="item in recentLoras"
+            :key="item.id"
+            class="flex items-start justify-between gap-3 rounded-lg border border-gray-200 p-3"
+          >
+            <div>
+              <p class="font-medium text-gray-900">{{ item.name }}</p>
+              <p class="text-xs text-gray-500">
+                {{ item.description ? truncate(item.description, 96) : 'No description available.' }}
+              </p>
+            </div>
+            <div class="shrink-0 text-right text-xs text-gray-500">
+              <div>{{ formatRelativeTime(item.updated_at ?? item.created_at ?? '') }}</div>
+              <div :class="item.active ? 'text-emerald-600' : 'text-amber-600'">
+                {{ item.active ? 'Active' : 'Inactive' }}
+              </div>
+            </div>
+          </li>
+        </ul>
+        <div v-else-if="isLoading" class="mt-3 flex flex-col items-center gap-2 text-sm text-gray-500">
+          <span class="loading loading-spinner loading-sm"></span>
+          Loading adapter data…
+        </div>
+        <div v-else class="mt-3 rounded-md border border-dashed border-gray-200 bg-gray-50 p-4 text-sm text-gray-500">
+          No adapters are loaded yet. Import a LoRA to get started.
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted } from 'vue';
+import { storeToRefs } from 'pinia';
+import { RouterLink } from 'vue-router';
+
+import { useAdapterCatalogStore } from '@/stores';
+import { formatRelativeTime } from '@/utils/format';
+
+const SUMMARY_QUERY = Object.freeze({ perPage: 12, sort: 'last_updated_desc' as const });
+
+const catalogStore = useAdapterCatalogStore();
+const { loras, isLoading } = storeToRefs(catalogStore);
+
+const totalLoras = computed(() => loras.value.length);
+const activeLoras = computed(() => loras.value.filter((item) => item.active !== false).length);
+const inactiveLoras = computed(() => Math.max(0, totalLoras.value - activeLoras.value));
+const getTimestamp = (value: string | undefined | null): number => {
+  if (!value) {
+    return 0;
+  }
+  const parsed = new Date(value).getTime();
+  return Number.isFinite(parsed) ? parsed : 0;
+};
+
+const recentLoras = computed(() =>
+  [...loras.value]
+    .sort((a, b) => getTimestamp(b.updated_at ?? b.created_at) - getTimestamp(a.updated_at ?? a.created_at))
+    .slice(0, 5),
+);
+
+const truncate = (value: string, maxLength: number) => {
+  if (!value || value.length <= maxLength) {
+    return value;
+  }
+  return `${value.slice(0, maxLength)}…`;
+};
+
+const refresh = async () => {
+  await catalogStore.ensureLoaded(SUMMARY_QUERY);
+};
+
+onMounted(async () => {
+  if (!loras.value.length) {
+    await refresh();
+  } else {
+    void catalogStore.ensureLoaded(SUMMARY_QUERY);
+  }
+});
+</script>

--- a/app/frontend/src/views/DashboardView.vue
+++ b/app/frontend/src/views/DashboardView.vue
@@ -5,9 +5,14 @@
       subtitle="Monitor system health, track jobs, and explore LoRA insights at a glance."
     >
       <template #actions>
-        <RouterLink class="btn btn-secondary btn-sm" to="/loras">
-          Browse LoRAs
-        </RouterLink>
+        <div class="flex gap-2">
+          <RouterLink class="btn btn-secondary btn-sm" to="/loras">
+            Browse LoRAs
+          </RouterLink>
+          <RouterLink class="btn btn-primary btn-sm" to="/generate">
+            Launch Studio
+          </RouterLink>
+        </div>
       </template>
     </PageHeader>
 
@@ -22,44 +27,235 @@
     </section>
 
     <section class="grid gap-6 xl:grid-cols-2">
-      <PerformanceAnalytics :show-page-header="false" :show-system-status="false" />
+      <DashboardLoraSummary />
+      <DashboardGenerationSummary />
+    </section>
+
+    <section class="grid gap-6 xl:grid-cols-2">
+      <DashboardLazyModuleCard
+        title="Performance analytics"
+        description="Visualize trends and KPI insights from the analytics suite."
+        route="/analytics"
+        cta-label="Open analytics"
+        :is-active="panels.analytics.active"
+        :is-loading="panels.analytics.loading"
+        @toggle="togglePanel('analytics')"
+      >
+        <template #placeholder>
+          Load the analytics module inline or open the dedicated analytics page for the complete dashboard.
+        </template>
+        <Suspense @pending="markPending('analytics')" @resolve="markResolved('analytics')">
+          <template #default>
+            <PerformanceAnalytics :show-page-header="false" :show-system-status="false" />
+          </template>
+          <template #fallback>
+            <div class="flex items-center justify-center py-6 text-sm text-gray-500">
+              <span class="loading loading-spinner loading-sm mr-2"></span>
+              Loading analytics…
+            </div>
+          </template>
+        </Suspense>
+      </DashboardLazyModuleCard>
       <SystemStatusPanel />
     </section>
 
     <section class="grid gap-6 xl:grid-cols-2">
-      <PromptComposer />
-      <GenerationStudio />
+      <DashboardLazyModuleCard
+        title="Prompt composer"
+        description="Draft prompts and queue presets without leaving this page."
+        route="/compose"
+        cta-label="Open composer"
+        :is-active="panels.composer.active"
+        :is-loading="panels.composer.loading"
+        @toggle="togglePanel('composer')"
+      >
+        <template #placeholder>
+          Activate the composer inline to reuse saved prompts or jump directly to the full composition workspace.
+        </template>
+        <Suspense @pending="markPending('composer')" @resolve="markResolved('composer')">
+          <template #default>
+            <PromptComposer />
+          </template>
+          <template #fallback>
+            <div class="flex items-center justify-center py-6 text-sm text-gray-500">
+              <span class="loading loading-spinner loading-sm mr-2"></span>
+              Loading prompt composer…
+            </div>
+          </template>
+        </Suspense>
+      </DashboardLazyModuleCard>
+
+      <DashboardLazyModuleCard
+        title="Generation studio"
+        description="Run complex jobs with live queue monitoring and inline previews."
+        route="/generate"
+        cta-label="Open studio"
+        :is-active="panels.studio.active"
+        :is-loading="panels.studio.loading"
+        @toggle="togglePanel('studio')"
+      >
+        <template #placeholder>
+          Use the inline studio for quick jobs or switch to the dedicated page for the full orchestrator experience.
+        </template>
+        <Suspense @pending="markPending('studio')" @resolve="markResolved('studio')">
+          <template #default>
+            <GenerationStudio />
+          </template>
+          <template #fallback>
+            <div class="flex items-center justify-center py-6 text-sm text-gray-500">
+              <span class="loading loading-spinner loading-sm mr-2"></span>
+              Loading generation studio…
+            </div>
+          </template>
+        </Suspense>
+      </DashboardLazyModuleCard>
     </section>
 
     <section class="grid gap-6 xl:grid-cols-2">
-      <LoraGallery />
-      <GenerationHistory />
+      <DashboardLazyModuleCard
+        title="LoRA gallery"
+        description="Review adapters, apply tags, and launch bulk operations."
+        route="/loras"
+        cta-label="Open gallery"
+        :is-active="panels.gallery.active"
+        :is-loading="panels.gallery.loading"
+        @toggle="togglePanel('gallery')"
+      >
+        <template #placeholder>
+          Quickly browse the gallery inline or open the dedicated gallery for the full management toolkit.
+        </template>
+        <Suspense @pending="markPending('gallery')" @resolve="markResolved('gallery')">
+          <template #default>
+            <LoraGallery />
+          </template>
+          <template #fallback>
+            <div class="flex items-center justify-center py-6 text-sm text-gray-500">
+              <span class="loading loading-spinner loading-sm mr-2"></span>
+              Loading LoRA gallery…
+            </div>
+          </template>
+        </Suspense>
+      </DashboardLazyModuleCard>
+
+      <DashboardLazyModuleCard
+        title="Generation history"
+        description="Audit completed jobs, manage favorites, and export images."
+        route="/history"
+        cta-label="Open history"
+        :is-active="panels.history.active"
+        :is-loading="panels.history.loading"
+        @toggle="togglePanel('history')"
+      >
+        <template #placeholder>
+          Load a lightweight history viewer inline or head to the history page for advanced filtering and exports.
+        </template>
+        <Suspense @pending="markPending('history')" @resolve="markResolved('history')">
+          <template #default>
+            <GenerationHistory />
+          </template>
+          <template #fallback>
+            <div class="flex items-center justify-center py-6 text-sm text-gray-500">
+              <span class="loading loading-spinner loading-sm mr-2"></span>
+              Loading generation history…
+            </div>
+          </template>
+        </Suspense>
+      </DashboardLazyModuleCard>
     </section>
 
     <section class="grid gap-6">
-      <ImportExportContainer />
+      <DashboardLazyModuleCard
+        title="Import & export"
+        description="Manage backups and move adapters between environments."
+        route="/import-export"
+        cta-label="Open tools"
+        :is-active="panels.importExport.active"
+        :is-loading="panels.importExport.loading"
+        @toggle="togglePanel('importExport')"
+      >
+        <template #placeholder>
+          Bring the import/export utilities inline for quick actions or open the dedicated workspace for bulk jobs.
+        </template>
+        <Suspense @pending="markPending('importExport')" @resolve="markResolved('importExport')">
+          <template #default>
+            <ImportExportContainer />
+          </template>
+          <template #fallback>
+            <div class="flex items-center justify-center py-6 text-sm text-gray-500">
+              <span class="loading loading-spinner loading-sm mr-2"></span>
+              Loading import/export tools…
+            </div>
+          </template>
+        </Suspense>
+      </DashboardLazyModuleCard>
     </section>
   </div>
 </template>
 
 <script setup lang="ts">
+import { defineAsyncComponent, reactive } from 'vue';
 import { RouterLink } from 'vue-router';
 
-import { defineAsyncComponent } from 'vue';
-
-import GenerationHistory from '@/components/history/GenerationHistory.vue';
-import GenerationStudio from '@/components/generation/GenerationStudio.vue';
-import ImportExportContainer from '@/components/import-export/ImportExportContainer.vue';
+import DashboardGenerationSummary from '@/components/dashboard/DashboardGenerationSummary.vue';
+import DashboardLazyModuleCard from '@/components/dashboard/DashboardLazyModuleCard.vue';
+import DashboardLoraSummary from '@/components/dashboard/DashboardLoraSummary.vue';
 import JobQueue from '@/components/shared/JobQueue.vue';
-import LoraGallery from '@/components/lora-gallery/LoraGallery.vue';
 import PageHeader from '@/components/layout/PageHeader.vue';
-import PromptComposer from '@/components/compose/PromptComposer.vue';
 import RecommendationsPanel from '@/components/recommendations/RecommendationsPanel.vue';
 import SystemAdminStatusCard from '@/components/system/SystemAdminStatusCard.vue';
 import SystemStatusCard from '@/components/system/SystemStatusCard.vue';
 import SystemStatusPanel from '@/components/system/SystemStatusPanel.vue';
 
-const PerformanceAnalytics = defineAsyncComponent(
-  () => import('@/views/analytics/PerformanceAnalyticsPage.vue'),
+const PerformanceAnalytics = defineAsyncComponent(() =>
+  import('@/views/analytics/PerformanceAnalyticsPage.vue'),
 );
+const PromptComposer = defineAsyncComponent(() => import('@/components/compose/PromptComposer.vue'));
+const GenerationStudio = defineAsyncComponent(() => import('@/components/generation/GenerationStudio.vue'));
+const LoraGallery = defineAsyncComponent(() => import('@/components/lora-gallery/LoraGallery.vue'));
+const GenerationHistory = defineAsyncComponent(() => import('@/components/history/GenerationHistory.vue'));
+const ImportExportContainer = defineAsyncComponent(
+  () => import('@/components/import-export/ImportExportContainer.vue'),
+);
+
+type PanelKey = 'analytics' | 'composer' | 'studio' | 'gallery' | 'history' | 'importExport';
+
+const panels = reactive<Record<PanelKey, { active: boolean; loading: boolean; hasEverLoaded: boolean }>>({
+  analytics: { active: false, loading: false, hasEverLoaded: false },
+  composer: { active: false, loading: false, hasEverLoaded: false },
+  studio: { active: false, loading: false, hasEverLoaded: false },
+  gallery: { active: false, loading: false, hasEverLoaded: false },
+  history: { active: false, loading: false, hasEverLoaded: false },
+  importExport: { active: false, loading: false, hasEverLoaded: false },
+});
+
+const togglePanel = (key: PanelKey) => {
+  const panel = panels[key];
+  if (!panel) {
+    return;
+  }
+  if (panel.active) {
+    panel.active = false;
+    panel.loading = false;
+    return;
+  }
+  panel.active = true;
+  panel.loading = !panel.hasEverLoaded;
+};
+
+const markPending = (key: PanelKey) => {
+  const panel = panels[key];
+  if (!panel) {
+    return;
+  }
+  panel.loading = true;
+};
+
+const markResolved = (key: PanelKey) => {
+  const panel = panels[key];
+  if (!panel) {
+    return;
+  }
+  panel.loading = false;
+  panel.hasEverLoaded = true;
+};
 </script>


### PR DESCRIPTION
## Summary
- add lightweight dashboard summaries for LoRA catalog and recent generations
- introduce a reusable lazy module card and gate heavy dashboard modules behind user-triggered loads
- update the dashboard layout to surface the new summaries by default while preserving links to full pages

## Testing
- npm run lint *(fails: existing repository-wide lint violations about restricted import paths)*
- npx eslint app/frontend/src/components/dashboard/DashboardGenerationSummary.vue
- npx eslint app/frontend/src/components/dashboard/DashboardLoraSummary.vue app/frontend/src/components/dashboard/DashboardLazyModuleCard.vue app/frontend/src/views/DashboardView.vue

------
https://chatgpt.com/codex/tasks/task_e_68da9ac6eb7883298abe4106b74b8645