### PR TITLE
Remove global hero header from app layout

### DIFF
--- a/app/frontend/src/App.vue
+++ b/app/frontend/src/App.vue
@@ -7,22 +7,11 @@
     <MainNavigation />
 
     <main id="main-content" class="main-content" tabindex="-1">
-      <div class="content-wrapper px-4 pb-12 pt-8">
-        <header class="flex flex-col gap-2 pb-4 sm:flex-row sm:items-center sm:justify-between">
-          <div>
-            <h1 class="text-3xl font-semibold tracking-tight text-slate-900">LoRA Manager</h1>
-            <p class="text-sm text-slate-600">
-              Monitor system status, manage jobs, and explore recommendations.
-            </p>
-          </div>
-          <div class="hidden items-center gap-2 sm:flex">
-            <RouterLink class="btn btn-secondary btn-sm" to="/loras">Browse LoRAs</RouterLink>
-            <RouterLink class="btn btn-primary btn-sm" to="/generate">Open Generation Studio</RouterLink>
-          </div>
-        </header>
-
-        <RouterView />
-      </div>
+      <RouterView v-slot="{ Component }">
+        <AppMainLayout>
+          <component :is="Component" />
+        </AppMainLayout>
+      </RouterView>
     </main>
 
     <AppFooter />
@@ -32,9 +21,10 @@
 </template>
 
 <script setup lang="ts">
-import { RouterLink, RouterView } from 'vue-router';
+import { RouterView } from 'vue-router';
 
 import AppFooter from '@/components/layout/AppFooter.vue';
+import AppMainLayout from '@/components/layout/AppMainLayout.vue';
 import MainNavigation from '@/components/layout/MainNavigation.vue';
 import MobileNav from '@/components/layout/MobileNav.vue';
 import Notifications from '@/components/shared/Notifications.vue';

--- a/app/frontend/src/components/layout/AppMainLayout.vue
+++ b/app/frontend/src/components/layout/AppMainLayout.vue
@@ -1,0 +1,6 @@
+<template>
+  <div class="content-wrapper px-4 pb-12 pt-8">
+    <slot name="hero" />
+    <slot />
+  </div>
+</template>

--- a/app/frontend/src/views/DashboardView.vue
+++ b/app/frontend/src/views/DashboardView.vue
@@ -10,7 +10,7 @@
             Browse LoRAs
           </RouterLink>
           <RouterLink class="btn btn-primary btn-sm" to="/generate">
-            Launch Studio
+            Open Generation Studio
           </RouterLink>
         </div>
       </template>


### PR DESCRIPTION
## Summary
- extract the content wrapper into a reusable AppMainLayout component without a baked-in hero header
- wrap routed views with the new layout so each page is responsible for its own top-level heading
- tweak the dashboard header action text to maintain navigation parity after removing the global hero

## Testing
- npm run lint *(fails: existing no-restricted-imports violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68daba224adc8329afc34db4730bf025