### PR TITLE
Add shared query param composable

### DIFF
--- a/app/frontend/src/components/layout/MainNavigation.vue
+++ b/app/frontend/src/components/layout/MainNavigation.vue
@@ -78,11 +78,11 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref, watch } from 'vue';
+import { computed } from 'vue';
 import { useRoute, useRouter, RouterLink } from 'vue-router';
 
 import { useAppStore } from '@/stores';
-import { useTheme } from '@/composables/shared';
+import { useSyncedQueryParam, useTheme } from '@/composables/shared';
 import { NAVIGATION_ITEMS } from '@/config/navigation';
 
 import NavigationIcon from './NavigationIcon.vue';
@@ -92,7 +92,7 @@ const router = useRouter();
 const route = useRoute();
 const { currentTheme, toggleTheme } = useTheme();
 
-const searchQuery = ref('');
+const searchQuery = useSyncedQueryParam();
 const items = NAVIGATION_ITEMS;
 
 const currentPath = computed(() => route.path.replace(/\/+$/, '') || '/');
@@ -102,37 +102,13 @@ const themeToggleLabel = computed(() =>
   currentTheme.value === 'dark' ? 'Switch to light theme' : 'Switch to dark theme'
 );
 
-const normalizeQueryValue = (value: unknown): string => {
-  if (Array.isArray(value)) {
-    return value[0] ?? '';
-  }
-
-  return typeof value === 'string' ? value : '';
-};
-
-const syncSearchQueryFromRoute = (value: unknown) => {
-  const normalized = normalizeQueryValue(value);
-
-  if (normalized !== searchQuery.value) {
-    searchQuery.value = normalized;
-  }
-};
-
-syncSearchQueryFromRoute(route.query.q);
-
-watch(
-  () => route.query.q,
-  newValue => {
-    syncSearchQueryFromRoute(newValue);
-  }
-);
-
 const handleSearch = () => {
   if (!canSearch.value) {
     return;
   }
 
   const query = searchQuery.value.trim();
+  searchQuery.value = query;
 
   router.push({ name: 'loras', query: { q: query } }).catch(() => {
     router.push('/loras');

--- a/app/frontend/src/composables/lora-gallery/useLoraGalleryFilters.ts
+++ b/app/frontend/src/composables/lora-gallery/useLoraGalleryFilters.ts
@@ -2,9 +2,13 @@ import { computed, ref } from 'vue';
 import type { Ref } from 'vue';
 
 import type { GalleryLora, LoraGallerySortOption } from '@/types';
+import { useSyncedQueryParam } from '@/composables/shared';
 
-export function useLoraGalleryFilters(loras: Ref<GalleryLora[]>) {
-  const searchTerm = ref('');
+export function useLoraGalleryFilters(
+  loras: Ref<GalleryLora[]>,
+  searchTermRef?: Ref<string>
+) {
+  const searchTerm = searchTermRef ?? useSyncedQueryParam();
   const activeOnly = ref(false);
   const selectedTags = ref<string[]>([]);
   const sortBy = ref<LoraGallerySortOption>('name_asc');

--- a/app/frontend/src/composables/shared/index.ts
+++ b/app/frontend/src/composables/shared/index.ts
@@ -5,3 +5,4 @@ export * from './useNotifications';
 export * from './usePolling';
 export * from './useTheme';
 export * from './usePersistence';
+export * from './useSyncedQueryParam';

--- a/app/frontend/src/composables/shared/useSyncedQueryParam.ts
+++ b/app/frontend/src/composables/shared/useSyncedQueryParam.ts
@@ -1,0 +1,64 @@
+import { ref, watch } from 'vue';
+import {
+  NavigationFailureType,
+  isNavigationFailure,
+  useRoute,
+  useRouter,
+} from 'vue-router';
+import type { Ref } from 'vue';
+import type { LocationQueryRaw } from 'vue-router';
+
+const normalizeQueryValue = (value: unknown): string => {
+  if (Array.isArray(value)) {
+    return value[0] ?? '';
+  }
+
+  return typeof value === 'string' ? value : '';
+};
+
+export function useSyncedQueryParam(key = 'q'): Ref<string> {
+  const route = useRoute();
+  const router = useRouter();
+
+  const value = ref<string>(normalizeQueryValue(route.query[key]));
+
+  const syncFromRoute = () => {
+    const normalized = normalizeQueryValue(route.query[key]);
+    if (normalized !== value.value) {
+      value.value = normalized;
+    }
+  };
+
+  watch(
+    () => route.query[key],
+    () => {
+      syncFromRoute();
+    }
+  );
+
+  watch(value, newValue => {
+    const currentQueryValue = normalizeQueryValue(route.query[key]);
+
+    if (newValue === currentQueryValue) {
+      return;
+    }
+
+    const nextQuery = { ...route.query } as LocationQueryRaw;
+
+    if (newValue) {
+      nextQuery[key] = newValue;
+    } else {
+      delete nextQuery[key];
+    }
+
+    router.push({ path: route.path, query: nextQuery }).catch(error => {
+      if (!isNavigationFailure(error, NavigationFailureType.duplicated)) {
+        console.error(`Failed to update "${key}" query parameter`, error);
+      }
+    });
+  });
+
+  syncFromRoute();
+
+  return value;
+}

--- a/tests/vue/JobQueue.spec.js
+++ b/tests/vue/JobQueue.spec.js
@@ -14,6 +14,9 @@ const serviceMocks = vi.hoisted(() => ({
 vi.mock('@/services', () => ({
   cancelGenerationJob: serviceMocks.cancelGenerationJob,
   fetchActiveGenerationJobs: serviceMocks.fetchActiveGenerationJobs,
+  useDashboardStatsApi: vi.fn(() => ({ get: vi.fn() })),
+  useSystemStatusApi: vi.fn(() => ({ get: vi.fn() })),
+  DEFAULT_POLL_INTERVAL: 1000,
 }));
 
 vi.mock('@/services/generation/generationService', () => ({

--- a/tests/vue/apiClients.spec.ts
+++ b/tests/vue/apiClients.spec.ts
@@ -1,7 +1,14 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { useActiveJobsApi } from '../../app/frontend/src/composables/shared/apiClients';
-import { useDashboardStatsApi, useSystemStatusApi } from '../../app/frontend/src/services/system';
+import {
+  useDashboardStatsApi,
+  useSystemStatusApi,
+} from '../../app/frontend/src/services/system';
+import {
+  fetchDashboardStats,
+  fetchSystemStatus,
+} from '../../app/frontend/src/services/system/systemService';
 
 import { useSettingsStore } from '../../app/frontend/src/stores/settings';
 

--- a/tests/vue/useJobQueue.spec.ts
+++ b/tests/vue/useJobQueue.spec.ts
@@ -14,6 +14,9 @@ vi.mock('@/services', () => ({
   fetchActiveGenerationJobs: serviceMocks.fetchActiveGenerationJobs,
   cancelGenerationJob: serviceMocks.cancelGenerationJob,
   buildAdapterListQuery: vi.fn(),
+  useDashboardStatsApi: vi.fn(() => ({ get: vi.fn() })),
+  useSystemStatusApi: vi.fn(() => ({ get: vi.fn() })),
+  DEFAULT_POLL_INTERVAL: 1000,
 }));
 
 vi.mock('@/services/generation/generationService', () => ({

--- a/tests/vue/useJobQueueActions.spec.ts
+++ b/tests/vue/useJobQueueActions.spec.ts
@@ -14,6 +14,9 @@ vi.mock('@/services', () => ({
   cancelGenerationJob: serviceMocks.cancelGenerationJob,
   fetchActiveGenerationJobs: serviceMocks.fetchActiveGenerationJobs,
   buildAdapterListQuery: vi.fn(),
+  useDashboardStatsApi: vi.fn(() => ({ get: vi.fn() })),
+  useSystemStatusApi: vi.fn(() => ({ get: vi.fn() })),
+  DEFAULT_POLL_INTERVAL: 1000,
 }));
 
 vi.mock('@/services/generation/generationService', () => ({

--- a/tests/vue/useSyncedQueryParam.spec.ts
+++ b/tests/vue/useSyncedQueryParam.spec.ts
@@ -1,0 +1,121 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { mount } from '@vue/test-utils';
+import { nextTick, reactive, type Ref } from 'vue';
+
+const routerMocks = vi.hoisted(() => ({
+  push: vi.fn(),
+  failures: { duplicated: 1 },
+}));
+
+const route = reactive({
+  path: '/loras',
+  query: reactive({}) as Record<string, unknown>,
+});
+
+vi.mock('vue-router', () => ({
+  useRoute: () => route,
+  useRouter: () => ({
+    push: routerMocks.push,
+  }),
+  isNavigationFailure: (error: unknown, failureType: number) =>
+    typeof error === 'object' && error !== null && 'type' in (error as Record<string, unknown>)
+      ? (error as { type?: number }).type === failureType
+      : false,
+  NavigationFailureType: routerMocks.failures,
+}));
+
+import { useSyncedQueryParam } from '@/composables/shared';
+
+describe('useSyncedQueryParam', () => {
+  beforeEach(() => {
+    routerMocks.push.mockReset();
+    routerMocks.push.mockResolvedValue(undefined);
+    route.path = '/loras';
+    Object.keys(route.query).forEach(key => {
+      delete (route.query as Record<string, unknown>)[key];
+    });
+  });
+
+  const withSetup = (key?: string): Ref<string> => {
+    let result!: Ref<string>;
+    mount({
+      template: '<div />',
+      setup() {
+        result = useSyncedQueryParam(key);
+        return {};
+      },
+    });
+
+    return result;
+  };
+
+  it('initializes from the current route query and normalizes arrays', async () => {
+    route.query.q = ['alpha', 'beta'];
+
+    const queryRef = withSetup();
+    await nextTick();
+
+    expect(queryRef.value).toBe('alpha');
+  });
+
+  it('updates when the route query changes', async () => {
+    const queryRef = withSetup();
+
+    route.query.q = 'gamma';
+    await nextTick();
+    expect(queryRef.value).toBe('gamma');
+
+    route.query.q = ['delta'];
+    await nextTick();
+    expect(queryRef.value).toBe('delta');
+  });
+
+  it('pushes router updates when the ref changes', async () => {
+    const queryRef = withSetup();
+
+    queryRef.value = 'epsilon';
+    await nextTick();
+
+    expect(routerMocks.push).toHaveBeenCalledTimes(1);
+    expect(routerMocks.push).toHaveBeenCalledWith({
+      path: '/loras',
+      query: { q: 'epsilon' },
+    });
+
+    route.query.q = 'epsilon';
+    await nextTick();
+
+    queryRef.value = '';
+    await nextTick();
+
+    expect(routerMocks.push).toHaveBeenCalledTimes(2);
+    expect(routerMocks.push).toHaveBeenLastCalledWith({
+      path: '/loras',
+      query: {},
+    });
+  });
+
+  it('suppresses duplicate navigation errors while logging others', async () => {
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const queryRef = withSetup();
+
+    routerMocks.push.mockRejectedValueOnce({ type: routerMocks.failures.duplicated });
+    queryRef.value = 'zeta';
+    await nextTick();
+    await Promise.resolve();
+    await nextTick();
+
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
+
+    routerMocks.push.mockRejectedValueOnce(new Error('boom'));
+    queryRef.value = 'eta';
+    await nextTick();
+    await Promise.resolve();
+    await nextTick();
+
+    expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
+
+    consoleErrorSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
- add a `useSyncedQueryParam` composable that normalizes query values and updates the router when the ref changes
- integrate the shared ref into the LoRA gallery filters and main navigation search box
- cover the composable with unit tests and update existing queue/service tests to mock the new dependencies

## Testing
- npm run test:unit

------
https://chatgpt.com/codex/tasks/task_e_68dacba4bbdc832985fad235de680430