### PR TITLE
Coordinate job queue polling with orchestrator manager

### DIFF
--- a/app/frontend/src/components/shared/JobQueue.vue
+++ b/app/frontend/src/components/shared/JobQueue.vue
@@ -76,10 +76,12 @@
 
 <script setup lang="ts">
 import { computed } from 'vue';
+import { storeToRefs } from 'pinia';
 
 import { useJobQueue } from '@/composables/generation';
 import { useJobQueueActions } from '@/composables/generation';
 import { formatElapsedTime } from '@/utils/format';
+import { useGenerationConnectionStore } from '@/stores/generation';
 
 import type { GenerationJob } from '@/types';
 
@@ -100,14 +102,24 @@ const props = withDefaults(defineProps<Props>(), {
   emptyStateMessage: 'Start a generation to see progress here',
   cardClass: '',
   pollingInterval: 2000,
-  disabled: false,
   showJobCount: true,
   showClearCompleted: false,
 });
 
+const connectionStore = useGenerationConnectionStore();
+const { queueManagerActive } = storeToRefs(connectionStore);
+
+const resolvedDisabled = computed(() => {
+  if (props.disabled === undefined) {
+    return queueManagerActive.value;
+  }
+  return props.disabled;
+});
+
 const { jobs, isReady } = useJobQueue({
   pollInterval: computed(() => props.pollingInterval),
-  disabled: computed(() => props.disabled),
+  disabled: resolvedDisabled,
+  managerActive: queueManagerActive,
 });
 
 const { isCancelling, clearCompletedJobs, cancelJob: cancelQueueJob } = useJobQueueActions();

--- a/app/frontend/src/services/generation/orchestrator.ts
+++ b/app/frontend/src/services/generation/orchestrator.ts
@@ -113,10 +113,17 @@ export const createGenerationOrchestrator = ({
   const initialize = async (): Promise<void> => {
     const nextLimit = showHistory.value ? 50 : DEFAULT_HISTORY_LIMIT;
     resultsStore.setHistoryLimit(nextLimit);
-    await transport.initializeUpdates(historyLimit.value);
+    connectionStore.setQueueManagerActive(true);
+    try {
+      await transport.initializeUpdates(historyLimit.value);
+    } catch (error) {
+      connectionStore.setQueueManagerActive(false);
+      throw error;
+    }
   };
 
   const cleanup = (): void => {
+    connectionStore.setQueueManagerActive(false);
     transport.clear();
   };
 
@@ -202,6 +209,7 @@ export const createGenerationOrchestrator = ({
 
   if (getCurrentScope()) {
     onScopeDispose(() => {
+      connectionStore.setQueueManagerActive(false);
       transport.clear();
     });
   }

--- a/app/frontend/src/stores/generation/connection.ts
+++ b/app/frontend/src/stores/generation/connection.ts
@@ -24,6 +24,7 @@ export const useGenerationConnectionStore = defineStore('generation-connection',
   const systemStatusReady = ref(false);
   const systemStatusLastUpdated = ref<Date | null>(null);
   const systemStatusApiAvailable = ref(true);
+  const queueManagerActive = ref(false);
 
   function setConnectionState(connected: boolean): void {
     isConnected.value = connected;
@@ -78,6 +79,11 @@ export const useGenerationConnectionStore = defineStore('generation-connection',
     resetSystemStatus();
     isConnected.value = false;
     pollIntervalMs.value = DEFAULT_POLL_INTERVAL;
+    queueManagerActive.value = false;
+  }
+
+  function setQueueManagerActive(active: boolean): void {
+    queueManagerActive.value = active;
   }
 
   return {
@@ -87,6 +93,7 @@ export const useGenerationConnectionStore = defineStore('generation-connection',
     systemStatusReady,
     systemStatusLastUpdated,
     systemStatusApiAvailable,
+    queueManagerActive,
     setConnectionState,
     setPollInterval,
     updateSystemStatus,
@@ -95,6 +102,7 @@ export const useGenerationConnectionStore = defineStore('generation-connection',
     markSystemStatusHydrated,
     markSystemStatusUnavailable,
     reset,
+    setQueueManagerActive,
   };
 });
 


### PR DESCRIPTION
## Summary
- add a shared queue manager flag to the generation connection store and toggle it from the orchestrator lifecycle
- make useJobQueue respect the shared manager so live updates skip polling while orchestrated
- default the JobQueue component disabled state to the manager flag and cover managed/unmanaged behaviour with new tests

## Testing
- npm run test -- tests/vue/useJobQueue.spec.ts
- npm run test -- tests/vue/JobQueue.spec.js

------
https://chatgpt.com/codex/tasks/task_e_68dac243f5488329ab7df8d67be05223