### PR TITLE
Fix delivery job count queries to return scalar integers

### DIFF
--- a/backend/services/delivery_repository.py
+++ b/backend/services/delivery_repository.py
@@ -223,31 +223,37 @@ class DeliveryJobRepository:
 
     def count_active_jobs(self) -> int:
         """Return the number of jobs considered active."""
-        result = self._session.exec(
-            select(func.count(DeliveryJob.id)).where(
-                DeliveryJob.status.in_(_ACTIVE_STATUSES)
-            ),
-        ).one()
-        return int(result or 0)
+        result = (
+            self._session.execute(
+                select(func.count(DeliveryJob.id)).where(
+                    DeliveryJob.status.in_(_ACTIVE_STATUSES)
+                )
+            ).scalar_one_or_none()
+            or 0
+        )
+        return int(result)
 
     def get_queue_statistics(self) -> Dict[str, int]:
         """Summarise queue-oriented counts for dashboards."""
-        total_jobs = self._session.exec(select(func.count(DeliveryJob.id))).one() or 0
+        total_jobs = (
+            self._session.execute(select(func.count(DeliveryJob.id))).scalar_one_or_none()
+            or 0
+        )
         active_jobs = self.count_active_jobs()
         running_jobs = (
-            self._session.exec(
+            self._session.execute(
                 select(func.count(DeliveryJob.id)).where(
                     DeliveryJob.status == "running"
-                ),
-            ).one()
+                )
+            ).scalar_one_or_none()
             or 0
         )
         failed_jobs = (
-            self._session.exec(
+            self._session.execute(
                 select(func.count(DeliveryJob.id)).where(
                     DeliveryJob.status == "failed"
-                ),
-            ).one()
+                )
+            ).scalar_one_or_none()
             or 0
         )
 

--- a/tests/test_system_status.py
+++ b/tests/test_system_status.py
@@ -43,3 +43,35 @@ def test_system_status_reports_queue_activity(client, db_session):
 
     payload = response.json()
     assert payload["queue_length"] >= 1
+
+
+def test_system_status_queue_counts_are_numeric(client, db_session):
+    """Queue statistics should remain numeric even when multiple statuses exist."""
+
+    jobs = [
+        DeliveryJob(prompt="pending", mode="cli", status="pending"),
+        DeliveryJob(prompt="running", mode="cli", status="running"),
+        DeliveryJob(prompt="retrying", mode="cli", status="retrying"),
+        DeliveryJob(prompt="failed", mode="cli", status="failed"),
+        DeliveryJob(prompt="done", mode="cli", status="succeeded"),
+    ]
+    db_session.add_all(jobs)
+    db_session.commit()
+
+    response = client.get("/api/v1/system/status")
+    assert response.status_code == 200
+
+    payload = response.json()
+    queue_stats = payload["queue"]
+
+    for key in ("total", "active", "running", "failed"):
+        assert isinstance(queue_stats[key], int)
+
+    assert queue_stats["total"] == len(jobs)
+    assert queue_stats["active"] == 3  # pending, running, retrying
+    assert queue_stats["running"] == 1
+    assert queue_stats["failed"] == 1
+
+    assert isinstance(payload["queue_length"], int)
+    assert payload["queue_length"] == queue_stats["active"]
+    assert isinstance(payload["active_workers"], int)


### PR DESCRIPTION
## Summary
- update delivery job count queries to fetch scalar values before coercion
- ensure queue statistics continue to return integers for API consumers
- extend system status tests to verify queue metrics remain numeric across statuses

## Testing
- pytest tests/test_system_status.py


------
https://chatgpt.com/codex/tasks/task_e_68dabd592cf48329847ead3631eab8ad