### PR TITLE
Fix frontend restricted import lint errors

### DIFF
--- a/app/frontend/src/composables/generation/useGenerationOrchestrator.ts
+++ b/app/frontend/src/composables/generation/useGenerationOrchestrator.ts
@@ -1,11 +1,11 @@
 import { storeToRefs } from 'pinia'
 
 import type { GenerationNotificationAdapter } from '@/composables/generation'
-import { createGenerationOrchestrator } from '@/services/generation/orchestrator'
-import type {
-  GenerationQueueClient,
-  GenerationWebSocketManager,
-} from '@/services/generation/updates'
+import {
+  createGenerationOrchestrator,
+  type GenerationQueueClient,
+  type GenerationWebSocketManager,
+} from '@/services'
 import {
   useGenerationConnectionStore,
   useGenerationFormStore,

--- a/app/frontend/src/composables/generation/useGenerationQueueClient.ts
+++ b/app/frontend/src/composables/generation/useGenerationQueueClient.ts
@@ -4,7 +4,7 @@ import {
   createGenerationQueueClient,
   DEFAULT_POLL_INTERVAL,
   type GenerationQueueClient,
-} from '@/services/generation/updates';
+} from '@/services';
 import type {
   GenerationRequestPayload,
   GenerationResult,
@@ -14,7 +14,7 @@ import type {
   SystemStatusState,
 } from '@/types';
 import type { GenerationJobInput } from '@/stores/generation';
-import { useSystemStatusController } from '@/stores/generation/systemStatusController';
+import { useSystemStatusController } from '@/stores/generation';
 
 const ensureArray = <T>(value: unknown): T[] => (Array.isArray(value) ? value : []);
 

--- a/app/frontend/src/composables/generation/useGenerationSocketBridge.ts
+++ b/app/frontend/src/composables/generation/useGenerationSocketBridge.ts
@@ -3,7 +3,7 @@ import { shallowRef } from 'vue';
 import {
   createGenerationWebSocketManager,
   type GenerationWebSocketManager,
-} from '@/services/generation/updates';
+} from '@/services';
 import type {
   GenerationCompleteMessage,
   GenerationErrorMessage,

--- a/app/frontend/src/composables/generation/useGenerationStudio.ts
+++ b/app/frontend/src/composables/generation/useGenerationStudio.ts
@@ -1,7 +1,7 @@
 import { computed, onMounted } from 'vue'
 
 import { useGenerationPersistence } from '@/composables/generation'
-import { useGenerationStudioController } from '@/composables/generation/useGenerationStudioController'
+import { useGenerationStudioController } from '@/composables/generation'
 import { useGenerationUI } from '@/composables/generation'
 import { useDialogService, useNotifications } from '@/composables/shared'
 import { useGenerationFormStore } from '@/stores/generation'

--- a/app/frontend/src/composables/generation/useGenerationStudioController.ts
+++ b/app/frontend/src/composables/generation/useGenerationStudioController.ts
@@ -1,7 +1,7 @@
 import type { Ref } from 'vue'
 
-import { toGenerationRequestPayload } from '@/services/generation/generationService'
-import { useGenerationOrchestrator } from '@/composables/generation/useGenerationOrchestrator'
+import { toGenerationRequestPayload } from '@/services'
+import { useGenerationOrchestrator } from '@/composables/generation'
 import { useGenerationFormStore } from '@/stores/generation'
 import type { GenerationFormState, NotificationType } from '@/types'
 

--- a/app/frontend/src/composables/generation/useGenerationTransport.ts
+++ b/app/frontend/src/composables/generation/useGenerationTransport.ts
@@ -2,7 +2,7 @@ import {
   extractGenerationErrorMessage,
   type GenerationQueueClient,
   type GenerationWebSocketManager,
-} from '@/services/generation/updates';
+} from '@/services';
 import type {
   GenerationCompleteMessage,
   GenerationErrorMessage,

--- a/app/frontend/src/composables/generation/useGenerationUpdates.ts
+++ b/app/frontend/src/composables/generation/useGenerationUpdates.ts
@@ -7,11 +7,11 @@ import {
   useGenerationQueueStore,
   useGenerationResultsStore,
 } from '@/stores/generation';
-import { createGenerationOrchestrator } from '@/services/generation/orchestrator';
-import type {
-  GenerationQueueClient,
-  GenerationWebSocketManager,
-} from '@/services/generation/updates';
+import {
+  createGenerationOrchestrator,
+  type GenerationQueueClient,
+  type GenerationWebSocketManager,
+} from '@/services';
 import type {
   GenerationJob,
   GenerationRequestPayload,

--- a/app/frontend/src/composables/generation/useJobQueueActions.ts
+++ b/app/frontend/src/composables/generation/useJobQueueActions.ts
@@ -1,7 +1,7 @@
 import { ref, unref, type MaybeRefOrGetter } from 'vue';
 import { storeToRefs } from 'pinia';
 
-import { cancelGenerationJob } from '@/services/generation/generationService';
+import { cancelGenerationJob } from '@/services';
 import { useGenerationQueueStore } from '@/stores/generation';
 import { useNotifications } from '@/composables/shared';
 import { useBackendBase } from '@/utils/backend';
@@ -63,6 +63,9 @@ export const useJobQueueActions = (options: UseJobQueueActionsOptions = {}) => {
         notifications.showToastInfo('Job cancelled');
         return true;
       } catch (error) {
+        if (import.meta.env.DEV) {
+          console.error('[JobQueue] Failed to cancel job', error);
+        }
         notifications.showToastError('Failed to cancel job');
         return false;
       }

--- a/app/frontend/src/composables/generation/useJobQueueTransport.ts
+++ b/app/frontend/src/composables/generation/useJobQueueTransport.ts
@@ -1,6 +1,6 @@
 import { ref, unref, type MaybeRefOrGetter, type Ref } from 'vue';
 
-import { fetchActiveGenerationJobs } from '@/services/generation/generationService';
+import { fetchActiveGenerationJobs } from '@/services';
 import { DEFAULT_BACKEND_BASE } from '@/utils/backend';
 import type { GenerationJobStatus } from '@/types';
 
@@ -42,6 +42,9 @@ export const useJobQueueTransport = (
       apiAvailable.value = true;
       return records;
     } catch (error) {
+      if (import.meta.env.DEV) {
+        console.error('[JobQueue] Failed to fetch active jobs', error);
+      }
       apiAvailable.value = false;
       return null;
     }

--- a/app/frontend/src/composables/history/useGenerationHistory.ts
+++ b/app/frontend/src/composables/history/useGenerationHistory.ts
@@ -2,7 +2,7 @@ import { computed, ref, unref, type ComputedRef } from 'vue';
 import type { MaybeRefOrGetter } from 'vue';
 
 import { debounce, type DebouncedFunction } from '@/utils/async';
-import { listResults as listHistoryResults } from '@/services/history/historyService';
+import { listResults as listHistoryResults } from '@/services';
 import type {
   GenerationHistoryQuery,
   GenerationHistoryResult,

--- a/app/frontend/src/composables/history/useHistoryActions.ts
+++ b/app/frontend/src/composables/history/useHistoryActions.ts
@@ -12,7 +12,7 @@ import {
   favoriteResult as favoriteHistoryResult,
   favoriteResults as favoriteHistoryResults,
   rateResult as rateHistoryResult,
-} from '@/services/history/historyService';
+} from '@/services';
 import type { GenerationHistoryResult, NotificationType } from '@/types';
 
 export interface UseHistoryActionsOptions {

--- a/app/frontend/src/composables/import-export/useImportWorkflow.ts
+++ b/app/frontend/src/composables/import-export/useImportWorkflow.ts
@@ -1,7 +1,7 @@
 import { computed, reactive, ref, type ComputedRef } from 'vue';
 
 import { ensureData, requestJson } from '@/services/apiClient';
-import type { ImportConfig, ImportMode } from '@/types';
+import type { ImportConfig } from '@/types';
 import type { NotifyFn, ProgressCallbacks } from './useExportWorkflow';
 
 export interface ImportPreviewItem {

--- a/app/frontend/src/composables/lora-gallery/useLoraCardActions.ts
+++ b/app/frontend/src/composables/lora-gallery/useLoraCardActions.ts
@@ -9,7 +9,7 @@ import {
   toggleLoraActiveState,
   triggerPreviewGeneration,
   updateLoraWeight,
-} from '@/services/lora/loraService';
+} from '@/services';
 import type { LoraListItem, LoraUpdatePayload } from '@/types';
 
 type UseLoraCardActionsOptions = {

--- a/app/frontend/src/composables/shared/apiClients.ts
+++ b/app/frontend/src/composables/shared/apiClients.ts
@@ -8,8 +8,11 @@ import type {
   GenerationResult,
   RecommendationResponse,
 } from '@/types';
-import { buildAdapterListQuery } from '@/services/lora/loraService';
-import { useDashboardStatsApi, useSystemStatusApi } from '@/services/system';
+import {
+  buildAdapterListQuery,
+  useDashboardStatsApi,
+  useSystemStatusApi,
+} from '@/services';
 import { resolveBackendUrl } from '@/utils/backend';
 
 export type DashboardStatsResponse = DashboardStatsSummary;

--- a/app/frontend/src/composables/shared/useAdapterListApi.ts
+++ b/app/frontend/src/composables/shared/useAdapterListApi.ts
@@ -1,7 +1,7 @@
 import { computed, reactive, unref, isRef, type MaybeRefOrGetter } from 'vue';
 
 import { useApi } from './useApi';
-import { buildAdapterListQuery } from '@/services/lora/loraService';
+import { buildAdapterListQuery } from '@/services';
 import { resolveBackendUrl, sanitizeBackendBaseUrl } from '@/utils/backend';
 import type { AdapterListQuery, AdapterListResponse, AdapterRead, LoraListItem } from '@/types';
 

--- a/app/frontend/src/composables/system/useSystemStatus.ts
+++ b/app/frontend/src/composables/system/useSystemStatus.ts
@@ -2,7 +2,7 @@ import { computed } from 'vue';
 import { storeToRefs } from 'pinia';
 
 import { useGenerationConnectionStore } from '@/stores/generation';
-import { useSystemStatusController } from '@/stores/generation/systemStatusController';
+import { useSystemStatusController } from '@/stores/generation';
 
 const formatMemory = (used: number, total: number) => {
   if (!total) {

--- a/app/frontend/src/composables/usePerformanceAnalytics.ts
+++ b/app/frontend/src/composables/usePerformanceAnalytics.ts
@@ -9,8 +9,8 @@ import { ref } from 'vue';
 import {
   exportAnalyticsReport,
   fetchPerformanceAnalytics,
-} from '@/services/analytics/analyticsService';
-import { fetchTopAdapters } from '@/services/lora/loraService';
+  fetchTopAdapters,
+} from '@/services';
 import { useBackendBase } from '@/utils/backend';
 import { formatDuration as formatDurationLabel } from '@/utils/format';
 

--- a/app/frontend/src/services/history/historyService.ts
+++ b/app/frontend/src/services/history/historyService.ts
@@ -3,7 +3,7 @@ import type { MaybeRefOrGetter } from 'vue';
 
 import { useApi } from '@/composables/shared';
 import { getFilenameFromContentDisposition, requestBlob } from '@/services/apiClient';
-import { resolveGenerationRoute } from '@/services/generation/generationService';
+import { resolveGenerationRoute } from '@/services';
 import { sanitizeBackendBaseUrl } from '@/utils/backend';
 
 import type {

--- a/app/frontend/src/stores/adapterCatalog.ts
+++ b/app/frontend/src/stores/adapterCatalog.ts
@@ -2,7 +2,7 @@ import { computed, ref } from 'vue';
 import { defineStore } from 'pinia';
 
 import { ApiError, useAdapterListApi } from '@/composables/shared';
-import { fetchAdapterTags, performBulkLoraAction } from '@/services/lora/loraService';
+import { fetchAdapterTags, performBulkLoraAction } from '@/services';
 import { useBackendBase } from '@/utils/backend';
 
 import type {

--- a/app/frontend/src/stores/adminMetrics.ts
+++ b/app/frontend/src/stores/adminMetrics.ts
@@ -5,7 +5,7 @@ import {
   deriveMetricsFromDashboard,
   emptyMetricsSnapshot,
   fetchDashboardStats,
-} from '@/services/system/systemService';
+} from '@/services';
 import { useBackendBase } from '@/utils/backend';
 import {
   buildResourceStats,

--- a/app/frontend/src/stores/generation/connection.ts
+++ b/app/frontend/src/stores/generation/connection.ts
@@ -1,7 +1,7 @@
 import { reactive, ref } from 'vue';
 import { defineStore } from 'pinia';
 
-import { DEFAULT_POLL_INTERVAL } from '@/services/generation/updates';
+import { DEFAULT_POLL_INTERVAL } from '@/services';
 import type { SystemStatusPayload, SystemStatusState } from '@/types';
 
 export const DEFAULT_SYSTEM_STATUS: SystemStatusState = {

--- a/app/frontend/src/stores/generation/systemStatusController.ts
+++ b/app/frontend/src/stores/generation/systemStatusController.ts
@@ -2,8 +2,8 @@ import { computed, ref, type ComputedRef } from 'vue';
 import { storeToRefs } from 'pinia';
 
 import { ApiError } from '@/composables/shared';
-import { fetchSystemStatus } from '@/services/system/systemService';
-import { useGenerationConnectionStore } from '@/stores/generation/connection';
+import { fetchSystemStatus } from '@/services';
+import { useGenerationConnectionStore } from './connection';
 import { useBackendBase } from '@/utils/backend';
 
 const DEFAULT_POLL_INTERVAL = 10_000;

--- a/app/frontend/src/stores/settings.ts
+++ b/app/frontend/src/stores/settings.ts
@@ -1,6 +1,6 @@
 import { defineStore } from 'pinia';
 
-import { loadFrontendSettings } from '@/services/system/systemService';
+import { loadFrontendSettings } from '@/services';
 import { trimTrailingSlash } from '@/utils/backend';
 import type { FrontendRuntimeSettings, SettingsState } from '@/types';
 

--- a/app/frontend/src/types/lora.ts
+++ b/app/frontend/src/types/lora.ts
@@ -2,7 +2,7 @@
  * Type definitions mirroring backend/schemas/adapters.py.
  */
 
-import type { JsonObject, JsonValue } from './json';
+import type { JsonObject } from './json';
 
 export type AdapterStatsMetric =
   | 'downloadCount'

--- a/app/frontend/src/utils/progress.ts
+++ b/app/frontend/src/utils/progress.ts
@@ -1,10 +1,10 @@
 export const normalizeGenerationProgress = (value?: number | null): number => {
   if (typeof value !== 'number' || Number.isNaN(value)) {
-    return 0
+    return 0;
   }
 
   const normalized = value <= 1 ? value * 100 : value
   const rounded = Math.round(normalized)
 
-  return Math.min(100, Math.max(0, rounded))
+  return Math.min(100, Math.max(0, rounded));
 }

--- a/app/frontend/src/utils/promptGeneration.ts
+++ b/app/frontend/src/utils/promptGeneration.ts
@@ -1,4 +1,4 @@
-import { createGenerationParams, requestGeneration } from '@/services/generation/generationService';
+import { createGenerationParams, requestGeneration } from '@/services';
 
 import type { CompositionEntry } from '@/types';
 


### PR DESCRIPTION
## Summary
- update generation, history, analytics, and system composables to consume service helpers via the root services barrel
- align stores and utilities with the shared barrels and add dev-mode logging so linted catch blocks use their error values
- drop unused TypeScript imports flagged by eslint

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dac10a93188329a42fc5772bc562ca