### PR TITLE
Refactor dashboard lazy panels to use configuration-driven rendering

### DIFF
--- a/app/frontend/src/views/DashboardView.vue
+++ b/app/frontend/src/views/DashboardView.vue
@@ -32,162 +32,37 @@
     </section>
 
     <section class="grid gap-6 xl:grid-cols-2">
-      <DashboardLazyModuleCard
-        title="Performance analytics"
-        description="Visualize trends and KPI insights from the analytics suite."
-        route="/analytics"
-        cta-label="Open analytics"
-        :is-active="panels.analytics.active"
-        :is-loading="panels.analytics.loading"
-        @toggle="togglePanel('analytics')"
-      >
-        <template #placeholder>
-          Load the analytics module inline or open the dedicated analytics page for the complete dashboard.
-        </template>
-        <Suspense @pending="markPending('analytics')" @resolve="markResolved('analytics')">
-          <template #default>
-            <PerformanceAnalytics :show-page-header="false" :show-system-status="false" />
+      <template v-for="panel in panels" :key="panel.key">
+        <DashboardLazyModuleCard
+          :key="panel.key"
+          :title="panel.title"
+          :description="panel.description"
+          :route="panel.route"
+          :cta-label="panel.ctaLabel"
+          :is-active="panelStates[panel.key].active"
+          :is-loading="panelStates[panel.key].loading"
+          @toggle="handlePanelToggle(panel.key)"
+        >
+          <template #placeholder>
+            {{ panel.placeholder }}
           </template>
-          <template #fallback>
-            <div class="flex items-center justify-center py-6 text-sm text-gray-500">
-              <span class="loading loading-spinner loading-sm mr-2"></span>
-              Loading analytics…
-            </div>
-          </template>
-        </Suspense>
-      </DashboardLazyModuleCard>
-      <SystemStatusPanel />
-    </section>
-
-    <section class="grid gap-6 xl:grid-cols-2">
-      <DashboardLazyModuleCard
-        title="Prompt composer"
-        description="Draft prompts and queue presets without leaving this page."
-        route="/compose"
-        cta-label="Open composer"
-        :is-active="panels.composer.active"
-        :is-loading="panels.composer.loading"
-        @toggle="togglePanel('composer')"
-      >
-        <template #placeholder>
-          Activate the composer inline to reuse saved prompts or jump directly to the full composition workspace.
-        </template>
-        <Suspense @pending="markPending('composer')" @resolve="markResolved('composer')">
-          <template #default>
-            <PromptComposer />
-          </template>
-          <template #fallback>
-            <div class="flex items-center justify-center py-6 text-sm text-gray-500">
-              <span class="loading loading-spinner loading-sm mr-2"></span>
-              Loading prompt composer…
-            </div>
-          </template>
-        </Suspense>
-      </DashboardLazyModuleCard>
-
-      <DashboardLazyModuleCard
-        title="Generation studio"
-        description="Run complex jobs with live queue monitoring and inline previews."
-        route="/generate"
-        cta-label="Open studio"
-        :is-active="panels.studio.active"
-        :is-loading="panels.studio.loading"
-        @toggle="togglePanel('studio')"
-      >
-        <template #placeholder>
-          Use the inline studio for quick jobs or switch to the dedicated page for the full orchestrator experience.
-        </template>
-        <Suspense @pending="markPending('studio')" @resolve="markResolved('studio')">
-          <template #default>
-            <GenerationStudio />
-          </template>
-          <template #fallback>
-            <div class="flex items-center justify-center py-6 text-sm text-gray-500">
-              <span class="loading loading-spinner loading-sm mr-2"></span>
-              Loading generation studio…
-            </div>
-          </template>
-        </Suspense>
-      </DashboardLazyModuleCard>
-    </section>
-
-    <section class="grid gap-6 xl:grid-cols-2">
-      <DashboardLazyModuleCard
-        title="LoRA gallery"
-        description="Review adapters, apply tags, and launch bulk operations."
-        route="/loras"
-        cta-label="Open gallery"
-        :is-active="panels.gallery.active"
-        :is-loading="panels.gallery.loading"
-        @toggle="togglePanel('gallery')"
-      >
-        <template #placeholder>
-          Quickly browse the gallery inline or open the dedicated gallery for the full management toolkit.
-        </template>
-        <Suspense @pending="markPending('gallery')" @resolve="markResolved('gallery')">
-          <template #default>
-            <LoraGallery />
-          </template>
-          <template #fallback>
-            <div class="flex items-center justify-center py-6 text-sm text-gray-500">
-              <span class="loading loading-spinner loading-sm mr-2"></span>
-              Loading LoRA gallery…
-            </div>
-          </template>
-        </Suspense>
-      </DashboardLazyModuleCard>
-
-      <DashboardLazyModuleCard
-        title="Generation history"
-        description="Audit completed jobs, manage favorites, and export images."
-        route="/history"
-        cta-label="Open history"
-        :is-active="panels.history.active"
-        :is-loading="panels.history.loading"
-        @toggle="togglePanel('history')"
-      >
-        <template #placeholder>
-          Load a lightweight history viewer inline or head to the history page for advanced filtering and exports.
-        </template>
-        <Suspense @pending="markPending('history')" @resolve="markResolved('history')">
-          <template #default>
-            <GenerationHistory />
-          </template>
-          <template #fallback>
-            <div class="flex items-center justify-center py-6 text-sm text-gray-500">
-              <span class="loading loading-spinner loading-sm mr-2"></span>
-              Loading generation history…
-            </div>
-          </template>
-        </Suspense>
-      </DashboardLazyModuleCard>
-    </section>
-
-    <section class="grid gap-6">
-      <DashboardLazyModuleCard
-        title="Import & export"
-        description="Manage backups and move adapters between environments."
-        route="/import-export"
-        cta-label="Open tools"
-        :is-active="panels.importExport.active"
-        :is-loading="panels.importExport.loading"
-        @toggle="togglePanel('importExport')"
-      >
-        <template #placeholder>
-          Bring the import/export utilities inline for quick actions or open the dedicated workspace for bulk jobs.
-        </template>
-        <Suspense @pending="markPending('importExport')" @resolve="markResolved('importExport')">
-          <template #default>
-            <ImportExportContainer />
-          </template>
-          <template #fallback>
-            <div class="flex items-center justify-center py-6 text-sm text-gray-500">
-              <span class="loading loading-spinner loading-sm mr-2"></span>
-              Loading import/export tools…
-            </div>
-          </template>
-        </Suspense>
-      </DashboardLazyModuleCard>
+          <Suspense
+            @pending="() => setPanelState(panel.key, { loading: true })"
+            @resolve="() => setPanelState(panel.key, { loading: false, hasEverLoaded: true })"
+          >
+            <template #default>
+              <component :is="panel.component" v-bind="panel.componentProps" />
+            </template>
+            <template #fallback>
+              <div class="flex items-center justify-center py-6 text-sm text-gray-500">
+                <span class="loading loading-spinner loading-sm mr-2"></span>
+                {{ panel.fallback }}
+              </div>
+            </template>
+          </Suspense>
+        </DashboardLazyModuleCard>
+        <SystemStatusPanel v-if="panel.key === 'analytics'" key="system-status-panel" />
+      </template>
     </section>
   </div>
 </template>
@@ -206,56 +81,123 @@ import SystemAdminStatusCard from '@/components/system/SystemAdminStatusCard.vue
 import SystemStatusCard from '@/components/system/SystemStatusCard.vue';
 import SystemStatusPanel from '@/components/system/SystemStatusPanel.vue';
 
-const PerformanceAnalytics = defineAsyncComponent(() =>
-  import('@/views/analytics/PerformanceAnalyticsPage.vue'),
-);
-const PromptComposer = defineAsyncComponent(() => import('@/components/compose/PromptComposer.vue'));
-const GenerationStudio = defineAsyncComponent(() => import('@/components/generation/GenerationStudio.vue'));
-const LoraGallery = defineAsyncComponent(() => import('@/components/lora-gallery/LoraGallery.vue'));
-const GenerationHistory = defineAsyncComponent(() => import('@/components/history/GenerationHistory.vue'));
-const ImportExportContainer = defineAsyncComponent(
-  () => import('@/components/import-export/ImportExportContainer.vue'),
-);
-
 type PanelKey = 'analytics' | 'composer' | 'studio' | 'gallery' | 'history' | 'importExport';
 
-const panels = reactive<Record<PanelKey, { active: boolean; loading: boolean; hasEverLoaded: boolean }>>({
-  analytics: { active: false, loading: false, hasEverLoaded: false },
-  composer: { active: false, loading: false, hasEverLoaded: false },
-  studio: { active: false, loading: false, hasEverLoaded: false },
-  gallery: { active: false, loading: false, hasEverLoaded: false },
-  history: { active: false, loading: false, hasEverLoaded: false },
-  importExport: { active: false, loading: false, hasEverLoaded: false },
-});
+type PanelState = { active: boolean; loading: boolean; hasEverLoaded: boolean };
 
-const togglePanel = (key: PanelKey) => {
-  const panel = panels[key];
-  if (!panel) {
-    return;
-  }
-  if (panel.active) {
-    panel.active = false;
-    panel.loading = false;
-    return;
-  }
-  panel.active = true;
-  panel.loading = !panel.hasEverLoaded;
+type PanelConfig = {
+  key: PanelKey;
+  title: string;
+  description: string;
+  route: string;
+  ctaLabel: string;
+  placeholder: string;
+  fallback: string;
+  loader: () => Promise<unknown>;
+  componentProps?: Record<string, unknown>;
 };
 
-const markPending = (key: PanelKey) => {
-  const panel = panels[key];
-  if (!panel) {
+const panelConfigs = [
+  {
+    key: 'analytics',
+    title: 'Performance analytics',
+    description: 'Visualize trends and KPI insights from the analytics suite.',
+    route: '/analytics',
+    ctaLabel: 'Open analytics',
+    placeholder:
+      'Load the analytics module inline or open the dedicated analytics page for the complete dashboard.',
+    fallback: 'Loading analytics…',
+    loader: () => import('@/views/analytics/PerformanceAnalyticsPage.vue'),
+    componentProps: { showPageHeader: false, showSystemStatus: false },
+  },
+  {
+    key: 'composer',
+    title: 'Prompt composer',
+    description: 'Draft prompts and queue presets without leaving this page.',
+    route: '/compose',
+    ctaLabel: 'Open composer',
+    placeholder:
+      'Activate the composer inline to reuse saved prompts or jump directly to the full composition workspace.',
+    fallback: 'Loading prompt composer…',
+    loader: () => import('@/components/compose/PromptComposer.vue'),
+  },
+  {
+    key: 'studio',
+    title: 'Generation studio',
+    description: 'Run complex jobs with live queue monitoring and inline previews.',
+    route: '/generate',
+    ctaLabel: 'Open studio',
+    placeholder:
+      'Use the inline studio for quick jobs or switch to the dedicated page for the full orchestrator experience.',
+    fallback: 'Loading generation studio…',
+    loader: () => import('@/components/generation/GenerationStudio.vue'),
+  },
+  {
+    key: 'gallery',
+    title: 'LoRA gallery',
+    description: 'Review adapters, apply tags, and launch bulk operations.',
+    route: '/loras',
+    ctaLabel: 'Open gallery',
+    placeholder:
+      'Quickly browse the gallery inline or open the dedicated gallery for the full management toolkit.',
+    fallback: 'Loading LoRA gallery…',
+    loader: () => import('@/components/lora-gallery/LoraGallery.vue'),
+  },
+  {
+    key: 'history',
+    title: 'Generation history',
+    description: 'Audit completed jobs, manage favorites, and export images.',
+    route: '/history',
+    ctaLabel: 'Open history',
+    placeholder:
+      'Load a lightweight history viewer inline or head to the history page for advanced filtering and exports.',
+    fallback: 'Loading generation history…',
+    loader: () => import('@/components/history/GenerationHistory.vue'),
+  },
+  {
+    key: 'importExport',
+    title: 'Import & export',
+    description: 'Manage backups and move adapters between environments.',
+    route: '/import-export',
+    ctaLabel: 'Open tools',
+    placeholder:
+      'Bring the import/export utilities inline for quick actions or open the dedicated workspace for bulk jobs.',
+    fallback: 'Loading import/export tools…',
+    loader: () => import('@/components/import-export/ImportExportContainer.vue'),
+  },
+] satisfies PanelConfig[];
+
+const panels = panelConfigs.map((panel) => ({
+  ...panel,
+  component: defineAsyncComponent(panel.loader),
+}));
+
+const panelStates = reactive<Record<PanelKey, PanelState>>(
+  panels.reduce((state, panel) => {
+    state[panel.key] = { active: false, loading: false, hasEverLoaded: false };
+    return state;
+  }, {} as Record<PanelKey, PanelState>),
+);
+
+const setPanelState = (key: PanelKey, updates: Partial<PanelState>) => {
+  const state = panelStates[key];
+  if (!state) {
     return;
   }
-  panel.loading = true;
+  Object.assign(state, updates);
 };
 
-const markResolved = (key: PanelKey) => {
-  const panel = panels[key];
-  if (!panel) {
+const handlePanelToggle = (key: PanelKey) => {
+  const state = panelStates[key];
+  if (!state) {
     return;
   }
-  panel.loading = false;
-  panel.hasEverLoaded = true;
+
+  if (state.active) {
+    setPanelState(key, { active: false, loading: false });
+    return;
+  }
+
+  setPanelState(key, { active: true, loading: !state.hasEverLoaded });
 };
 </script>


### PR DESCRIPTION
## Summary
- add a configuration array for dashboard lazy panels and render them through a single v-for loop
- centralize lazy panel state management keyed off the configuration entries, removing bespoke handlers

## Testing
- npm run lint *(fails: existing no-restricted-imports violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68daab5d101883298ba6f7de0a074462