### PR TITLE
Clamp generation progress normalization

### DIFF
--- a/app/frontend/src/utils/progress.ts
+++ b/app/frontend/src/utils/progress.ts
@@ -3,5 +3,8 @@ export const normalizeGenerationProgress = (value?: number | null): number => {
     return 0
   }
 
-  return value <= 1 ? Math.round(value * 100) : Math.round(value)
+  const normalized = value <= 1 ? value * 100 : value
+  const rounded = Math.round(normalized)
+
+  return Math.min(100, Math.max(0, rounded))
 }


### PR DESCRIPTION
## Summary
- clamp normalized generation progress values between 0 and 100
- cover negative and oversized inputs in progress utility unit tests
- smoke test the generation queue store to ensure progress clamping end-to-end

## Testing
- npx vitest run tests/vue/progressUtils.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68dabfe8f32c8329984276f9036cd001