### PR TITLE
Handle missing localStorage in Lora gallery selection

### DIFF
--- a/app/frontend/src/composables/lora-gallery/useLoraGallerySelection.ts
+++ b/app/frontend/src/composables/lora-gallery/useLoraGallerySelection.ts
@@ -2,7 +2,58 @@ import { computed, ref, watch } from 'vue';
 import type { Ref } from 'vue';
 
 import { useLoraSelection } from './useLoraSelection';
+import { PERSISTENCE_KEYS } from '@/constants/persistence';
 import type { GalleryLora, LoraGallerySelectionState } from '@/types';
+
+const storage = (() => {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+
+  try {
+    return window.localStorage ?? null;
+  } catch (error) {
+    if (import.meta.env.DEV) {
+      console.warn('[useLoraGallerySelection] Failed to access localStorage', error);
+    }
+    return null;
+  }
+})();
+
+const VIEW_MODE_KEY = PERSISTENCE_KEYS.loraGalleryViewMode;
+
+const persistViewMode = (mode: LoraGallerySelectionState['viewMode']) => {
+  if (!storage) {
+    return;
+  }
+
+  try {
+    storage.setItem(VIEW_MODE_KEY, mode);
+  } catch (error) {
+    if (import.meta.env.DEV) {
+      console.warn('[useLoraGallerySelection] Failed to persist view mode', error);
+    }
+  }
+};
+
+const readPersistedViewMode = (): LoraGallerySelectionState['viewMode'] | null => {
+  if (!storage) {
+    return null;
+  }
+
+  try {
+    const savedViewMode = storage.getItem(VIEW_MODE_KEY);
+    if (savedViewMode === 'grid' || savedViewMode === 'list') {
+      return savedViewMode;
+    }
+  } catch (error) {
+    if (import.meta.env.DEV) {
+      console.warn('[useLoraGallerySelection] Failed to read view mode', error);
+    }
+  }
+
+  return null;
+};
 
 export function useLoraGallerySelection(filteredLoras: Ref<GalleryLora[]>) {
   const selection = useLoraSelection();
@@ -16,7 +67,7 @@ export function useLoraGallerySelection(filteredLoras: Ref<GalleryLora[]>) {
 
   const setViewMode = (mode: LoraGallerySelectionState['viewMode']) => {
     viewMode.value = mode;
-    localStorage.setItem('loraViewMode', mode);
+    persistViewMode(mode);
   };
 
   const toggleBulkMode = () => {
@@ -37,8 +88,8 @@ export function useLoraGallerySelection(filteredLoras: Ref<GalleryLora[]>) {
   };
 
   const initializeSelection = () => {
-    const savedViewMode = localStorage.getItem('loraViewMode');
-    if (savedViewMode === 'grid' || savedViewMode === 'list') {
+    const savedViewMode = readPersistedViewMode();
+    if (savedViewMode) {
       viewMode.value = savedViewMode;
     }
   };


### PR DESCRIPTION
## Summary
- guard the LoRA gallery selection composable against missing localStorage
- reuse the persistence key constant while keeping grid as the default view

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dab05ba45483298e4bcdce61582db3