### PR TITLE
Add prompt embedding support for recommendations

### DIFF
--- a/backend/services/recommendations/components/interfaces.py
+++ b/backend/services/recommendations/components/interfaces.py
@@ -21,6 +21,11 @@ class SemanticEmbedderProtocol(Protocol):
     def batch_encode_collection(self, loras: Sequence[Any]) -> Dict[str, np.ndarray]:
         """Batch encode a collection of LoRAs."""
 
+    def compute_prompt_embeddings(
+        self, prompt: str, *, device: Optional[str] = None
+    ) -> Dict[str, np.ndarray]:
+        """Compute embeddings for a free-form prompt."""
+
 
 @runtime_checkable
 class FeatureExtractorProtocol(Protocol):

--- a/backend/services/recommendations/strategies.py
+++ b/backend/services/recommendations/strategies.py
@@ -101,7 +101,7 @@ async def get_recommendations_for_prompt(
 
     # Get embeddings for the prompt
     prompt_embeddings = await asyncio.to_thread(
-        embedder.compute_prompt_embeddings, prompt, device
+        embedder.compute_prompt_embeddings, prompt, device=device
     )
     prompt_embedding = prompt_embeddings["semantic"]
 

--- a/tests/recommendations/test_semantic_embedder.py
+++ b/tests/recommendations/test_semantic_embedder.py
@@ -1,0 +1,42 @@
+"""Tests for the semantic embedder implementation."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from backend.services.recommendations.components.embedder import (
+    LoRASemanticEmbedder,
+)
+
+
+class TestLoRASemanticEmbedder:
+    """Unit tests covering prompt embedding generation."""
+
+    def setup_method(self) -> None:
+        self.embedder = LoRASemanticEmbedder(
+            device="cpu", force_fallback=True
+        )
+
+    def test_compute_prompt_embeddings_returns_modalities(self) -> None:
+        prompt = "dreamy watercolor landscape"
+
+        result = self.embedder.compute_prompt_embeddings(prompt, device="cpu")
+
+        assert set(result.keys()) == {"semantic", "artistic", "technical"}
+        assert all(isinstance(vector, np.ndarray) for vector in result.values())
+        assert all(vector.dtype == np.float32 for vector in result.values())
+        assert result["semantic"].shape == (LoRASemanticEmbedder.SEMANTIC_DIM,)
+        assert result["artistic"].shape == (LoRASemanticEmbedder.ARTISTIC_DIM,)
+        assert result["technical"].shape == (LoRASemanticEmbedder.TECHNICAL_DIM,)
+
+    def test_compute_prompt_embeddings_for_empty_prompt_returns_zeros(self) -> None:
+        result = self.embedder.compute_prompt_embeddings("   ", device="cpu")
+
+        for key, expected_dim in {
+            "semantic": LoRASemanticEmbedder.SEMANTIC_DIM,
+            "artistic": LoRASemanticEmbedder.ARTISTIC_DIM,
+            "technical": LoRASemanticEmbedder.TECHNICAL_DIM,
+        }.items():
+            embedding = result[key]
+            assert embedding.shape == (expected_dim,)
+            assert np.allclose(embedding, 0.0)

--- a/tests/recommendations/test_use_cases.py
+++ b/tests/recommendations/test_use_cases.py
@@ -1,7 +1,11 @@
 """Tests for recommendation use cases."""
 
+from dataclasses import dataclass
+import pickle
+from typing import List, Optional
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import numpy as np
 import pytest
 
 from backend.services.recommendations import (
@@ -85,4 +89,81 @@ class TestRecommendationUseCases:
         assert result == payload
         strategy.assert_awaited_once()
         embedder_provider.assert_called_once()
+        metrics.record_query.assert_called_once()
+
+    @pytest.mark.anyio("asyncio")
+    async def test_prompt_use_case_generates_embeddings(self):
+        @dataclass
+        class _Adapter:
+            id: str
+            name: str
+            description: Optional[str]
+            tags: tuple[str, ...]
+            author_username: str
+            sd_version: Optional[str]
+            nsfw_level: Optional[str]
+
+        @dataclass
+        class _Embedding:
+            semantic_embedding: bytes
+            artistic_embedding: bytes
+            technical_embedding: bytes
+            predicted_style: Optional[str]
+
+        class _Repository:
+            def __init__(self, adapter: _Adapter, embedding: _Embedding) -> None:
+                self._data = [(adapter, embedding)]
+
+            def get_active_loras_with_embeddings(self, *, exclude_ids=None):
+                return self._data
+
+        class _Embedder:
+            def __init__(self) -> None:
+                self.calls: List[tuple[str, Optional[str]]] = []
+                self._vector = np.asarray([1.0, 0.0, 0.0], dtype=np.float32)
+
+            def compute_prompt_embeddings(self, prompt: str, *, device: Optional[str] = None):
+                self.calls.append((prompt, device))
+                return {
+                    "semantic": self._vector,
+                    "artistic": self._vector,
+                    "technical": self._vector,
+                }
+
+        adapter = _Adapter(
+            id="adapter-1",
+            name="Aurora",
+            description="Celestial style adapter",
+            tags=("fantasy", "portrait"),
+            author_username="artist",
+            sd_version="1.5",
+            nsfw_level="safe",
+        )
+        embedding_vector = np.asarray([1.0, 0.0, 0.0], dtype=np.float32)
+        embedding = _Embedding(
+            semantic_embedding=pickle.dumps(embedding_vector),
+            artistic_embedding=pickle.dumps(embedding_vector),
+            technical_embedding=pickle.dumps(embedding_vector),
+            predicted_style="dreamy",
+        )
+        repository = _Repository(adapter, embedding)
+        embedder = _Embedder()
+        metrics = MagicMock()
+        use_case = PromptRecommendationUseCase(
+            repository=repository,
+            embedder_provider=lambda: embedder,
+            metrics=metrics,
+            device="cpu",
+        )
+
+        results = await use_case.execute(
+            prompt="glowing forest",
+            active_loras=None,
+            limit=1,
+            style_preference=None,
+            weights={"semantic": 1.0, "artistic": 1.0, "technical": 1.0},
+        )
+
+        assert len(results) == 1
+        assert embedder.calls == [("glowing forest", "cpu")]
         metrics.record_query.assert_called_once()


### PR DESCRIPTION
## Summary
- extend the semantic embedder protocol and implementation with prompt embedding support
- ensure prompt recommendation strategy requests prompt embeddings with an explicit device override
- add tests covering prompt embedding generation and the prompt recommendation use case

## Testing
- pytest tests/recommendations/test_semantic_embedder.py tests/recommendations/test_use_cases.py

------
https://chatgpt.com/codex/tasks/task_e_68dabd6b31108329b51e81e53cbd541f