### PR TITLE
Refactor adapter catalog store state management

### DIFF
--- a/tests/vue/LoraGallery.spec.js
+++ b/tests/vue/LoraGallery.spec.js
@@ -111,6 +111,7 @@ vi.mock('@/composables/shared', async (importOriginal) => {
         query,
         adapters,
         fetchData,
+        cancelActiveRequest: vi.fn(),
       };
     },
   };


### PR DESCRIPTION
## Summary
- manage adapter catalog data with store-owned refs and computed summaries instead of mutating the API composable
- update fetch and mutation helpers to copy payloads into the new refs while resetting loading/error flags
- refresh tests to reflect the revised adapter list API mock interface

## Testing
- npm run test -- --runTestsByPath tests/vue/useAdapterCatalog.spec.ts
- npm run test -- --runTestsByPath tests/vue/LoraGallery.spec.js

------
https://chatgpt.com/codex/tasks/task_e_68dab880a3888329aadf1b283107f5c3