### PR TITLE
Refactor frontend services to use configured API helpers

### DIFF
--- a/app/frontend/src/composables/shared/apiClients.ts
+++ b/app/frontend/src/composables/shared/apiClients.ts
@@ -9,7 +9,6 @@ import type {
   RecommendationResponse,
 } from '@/types';
 import { buildAdapterListQuery } from '@/services/lora/loraService';
-import { useDashboardStatsApi, useSystemStatusApi } from '@/services/system';
 import { resolveBackendUrl } from '@/utils/backend';
 
 export type DashboardStatsResponse = DashboardStatsSummary;
@@ -32,4 +31,4 @@ export const useRecentResultsApi = (
   init: RequestInit = {},
 ) => useApi<GenerationResult[]>(url, withCredentials(init));
 
-export { buildAdapterListQuery, useAdapterListApi, useDashboardStatsApi, useSystemStatusApi };
+export { buildAdapterListQuery, useAdapterListApi };

--- a/app/frontend/src/services/history/historyService.ts
+++ b/app/frontend/src/services/history/historyService.ts
@@ -1,8 +1,12 @@
-import { computed, reactive, unref } from 'vue';
-import type { MaybeRefOrGetter } from 'vue';
 
-import { useApi } from '@/composables/shared';
-import { getFilenameFromContentDisposition, requestBlob } from '@/services/apiClient';
+import {
+  getFilenameFromContentDisposition,
+  performConfiguredRequest,
+  requestBlob,
+  requestConfiguredJson,
+  type ApiRequestConfig,
+  type ApiRequestInit,
+} from '@/services/apiClient';
 import { resolveGenerationRoute } from '@/services/generation/generationService';
 import { sanitizeBackendBaseUrl } from '@/utils/backend';
 
@@ -20,13 +24,22 @@ import type {
   GenerationRatingUpdate,
 } from '@/types';
 
-const resolveBaseUrl = (value: MaybeRefOrGetter<string>): string => {
-  const raw = typeof value === 'function' ? (value as () => string)() : unref(value);
-  return sanitizeBackendBaseUrl(raw);
-};
-
 const resolveHistoryEndpoint = (base: string, path: string): string =>
   resolveGenerationRoute(path, base);
+
+const withSameOrigin = (init: ApiRequestInit = {}): ApiRequestInit => ({
+  credentials: 'same-origin',
+  ...init,
+});
+
+const createHistoryRequestConfig = (
+  base: string,
+  path: string,
+  init: ApiRequestInit = {},
+): ApiRequestConfig => ({
+  target: resolveHistoryEndpoint(base, path),
+  init: withSameOrigin(init),
+});
 
 const toStats = (stats?: GenerationHistoryStats | null): GenerationHistoryStats => ({
   total_results: stats?.total_results ?? 0,
@@ -127,45 +140,6 @@ export const buildHistoryQuery = (query: GenerationHistoryQuery = {}): string =>
   return search ? `?${search}` : '';
 };
 
-export const useGenerationHistoryApi = (
-  baseUrl: MaybeRefOrGetter<string>,
-  initialQuery: GenerationHistoryQuery = {},
-) => {
-  const query = reactive<GenerationHistoryQuery>({ ...initialQuery });
-  const api = useApi<GenerationHistoryListPayload>(
-    () => {
-      const base = resolveBaseUrl(baseUrl);
-      const suffix = buildHistoryQuery(query);
-      return resolveHistoryEndpoint(base, `/results${suffix}`);
-    },
-    { credentials: 'same-origin' },
-  );
-
-  const fetchPage = async (overrides: GenerationHistoryQuery = {}) => {
-    Object.assign(query, overrides);
-    await api.fetchData();
-    return toListOutput(api.data.value);
-  };
-
-  const results = computed<GenerationHistoryResult[]>(() => toListOutput(api.data.value).results);
-
-  const pageInfo = computed<GenerationHistoryListResponse | null>(() => {
-    const payload = api.data.value;
-    if (!payload || Array.isArray(payload)) {
-      return null;
-    }
-    return payload;
-  });
-
-  return {
-    ...api,
-    query,
-    fetchPage,
-    results,
-    pageInfo,
-  };
-};
-
 export const listResults = async (
   baseUrl: string,
   query: GenerationHistoryQuery = {},
@@ -174,11 +148,11 @@ export const listResults = async (
   const base = sanitizeBackendBaseUrl(baseUrl);
   const queryString = buildHistoryQuery(query);
   const targetUrl = resolveHistoryEndpoint(base, `/results${queryString}`);
-  const api = useApi<GenerationHistoryListPayload>(() => targetUrl, {
-    credentials: 'same-origin',
-  });
-  const payload = await api.fetchData({ signal: options.signal });
-  return toListOutput(payload ?? null);
+  const result = await requestConfiguredJson<GenerationHistoryListPayload>(
+    { target: targetUrl, init: withSameOrigin() },
+    { signal: options.signal },
+  );
+  return toListOutput((result.data as GenerationHistoryListPayload | null) ?? null);
 };
 
 export const rateResult = async (
@@ -187,20 +161,20 @@ export const rateResult = async (
   rating: number,
 ): Promise<GenerationHistoryResult | null> => {
   const base = sanitizeBackendBaseUrl(baseUrl);
-  const api = useApi<GenerationHistoryResult | null>(
-    () => resolveHistoryEndpoint(base, `/results/${encodeURIComponent(String(resultId))}/rating`),
+  const config = createHistoryRequestConfig(
+    base,
+    `/results/${encodeURIComponent(String(resultId))}/rating`,
     {
-      credentials: 'same-origin',
       headers: {
         'Content-Type': 'application/json',
       },
     },
   );
-  const payload = await api.fetchData({
+  const result = await requestConfiguredJson<GenerationHistoryResult | null>(config, {
     method: 'PUT',
     body: JSON.stringify({ rating } satisfies GenerationRatingUpdate),
   });
-  return payload ?? null;
+  return (result.data as GenerationHistoryResult | null) ?? null;
 };
 
 export const favoriteResult = async (
@@ -209,20 +183,20 @@ export const favoriteResult = async (
   isFavorite: boolean,
 ): Promise<GenerationHistoryResult | null> => {
   const base = sanitizeBackendBaseUrl(baseUrl);
-  const api = useApi<GenerationHistoryResult | null>(
-    () => resolveHistoryEndpoint(base, `/results/${encodeURIComponent(String(resultId))}/favorite`),
+  const config = createHistoryRequestConfig(
+    base,
+    `/results/${encodeURIComponent(String(resultId))}/favorite`,
     {
-      credentials: 'same-origin',
       headers: {
         'Content-Type': 'application/json',
       },
     },
   );
-  const payload = await api.fetchData({
+  const result = await requestConfiguredJson<GenerationHistoryResult | null>(config, {
     method: 'PUT',
     body: JSON.stringify({ is_favorite: isFavorite }),
   });
-  return payload ?? null;
+  return (result.data as GenerationHistoryResult | null) ?? null;
 };
 
 export const favoriteResults = async (
@@ -230,16 +204,12 @@ export const favoriteResults = async (
   payload: GenerationBulkFavoriteRequest,
 ): Promise<void> => {
   const base = sanitizeBackendBaseUrl(baseUrl);
-  const api = useApi<void>(
-    () => resolveHistoryEndpoint(base, '/results/bulk-favorite'),
-    {
-      credentials: 'same-origin',
-      headers: {
-        'Content-Type': 'application/json',
-      },
+  const config = createHistoryRequestConfig(base, '/results/bulk-favorite', {
+    headers: {
+      'Content-Type': 'application/json',
     },
-  );
-  await api.fetchData({
+  });
+  await performConfiguredRequest<void>(config, {
     method: 'PUT',
     body: JSON.stringify(payload),
   });
@@ -250,13 +220,11 @@ export const deleteResult = async (
   resultId: GenerationHistoryResult['id'],
 ): Promise<void> => {
   const base = sanitizeBackendBaseUrl(baseUrl);
-  const api = useApi<void>(
-    () => resolveHistoryEndpoint(base, `/results/${encodeURIComponent(String(resultId))}`),
-    {
-      credentials: 'same-origin',
-    },
+  const config = createHistoryRequestConfig(
+    base,
+    `/results/${encodeURIComponent(String(resultId))}`,
   );
-  await api.fetchData({ method: 'DELETE' });
+  await performConfiguredRequest<void>(config, { method: 'DELETE' });
 };
 
 export const deleteResults = async (
@@ -264,16 +232,12 @@ export const deleteResults = async (
   payload: GenerationBulkDeleteRequest,
 ): Promise<void> => {
   const base = sanitizeBackendBaseUrl(baseUrl);
-  const api = useApi<void>(
-    () => resolveHistoryEndpoint(base, '/results/bulk-delete'),
-    {
-      credentials: 'same-origin',
-      headers: {
-        'Content-Type': 'application/json',
-      },
+  const config = createHistoryRequestConfig(base, '/results/bulk-delete', {
+    headers: {
+      'Content-Type': 'application/json',
     },
-  );
-  await api.fetchData({
+  });
+  await performConfiguredRequest<void>(config, {
     method: 'DELETE',
     body: JSON.stringify(payload),
   });

--- a/tests/vue/GenerationHistory.spec.js
+++ b/tests/vue/GenerationHistory.spec.js
@@ -29,7 +29,7 @@ const serviceMocks = vi.hoisted(() => ({
   deleteResults: vi.fn(),
 }));
 
-vi.mock('../../app/frontend/src/services/historyService', () => ({
+vi.mock('../../app/frontend/src/services/history/historyService', () => ({
   listResults: serviceMocks.listResults,
   rateResult: serviceMocks.rateResult,
   favoriteResult: serviceMocks.favoriteResult,

--- a/tests/vue/apiClients.spec.ts
+++ b/tests/vue/apiClients.spec.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { useActiveJobsApi, useAdapterListApi } from '../../app/frontend/src/composables/shared/apiClients';
-import { useDashboardStatsApi, useSystemStatusApi } from '../../app/frontend/src/services/system';
+import { fetchDashboardStats, fetchSystemStatus } from '../../app/frontend/src/services/system/systemService';
 import { useSettingsStore } from '../../app/frontend/src/stores/settings';
 
 const createJsonResponse = (payload: unknown): Response => ({
@@ -42,14 +42,10 @@ describe('apiClients composables', () => {
   });
 
   it('resolves dashboard stats requests against the configured backend URL', async () => {
-    const settingsStore = useSettingsStore();
-    settingsStore.setSettings({ backendUrl: 'https://stats.example/backend' });
-
     const fetchMock = vi.fn().mockResolvedValue(createJsonResponse({}));
     global.fetch = fetchMock as unknown as typeof fetch;
 
-    const { fetchData } = useDashboardStatsApi();
-    await fetchData();
+    await fetchDashboardStats('https://stats.example/backend/');
 
     expect(fetchMock).toHaveBeenCalledWith(
       'https://stats.example/backend/dashboard/stats',
@@ -58,14 +54,10 @@ describe('apiClients composables', () => {
   });
 
   it('resolves system status requests against the configured backend URL', async () => {
-    const settingsStore = useSettingsStore();
-    settingsStore.setSettings({ backendUrl: 'https://status.example/api' });
-
     const fetchMock = vi.fn().mockResolvedValue(createJsonResponse({}));
     global.fetch = fetchMock as unknown as typeof fetch;
 
-    const { fetchData } = useSystemStatusApi();
-    await fetchData();
+    await fetchSystemStatus('https://status.example/api');
 
     expect(fetchMock).toHaveBeenCalledWith(
       'https://status.example/api/system/status',


### PR DESCRIPTION
## Summary
- introduce configured request helpers in the shared API client to merge options while preserving authentication headers
- refactor the system and history services to use the helpers and return plain promises, updating the dashboard generation summary component to manage its own reactive state
- refresh unit tests to cover the new abstractions and adjusted service contracts

## Testing
- npm run test -- --run tests/vue/apiClient.spec.ts tests/vue/apiClients.spec.ts tests/vue/useGenerationHistory.spec.js
- npm run test -- --run tests/vue/GenerationHistory.spec.js

------
https://chatgpt.com/codex/tasks/task_e_68dac2808f1c8329a393847ec75b4065