### PR TITLE
Cancel adapter fetch when resetting adapter catalog store

### DIFF
--- a/app/frontend/src/stores/adapterCatalog.ts
+++ b/app/frontend/src/stores/adapterCatalog.ts
@@ -213,6 +213,7 @@ export const useAdapterCatalogStore = defineStore('adapterCatalog', () => {
   };
 
   const reset = () => {
+    api.cancelActiveRequest();
     pendingFetch.value = null;
     lastFetchedAt.value = null;
     pendingTagFetch.value = null;


### PR DESCRIPTION
## Summary
- cancel the active adapter list request when resetting the catalog store
- clear the pending fetch tracker so consumers do not await stale promises

## Testing
- `npm run lint` *(fails: existing no-restricted-imports violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68daafdc71388329914481f7ed198726