### PR TITLE
feat(frontend): centralize backend settings provider

### DIFF
--- a/app/frontend/src/config/backendSettings.ts
+++ b/app/frontend/src/config/backendSettings.ts
@@ -1,0 +1,73 @@
+import { computed, reactive, readonly } from 'vue';
+
+import runtimeConfig from '@/config/runtime';
+
+export interface BackendSettingsState {
+  backendUrl: string;
+  backendApiKey: string | null;
+}
+
+type BackendSettingsUpdate = {
+  backendUrl?: string | null;
+  backendApiKey?: string | null;
+};
+
+const trimTrailingSlash = (value: string): string => value.replace(/\/+$/, '');
+const normaliseApiKey = (value: string | null): string | null => {
+  if (value == null) {
+    return null;
+  }
+
+  const trimmed = `${value}`.trim();
+  return trimmed.length > 0 ? trimmed : null;
+};
+
+const initialState: BackendSettingsState = {
+  backendUrl: trimTrailingSlash(runtimeConfig.backendBasePath),
+  backendApiKey: normaliseApiKey(runtimeConfig.backendApiKey ?? null),
+};
+
+const state = reactive<BackendSettingsState>({
+  backendUrl: initialState.backendUrl,
+  backendApiKey: initialState.backendApiKey,
+});
+
+const backendUrlRef = computed(() => state.backendUrl);
+const backendApiKeyRef = computed(() => state.backendApiKey);
+
+export const backendSettingsState = readonly(state);
+
+export const updateBackendSettings = (update: BackendSettingsUpdate = {}): void => {
+  if (Object.prototype.hasOwnProperty.call(update, 'backendUrl')) {
+    const raw = update.backendUrl ?? '';
+    const stringified = String(raw).trim();
+    state.backendUrl = stringified ? trimTrailingSlash(stringified) : '';
+  }
+
+  if (Object.prototype.hasOwnProperty.call(update, 'backendApiKey')) {
+    const raw = update.backendApiKey ?? null;
+    state.backendApiKey = normaliseApiKey(raw);
+  }
+};
+
+export const resetBackendSettings = (): void => {
+  state.backendUrl = initialState.backendUrl;
+  state.backendApiKey = initialState.backendApiKey;
+};
+
+export const getBackendUrl = (): string => backendUrlRef.value;
+export const getBackendApiKey = (): string | null => backendApiKeyRef.value;
+
+export const useBackendSettings = () => ({
+  backendUrl: backendUrlRef,
+  backendApiKey: backendApiKeyRef,
+});
+
+export default {
+  state: backendSettingsState,
+  update: updateBackendSettings,
+  reset: resetBackendSettings,
+  use: useBackendSettings,
+  getBackendUrl,
+  getBackendApiKey,
+};

--- a/app/frontend/src/stores/settings.ts
+++ b/app/frontend/src/stores/settings.ts
@@ -1,33 +1,9 @@
 import { defineStore } from 'pinia';
 
+import { resetBackendSettings, updateBackendSettings } from '@/config/backendSettings';
 import { loadFrontendSettings } from '@/services';
 import { trimTrailingSlash } from '@/utils/backend';
 import type { FrontendRuntimeSettings, SettingsState } from '@/types';
-
-const applyWindowGlobals = (settings: FrontendRuntimeSettings | null) => {
-  if (typeof window === 'undefined') {
-    return;
-  }
-
-  const win = window as typeof window & {
-    BACKEND_URL?: string;
-    BACKEND_API_KEY?: string | null;
-    __APP_SETTINGS__?: FrontendRuntimeSettings | null;
-  };
-
-  if (settings) {
-    const backendUrl = typeof settings.backendUrl === 'string'
-      ? trimTrailingSlash(settings.backendUrl)
-      : '';
-    win.BACKEND_URL = backendUrl;
-    win.BACKEND_API_KEY = settings.backendApiKey ?? '';
-    win.__APP_SETTINGS__ = settings;
-  } else {
-    win.__APP_SETTINGS__ = null;
-    win.BACKEND_URL = '';
-    win.BACKEND_API_KEY = '';
-  }
-};
 
 export const useSettingsStore = defineStore('app-settings', {
   state: (): SettingsState => ({
@@ -62,7 +38,10 @@ export const useSettingsStore = defineStore('app-settings', {
 
       this.settings = merged;
       this.isLoaded = true;
-      applyWindowGlobals(merged);
+      updateBackendSettings({
+        backendUrl,
+        backendApiKey,
+      });
     },
 
     async loadSettings(force = false) {
@@ -95,7 +74,7 @@ export const useSettingsStore = defineStore('app-settings', {
       this.isLoaded = false;
       this.isLoading = false;
       this.error = null;
-      applyWindowGlobals(null);
+      resetBackendSettings();
     },
   },
 });

--- a/app/frontend/src/utils/httpAuth.ts
+++ b/app/frontend/src/utils/httpAuth.ts
@@ -1,4 +1,5 @@
 import runtimeConfig from '@/config/runtime';
+import { getBackendApiKey } from '@/config/backendSettings';
 
 export const API_AUTH_HEADER = 'X-API-Key';
 
@@ -16,20 +17,8 @@ const sanitiseApiKey = (value?: string | null): string | null => {
   return trimmed.length > 0 ? trimmed : null;
 };
 
-const readWindowApiKey = (): string | null => {
-  if (typeof window === 'undefined') {
-    return null;
-  }
-
-  const win = window as typeof window & {
-    BACKEND_API_KEY?: string | null;
-  };
-
-  return sanitiseApiKey(win.BACKEND_API_KEY ?? null);
-};
-
 export const getActiveApiKey = (): string | null => {
-  return readWindowApiKey() ?? sanitiseApiKey(runtimeConfig.backendApiKey);
+  return sanitiseApiKey(getBackendApiKey()) ?? sanitiseApiKey(runtimeConfig.backendApiKey);
 };
 
 const normaliseKey = (key: string): string => key.toLowerCase();

--- a/tests/setup/vitest.setup.js
+++ b/tests/setup/vitest.setup.js
@@ -2,9 +2,15 @@
 import '@testing-library/jest-dom';
 import { createPinia, setActivePinia } from 'pinia';
 
+import { resetBackendSettings } from '@/config/backendSettings';
+
 import '../mocks/api-mocks.js';
 
 beforeEach(() => {
   setActivePinia(createPinia());
+});
+
+afterEach(() => {
+  resetBackendSettings();
 });
 

--- a/tests/vue/JobQueue.spec.js
+++ b/tests/vue/JobQueue.spec.js
@@ -9,11 +9,18 @@ import { useSettingsStore } from '../../app/frontend/src/stores/settings';
 const serviceMocks = vi.hoisted(() => ({
   cancelGenerationJob: vi.fn(),
   fetchActiveGenerationJobs: vi.fn(),
+  fetchSystemStatus: vi.fn(),
+  useDashboardStatsApi: vi.fn(() => ({ fetchData: vi.fn() })),
+  useSystemStatusApi: vi.fn(() => ({ fetchData: vi.fn() })),
 }));
 
 vi.mock('@/services', () => ({
   cancelGenerationJob: serviceMocks.cancelGenerationJob,
   fetchActiveGenerationJobs: serviceMocks.fetchActiveGenerationJobs,
+  fetchSystemStatus: serviceMocks.fetchSystemStatus,
+  useDashboardStatsApi: serviceMocks.useDashboardStatsApi,
+  useSystemStatusApi: serviceMocks.useSystemStatusApi,
+  DEFAULT_POLL_INTERVAL: 2500,
 }));
 
 vi.mock('@/services/generation/generationService', () => ({

--- a/tests/vue/apiClients.spec.ts
+++ b/tests/vue/apiClients.spec.ts
@@ -1,7 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { useActiveJobsApi } from '../../app/frontend/src/composables/shared/apiClients';
-import { useDashboardStatsApi, useSystemStatusApi } from '../../app/frontend/src/services/system';
+import {
+  fetchDashboardStats,
+  fetchSystemStatus,
+  useDashboardStatsApi,
+  useSystemStatusApi,
+} from '../../app/frontend/src/services/system';
 
 import { useSettingsStore } from '../../app/frontend/src/stores/settings';
 

--- a/tests/vue/httpAuth.spec.ts
+++ b/tests/vue/httpAuth.spec.ts
@@ -1,0 +1,63 @@
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { getBackendApiKey, resetBackendSettings, updateBackendSettings } from '@/config/backendSettings';
+import {
+  API_AUTH_HEADER,
+  buildAuthenticatedHeaders,
+  getActiveApiKey,
+} from '@/utils/httpAuth';
+
+const originalWindowApiKey = typeof window !== 'undefined'
+  ? (window as typeof window & { BACKEND_API_KEY?: string | null }).BACKEND_API_KEY
+  : undefined;
+
+describe('httpAuth utilities', () => {
+  afterEach(() => {
+    resetBackendSettings();
+
+    if (typeof window !== 'undefined') {
+      const win = window as typeof window & { BACKEND_API_KEY?: string | null };
+      if (originalWindowApiKey === undefined) {
+        delete win.BACKEND_API_KEY;
+      } else {
+        win.BACKEND_API_KEY = originalWindowApiKey;
+      }
+    }
+  });
+
+  it('returns null when no API key is configured', () => {
+    resetBackendSettings();
+
+    expect(getBackendApiKey()).toBeNull();
+    expect(getActiveApiKey()).toBeNull();
+
+    const headers = buildAuthenticatedHeaders({ Accept: 'application/json' });
+    expect(headers).toEqual({ Accept: 'application/json' });
+  });
+
+  it('prefers provider state over window globals', () => {
+    if (typeof window !== 'undefined') {
+      (window as typeof window & { BACKEND_API_KEY?: string | null }).BACKEND_API_KEY = 'window-value';
+    }
+
+    updateBackendSettings({ backendApiKey: '  secret-key  ' });
+
+    expect(getBackendApiKey()).toBe('secret-key');
+    expect(getActiveApiKey()).toBe('secret-key');
+
+    const headers = buildAuthenticatedHeaders();
+    expect(headers).toMatchObject({ [API_AUTH_HEADER]: 'secret-key' });
+  });
+
+  it('responds to runtime updates without mutating existing headers', () => {
+    updateBackendSettings({ backendApiKey: 'initial' });
+    const first = buildAuthenticatedHeaders();
+    expect(first).toMatchObject({ [API_AUTH_HEADER]: 'initial' });
+
+    updateBackendSettings({ backendApiKey: 'updated-value' });
+
+    const headers = buildAuthenticatedHeaders({ [API_AUTH_HEADER]: 'preset' });
+    expect(headers).toMatchObject({ [API_AUTH_HEADER]: 'preset' });
+    expect(getActiveApiKey()).toBe('updated-value');
+  });
+});

--- a/tests/vue/useJobQueue.spec.ts
+++ b/tests/vue/useJobQueue.spec.ts
@@ -8,12 +8,19 @@ import { useGenerationConnectionStore, useGenerationQueueStore } from '@/stores/
 const serviceMocks = vi.hoisted(() => ({
   fetchActiveGenerationJobs: vi.fn(),
   cancelGenerationJob: vi.fn(),
+  fetchSystemStatus: vi.fn(),
+  useDashboardStatsApi: vi.fn(() => ({ fetchData: vi.fn() })),
+  useSystemStatusApi: vi.fn(() => ({ fetchData: vi.fn() })),
 }));
 
 vi.mock('@/services', () => ({
   fetchActiveGenerationJobs: serviceMocks.fetchActiveGenerationJobs,
   cancelGenerationJob: serviceMocks.cancelGenerationJob,
+  fetchSystemStatus: serviceMocks.fetchSystemStatus,
+  useDashboardStatsApi: serviceMocks.useDashboardStatsApi,
+  useSystemStatusApi: serviceMocks.useSystemStatusApi,
   buildAdapterListQuery: vi.fn(),
+  DEFAULT_POLL_INTERVAL: 2500,
 }));
 
 vi.mock('@/services/generation/generationService', () => ({

--- a/tests/vue/useJobQueueActions.spec.ts
+++ b/tests/vue/useJobQueueActions.spec.ts
@@ -8,12 +8,19 @@ import { useGenerationQueueStore } from '@/stores/generation';
 const serviceMocks = vi.hoisted(() => ({
   cancelGenerationJob: vi.fn(),
   fetchActiveGenerationJobs: vi.fn(),
+  fetchSystemStatus: vi.fn(),
+  useDashboardStatsApi: vi.fn(() => ({ fetchData: vi.fn() })),
+  useSystemStatusApi: vi.fn(() => ({ fetchData: vi.fn() })),
 }));
 
 vi.mock('@/services', () => ({
   cancelGenerationJob: serviceMocks.cancelGenerationJob,
   fetchActiveGenerationJobs: serviceMocks.fetchActiveGenerationJobs,
+  fetchSystemStatus: serviceMocks.fetchSystemStatus,
+  useDashboardStatsApi: serviceMocks.useDashboardStatsApi,
+  useSystemStatusApi: serviceMocks.useSystemStatusApi,
   buildAdapterListQuery: vi.fn(),
+  DEFAULT_POLL_INTERVAL: 2500,
 }));
 
 vi.mock('@/services/generation/generationService', () => ({


### PR DESCRIPTION
## Summary
- add a reactive backend settings provider to expose backend URL and API key
- push settings store updates into the provider and read it from httpAuth
- reset provider state in Vitest setup and extend unit tests, including new httpAuth coverage

## Testing
- npm run test:unit

------
https://chatgpt.com/codex/tasks/task_e_68dacbbb27608329a1544b1574171ccc