### PR TITLE
Introduce backend client helper and refactor service integrations

### DIFF
--- a/app/frontend/src/components/dashboard/DashboardGenerationSummary.vue
+++ b/app/frontend/src/components/dashboard/DashboardGenerationSummary.vue
@@ -97,15 +97,14 @@ import { computed, onMounted, ref } from 'vue';
 import { storeToRefs } from 'pinia';
 import { RouterLink } from 'vue-router';
 
-import { listResults as listHistoryResults } from '@/services';
+import { listResults as listHistoryResults, useBackendClient } from '@/services';
 import { useGenerationResultsStore } from '@/stores/generation';
-import { useBackendBase } from '@/utils/backend';
 import { formatFileSize, formatRelativeTime } from '@/utils/format';
 import type { GenerationHistoryResult, GenerationHistoryStats } from '@/types';
 
 const SUMMARY_QUERY = Object.freeze({ page_size: 4, sort: 'created_at_desc' as const });
 
-const backendBase = useBackendBase();
+const backendClient = useBackendClient();
 const resultsStore = useGenerationResultsStore();
 const { recentResults: storeResults } = storeToRefs(resultsStore);
 
@@ -161,7 +160,7 @@ const refresh = async () => {
   error.value = null;
 
   try {
-    const output = await listHistoryResults(backendBase.value, { ...SUMMARY_QUERY });
+    const output = await listHistoryResults({ ...SUMMARY_QUERY }, {}, backendClient);
     stats.value = output.stats;
     fetchedResults.value = output.results;
     if (!storeResults.value.length && output.results.length) {

--- a/app/frontend/src/composables/usePerformanceAnalytics.ts
+++ b/app/frontend/src/composables/usePerformanceAnalytics.ts
@@ -10,8 +10,8 @@ import {
   exportAnalyticsReport,
   fetchPerformanceAnalytics,
   fetchTopAdapters,
+  useBackendClient,
 } from '@/services';
-import { useBackendBase } from '@/utils/backend';
 import { formatDuration as formatDurationLabel } from '@/utils/format';
 
 import type {
@@ -86,7 +86,7 @@ const createDevTopLoras = (): TopLoraPerformance[] => [
 ];
 
 export function usePerformanceAnalytics() {
-  const backendBase = useBackendBase();
+  const backendClient = useBackendClient();
 
   const timeRange = ref<PerformanceTimeRange>('24h');
   const autoRefresh = ref<boolean>(false);
@@ -101,7 +101,7 @@ export function usePerformanceAnalytics() {
 
   const loadTopLoras = async (): Promise<void> => {
     try {
-      const adapters = await fetchTopAdapters(backendBase.value, 10);
+      const adapters = await fetchTopAdapters(10, backendClient);
       topLoras.value = adapters;
 
       if (!topLoras.value.length && import.meta.env.DEV) {
@@ -129,7 +129,7 @@ export function usePerformanceAnalytics() {
 
   const loadAnalyticsSummary = async (): Promise<void> => {
     try {
-      const summary = await fetchPerformanceAnalytics(backendBase.value, timeRange.value);
+      const summary = await fetchPerformanceAnalytics(timeRange.value, backendClient);
 
       kpis.value = {
         ...DEFAULT_KPIS,
@@ -187,7 +187,7 @@ export function usePerformanceAnalytics() {
     format: string,
     overrides: Partial<AnalyticsExportOptions> = {},
   ): Promise<AnalyticsExportResult> =>
-    exportAnalyticsReport(backendBase.value, { format, ...overrides });
+    exportAnalyticsReport({ format, ...overrides }, backendClient);
 
   return {
     timeRange,

--- a/app/frontend/src/services/backendClient.ts
+++ b/app/frontend/src/services/backendClient.ts
@@ -1,0 +1,93 @@
+import type { MaybeRefOrGetter } from 'vue';
+
+import {
+  deleteRequest,
+  postJson as postJsonRequest,
+  putJson as putJsonRequest,
+  patchJson as patchJsonRequest,
+  requestBlob as requestBlobFromApi,
+  requestJson as requestJsonFromApi,
+  type ApiRequestInit,
+  type ApiResult,
+  type BlobResult,
+} from '@/services/apiClient';
+import { resolveBackendBaseUrl, resolveBackendUrl, useBackendBase } from '@/utils/backend';
+
+export interface BackendClient {
+  resolve: (path?: string) => string;
+  requestJson: <TPayload = unknown>(path: string, init?: ApiRequestInit) => Promise<ApiResult<TPayload>>;
+  getJson: <TPayload = unknown>(path: string, init?: ApiRequestInit) => Promise<TPayload | null>;
+  postJson: <TResponse = unknown, TBody = unknown>(
+    path: string,
+    body: TBody,
+    init?: ApiRequestInit,
+  ) => Promise<ApiResult<TResponse>>;
+  putJson: <TResponse = unknown, TBody = unknown>(
+    path: string,
+    body: TBody,
+    init?: ApiRequestInit,
+  ) => Promise<ApiResult<TResponse>>;
+  patchJson: <TResponse = unknown, TBody = unknown>(
+    path: string,
+    body: TBody,
+    init?: ApiRequestInit,
+  ) => Promise<ApiResult<TResponse>>;
+  delete: <TResponse = unknown>(path: string, init?: ApiRequestInit) => Promise<ApiResult<TResponse>>;
+  requestBlob: (path: string, init?: RequestInit) => Promise<BlobResult>;
+}
+
+export type BackendBaseOverride =
+  | string
+  | null
+  | undefined
+  | (() => string | null | undefined);
+
+const createClientFromResolver = (resolveBase: () => string): BackendClient => {
+  const resolvePath = (path = ''): string => {
+    if (typeof path === 'string' && /^https?:\/\//i.test(path)) {
+      return path;
+    }
+    return resolveBackendUrl(path, resolveBase());
+  };
+
+  return {
+    resolve: resolvePath,
+    requestJson: <TPayload>(path: string, init?: ApiRequestInit) =>
+      requestJsonFromApi<TPayload>(resolvePath(path), init),
+    getJson: async <TPayload>(path: string, init?: ApiRequestInit) => {
+      const result = await requestJsonFromApi<TPayload>(resolvePath(path), init);
+      return (result.data as TPayload | null) ?? null;
+    },
+    postJson: <TResponse, TBody>(path: string, body: TBody, init?: ApiRequestInit) =>
+      postJsonRequest<TResponse, TBody>(resolvePath(path), body, init),
+    putJson: <TResponse, TBody>(path: string, body: TBody, init?: ApiRequestInit) =>
+      putJsonRequest<TResponse, TBody>(resolvePath(path), body, init),
+    patchJson: <TResponse, TBody>(path: string, body: TBody, init?: ApiRequestInit) =>
+      patchJsonRequest<TResponse, TBody>(resolvePath(path), body, init),
+    delete: <TResponse>(path: string, init?: ApiRequestInit) =>
+      deleteRequest<TResponse>(resolvePath(path), init),
+    requestBlob: (path: string, init?: RequestInit) => requestBlobFromApi(resolvePath(path), init),
+  } satisfies BackendClient;
+};
+
+const resolveOverrideBase = (override?: BackendBaseOverride): (() => string) => {
+  if (typeof override === 'function') {
+    return () => resolveBackendBaseUrl(override() ?? undefined);
+  }
+
+  return () => resolveBackendBaseUrl(override ?? undefined);
+};
+
+const defaultClient = createClientFromResolver(resolveOverrideBase());
+
+export const createBackendClient = (override?: BackendBaseOverride): BackendClient =>
+  createClientFromResolver(resolveOverrideBase(override));
+
+export const resolveBackendClient = (client?: BackendClient | null): BackendClient => client ?? defaultClient;
+
+export const useBackendClient = (override?: MaybeRefOrGetter<string | null>): BackendClient => {
+  const backendBase = useBackendBase(override);
+  return createClientFromResolver(() => backendBase.value);
+};
+
+export type { ApiRequestInit, ApiResult, BlobResult };

--- a/app/frontend/src/services/index.ts
+++ b/app/frontend/src/services/index.ts
@@ -1,4 +1,5 @@
 export * from './apiClient';
+export * from './backendClient';
 export * from './generation';
 export * from './system';
 export * from './lora';

--- a/app/frontend/src/stores/adminMetrics.ts
+++ b/app/frontend/src/stores/adminMetrics.ts
@@ -5,8 +5,8 @@ import {
   deriveMetricsFromDashboard,
   emptyMetricsSnapshot,
   fetchDashboardStats,
+  useBackendClient,
 } from '@/services';
-import { useBackendBase } from '@/utils/backend';
 import {
   buildResourceStats,
   defaultResourceStats,
@@ -28,7 +28,7 @@ interface RefreshOptions {
 }
 
 export const useAdminMetricsStore = defineStore('adminMetrics', () => {
-  const backendBase = useBackendBase();
+  const backendClient = useBackendClient();
 
   const summary = ref<DashboardStatsSummary | null>(null);
   const metrics = ref<SystemMetricsSnapshot>(emptyMetricsSnapshot());
@@ -76,7 +76,7 @@ export const useAdminMetricsStore = defineStore('adminMetrics', () => {
     }
 
     try {
-      const payload = await fetchDashboardStats(backendBase.value);
+      const payload = await fetchDashboardStats(backendClient);
       applySummary(payload);
     } catch (err) {
       if (import.meta.env.DEV) {

--- a/app/frontend/src/stores/generation/systemStatusController.ts
+++ b/app/frontend/src/stores/generation/systemStatusController.ts
@@ -2,9 +2,8 @@ import { computed, ref, type ComputedRef } from 'vue';
 import { storeToRefs } from 'pinia';
 
 import { ApiError } from '@/composables/shared';
-import { fetchSystemStatus } from '@/services';
+import { fetchSystemStatus, useBackendClient } from '@/services';
 import { useGenerationConnectionStore } from '@/stores/generation';
-import { useBackendBase } from '@/utils/backend';
 
 const DEFAULT_POLL_INTERVAL = 10_000;
 
@@ -25,7 +24,7 @@ export const useSystemStatusController = (): SystemStatusController => {
 
   const connectionStore = useGenerationConnectionStore();
   const { systemStatusReady } = storeToRefs(connectionStore);
-  const backendBase = useBackendBase();
+  const backendClient = useBackendClient();
   const pollHandle = ref<ReturnType<typeof setInterval> | null>(null);
   const inFlight = ref<Promise<void> | null>(null);
 
@@ -43,7 +42,7 @@ export const useSystemStatusController = (): SystemStatusController => {
 
     const run = (async () => {
       try {
-        const payload = await fetchSystemStatus(backendBase.value);
+        const payload = await fetchSystemStatus(backendClient);
         connectionStore.resetSystemStatus();
 
         if (payload) {

--- a/tests/vue/JobQueue.spec.js
+++ b/tests/vue/JobQueue.spec.js
@@ -11,10 +11,14 @@ const serviceMocks = vi.hoisted(() => ({
   fetchActiveGenerationJobs: vi.fn(),
 }));
 
-vi.mock('@/services', () => ({
-  cancelGenerationJob: serviceMocks.cancelGenerationJob,
-  fetchActiveGenerationJobs: serviceMocks.fetchActiveGenerationJobs,
-}));
+vi.mock('@/services', async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    cancelGenerationJob: serviceMocks.cancelGenerationJob,
+    fetchActiveGenerationJobs: serviceMocks.fetchActiveGenerationJobs,
+  };
+});
 
 vi.mock('@/services/generation/generationService', () => ({
   cancelGenerationJob: serviceMocks.cancelGenerationJob,

--- a/tests/vue/LoraCard.spec.js
+++ b/tests/vue/LoraCard.spec.js
@@ -210,15 +210,26 @@ describe('LoraCard', () => {
 
     grid.vm.$emit('change-weight', 1.25);
     await flushPromises();
-    expect(mocks.updateLoraWeightMock).toHaveBeenCalledWith('/api/v1', 1, 1.25);
+    expect(mocks.updateLoraWeightMock).toHaveBeenCalledWith(
+      1,
+      1.25,
+      expect.objectContaining({ resolve: expect.any(Function) }),
+    );
 
     grid.vm.$emit('toggle-active');
     await flushPromises();
-    expect(mocks.toggleLoraActiveStateMock).toHaveBeenCalledWith('/api/v1', 1, false);
+    expect(mocks.toggleLoraActiveStateMock).toHaveBeenCalledWith(
+      1,
+      false,
+      expect.objectContaining({ resolve: expect.any(Function) }),
+    );
 
     grid.vm.$emit('generate-preview');
     await flushPromises();
-    expect(mocks.triggerPreviewGenerationMock).toHaveBeenCalledWith('/api/v1', 1);
+    expect(mocks.triggerPreviewGenerationMock).toHaveBeenCalledWith(
+      1,
+      expect.objectContaining({ resolve: expect.any(Function) }),
+    );
   });
 
   it('navigates to recommendations via the router', async () => {

--- a/tests/vue/LoraGallery.spec.js
+++ b/tests/vue/LoraGallery.spec.js
@@ -103,7 +103,7 @@ describe('LoraGallery', () => {
     settingsStore.reset();
     settingsStore.setSettings({ backendUrl: '/api/v1' });
 
-    mocks.fetchAdapterListMock.mockImplementation(async (_baseUrl, query = {}) => ({
+    mocks.fetchAdapterListMock.mockImplementation(async (query = {}) => ({
       items: [
         {
           id: '1',
@@ -156,8 +156,8 @@ describe('LoraGallery', () => {
   it('loads LoRAs on mount', async () => {
     await mountGallery();
     expect(mocks.fetchAdapterListMock).toHaveBeenCalledWith(
-      '/api/v1',
       expect.objectContaining({ perPage: 200 }),
+      expect.objectContaining({ resolve: expect.any(Function) }),
     );
   });
 
@@ -228,10 +228,12 @@ describe('LoraGallery', () => {
     await mountGallery();
 
     expect(mocks.fetchAdapterListMock).toHaveBeenCalledWith(
-      '/api/v1',
       expect.objectContaining({ perPage: 200 }),
+      expect.objectContaining({ resolve: expect.any(Function) }),
     );
-    expect(mocks.fetchAdapterTagsMock).toHaveBeenCalledWith('/api/v1');
+    expect(mocks.fetchAdapterTagsMock).toHaveBeenCalledWith(
+      expect.objectContaining({ resolve: expect.any(Function) }),
+    );
   });
 
   it('performs bulk actions using shared selection state', async () => {
@@ -247,10 +249,10 @@ describe('LoraGallery', () => {
 
     await wrapper.vm.performBulkAction('activate');
     await flushPromises();
-    expect(mocks.performBulkLoraActionMock).toHaveBeenCalledWith('/api/v1', {
-      action: 'activate',
-      lora_ids: ['1'],
-    });
+    expect(mocks.performBulkLoraActionMock).toHaveBeenCalledWith(
+      { action: 'activate', lora_ids: ['1'] },
+      expect.objectContaining({ resolve: expect.any(Function) }),
+    );
     expect(wrapper.vm.selectedCount).toBe(0);
     expect(dialogServiceMocks.confirm).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/tests/vue/apiClients.spec.ts
+++ b/tests/vue/apiClients.spec.ts
@@ -1,7 +1,13 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { useActiveJobsApi } from '../../app/frontend/src/composables/shared/apiClients';
-import { useDashboardStatsApi, useSystemStatusApi } from '../../app/frontend/src/services/system';
+import {
+  fetchDashboardStats,
+  fetchSystemStatus,
+  useDashboardStatsApi,
+  useSystemStatusApi,
+} from '../../app/frontend/src/services/system';
+import { createBackendClient } from '../../app/frontend/src/services/backendClient';
 
 import { useSettingsStore } from '../../app/frontend/src/stores/settings';
 
@@ -30,7 +36,7 @@ describe('apiClients composables', () => {
     const fetchMock = vi.fn().mockResolvedValue(createJsonResponse({}));
     global.fetch = fetchMock as unknown as typeof fetch;
 
-    await fetchDashboardStats('https://stats.example/backend/');
+    await fetchDashboardStats(createBackendClient('https://stats.example/backend/'));
 
     expect(fetchMock).toHaveBeenCalledWith(
       'https://stats.example/backend/dashboard/stats',
@@ -42,7 +48,7 @@ describe('apiClients composables', () => {
     const fetchMock = vi.fn().mockResolvedValue(createJsonResponse({}));
     global.fetch = fetchMock as unknown as typeof fetch;
 
-    await fetchSystemStatus('https://status.example/api');
+    await fetchSystemStatus(createBackendClient('https://status.example/api'));
 
     expect(fetchMock).toHaveBeenCalledWith(
       'https://status.example/api/system/status',

--- a/tests/vue/generationService.spec.ts
+++ b/tests/vue/generationService.spec.ts
@@ -150,14 +150,14 @@ describe('resolveBackendUrl', () => {
     const store = useSettingsStore()
     store.setSettings({ backendUrl: '/prefixed/api' })
 
-    expect(resolveGenerationBaseUrl()).toBe('/prefixed/api')
+    expect(resolveGenerationBaseUrl()).toBe('/prefixed/api/generation')
   })
 
   it('resolves an absolute backend base when the frontend origin differs', () => {
     const store = useSettingsStore()
     store.setSettings({ backendUrl: 'https://remote.example/api/v3/' })
 
-    expect(resolveGenerationBaseUrl()).toBe('https://remote.example/api/v3')
+    expect(resolveGenerationBaseUrl()).toBe('https://remote.example/api/v3/generation')
     expect(resolveBackendUrl('/generation/jobs/active')).toBe(
       'https://remote.example/api/v3/generation/jobs/active',
     )

--- a/tests/vue/loraService.spec.ts
+++ b/tests/vue/loraService.spec.ts
@@ -11,6 +11,7 @@ import {
   deleteLora,
   triggerPreviewGeneration,
 } from '@/services';
+import { createBackendClient } from '@/services/backendClient';
 import type { AdapterListResponse } from '@/types';
 
 const originalFetch = global.fetch;
@@ -96,13 +97,14 @@ describe('loraService', () => {
     const fetchMock = vi.fn().mockResolvedValue(response) as unknown as typeof fetch;
     global.fetch = fetchMock;
 
-    const result = await fetchAdapterList('/api/v1', {
+    const client = createBackendClient('/api/v1');
+    const result = await fetchAdapterList({
       page: 1,
       perPage: 10,
       search: 'Adapter',
       active: true,
       tags: ['fantasy'],
-    });
+    }, client);
 
     expect(fetchMock).toHaveBeenCalledWith(
       '/api/v1/adapters?page=1&per_page=10&search=Adapter&active=true&tags=fantasy',
@@ -174,7 +176,8 @@ describe('loraService', () => {
     const fetchMock = vi.fn().mockResolvedValue(response) as unknown as typeof fetch;
     global.fetch = fetchMock;
 
-    const result = await fetchAdapters('/api/v1', { perPage: 25 });
+    const client = createBackendClient('/api/v1');
+    const result = await fetchAdapters({ perPage: 25 }, client);
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(result).toHaveLength(1);
@@ -195,7 +198,8 @@ describe('loraService', () => {
     const fetchMock = vi.fn().mockResolvedValue(response) as unknown as typeof fetch;
     global.fetch = fetchMock;
 
-    const tags = await fetchAdapterTags('/api/v1/');
+    const client = createBackendClient('/api/v1/');
+    const tags = await fetchAdapterTags(client);
 
     expect(fetchMock).toHaveBeenCalledWith(
       '/api/v1/adapters/tags',
@@ -217,10 +221,11 @@ describe('loraService', () => {
     const fetchMock = vi.fn().mockResolvedValue(response) as unknown as typeof fetch;
     global.fetch = fetchMock;
 
-    await performBulkLoraAction('/api/v1', {
+    const client = createBackendClient('/api/v1');
+    await performBulkLoraAction({
       action: 'activate',
       lora_ids: ['alpha', 'beta'],
-    });
+    }, client);
 
     expect(fetchMock).toHaveBeenCalledWith(
       '/api/v1/adapters/bulk',
@@ -251,7 +256,8 @@ describe('loraService', () => {
     const fetchMock = vi.fn().mockResolvedValue(response) as unknown as typeof fetch;
     global.fetch = fetchMock;
 
-    const result = await updateLoraWeight('/api/v1', 'adapter-1', 0.5);
+    const client = createBackendClient('/api/v1');
+    const result = await updateLoraWeight('adapter-1', 0.5, client);
 
     expect(fetchMock).toHaveBeenCalledWith(
       '/api/v1/adapters/adapter-1',
@@ -278,7 +284,8 @@ describe('loraService', () => {
     const fetchMock = vi.fn().mockResolvedValue(response) as unknown as typeof fetch;
     global.fetch = fetchMock;
 
-    const result = await toggleLoraActiveState('/api/v1', 'adapter-2', true);
+    const client = createBackendClient('/api/v1');
+    const result = await toggleLoraActiveState('adapter-2', true, client);
 
     expect(fetchMock).toHaveBeenCalledWith(
       '/api/v1/adapters/adapter-2/activate',
@@ -300,7 +307,8 @@ describe('loraService', () => {
     const fetchMock = vi.fn().mockResolvedValue(response) as unknown as typeof fetch;
     global.fetch = fetchMock;
 
-    await deleteLora('/api/v1', 'adapter-3');
+    const client = createBackendClient('/api/v1');
+    await deleteLora('adapter-3', client);
 
     expect(fetchMock).toHaveBeenCalledWith(
       '/api/v1/adapters/adapter-3',
@@ -322,7 +330,8 @@ describe('loraService', () => {
     const fetchMock = vi.fn().mockResolvedValue(response) as unknown as typeof fetch;
     global.fetch = fetchMock;
 
-    const result = await triggerPreviewGeneration('/api/v1', 'adapter-9');
+    const client = createBackendClient('/api/v1');
+    const result = await triggerPreviewGeneration('adapter-9', client);
 
     expect(fetchMock).toHaveBeenCalledWith(
       '/api/v1/adapters/adapter-9/preview',

--- a/tests/vue/useAdapterCatalog.spec.ts
+++ b/tests/vue/useAdapterCatalog.spec.ts
@@ -53,7 +53,7 @@ describe('useAdapterCatalog', () => {
     settingsStore.setSettings({ backendUrl: '/api/v1' });
 
     mocks.fetchAdapterListMock.mockReset();
-    mocks.fetchAdapterListMock.mockImplementation(async (_baseUrl, query = {}) => ({
+    mocks.fetchAdapterListMock.mockImplementation(async (query = {}, _client) => ({
       items: [
         { id: 'alpha', name: 'Alpha', description: 'First adapter', active: true },
         { id: 'beta', name: 'Beta', description: 'Second adapter', active: false },

--- a/tests/vue/useHistoryActions.spec.ts
+++ b/tests/vue/useHistoryActions.spec.ts
@@ -18,7 +18,13 @@ const serviceMocks = vi.hoisted(() => ({
 
 const downloadFileMock = vi.hoisted(() => vi.fn());
 
-vi.mock('@/services', () => serviceMocks);
+vi.mock('@/services', async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    ...serviceMocks,
+  };
+});
 vi.mock('@/utils/browser', () => ({
   downloadFile: downloadFileMock,
 }));
@@ -111,7 +117,11 @@ describe('useHistoryActions', () => {
     const success = await actions.setRating(result, 5);
 
     expect(success).toBe(true);
-    expect(serviceMocks.rateResult).toHaveBeenCalledWith('/api', 1, 5);
+    expect(serviceMocks.rateResult).toHaveBeenCalledWith(
+      1,
+      5,
+      expect.objectContaining({ resolve: expect.any(Function) }),
+    );
     expect(result.rating).toBe(5);
     expect(applyFilters).toHaveBeenCalled();
     expect(showToast).toHaveBeenCalledWith('Rating updated successfully');
@@ -132,7 +142,10 @@ describe('useHistoryActions', () => {
     const success = await actions.deleteResult(1);
 
     expect(success).toBe(true);
-    expect(serviceMocks.deleteResult).toHaveBeenCalledWith('/api', 1);
+    expect(serviceMocks.deleteResult).toHaveBeenCalledWith(
+      1,
+      expect.objectContaining({ resolve: expect.any(Function) }),
+    );
     expect(data.value.map((item) => item.id)).toEqual([2, 3]);
     expect(selectedIds.value).toEqual([2]);
     expect(showToast).toHaveBeenCalledWith('Image deleted successfully');
@@ -145,7 +158,10 @@ describe('useHistoryActions', () => {
     const success = await actions.deleteSelected();
 
     expect(success).toBe(true);
-    expect(serviceMocks.deleteResults).toHaveBeenCalledWith('/api', { ids: [1, 2] });
+    expect(serviceMocks.deleteResults).toHaveBeenCalledWith(
+      { ids: [1, 2] },
+      expect.objectContaining({ resolve: expect.any(Function) }),
+    );
     expect(data.value.map((item) => item.id)).toEqual([3]);
     expect(clearSelection).toHaveBeenCalled();
     expect(showToast).toHaveBeenCalledWith('2 images deleted successfully');

--- a/tests/vue/useJobQueue.spec.ts
+++ b/tests/vue/useJobQueue.spec.ts
@@ -10,11 +10,15 @@ const serviceMocks = vi.hoisted(() => ({
   cancelGenerationJob: vi.fn(),
 }));
 
-vi.mock('@/services', () => ({
-  fetchActiveGenerationJobs: serviceMocks.fetchActiveGenerationJobs,
-  cancelGenerationJob: serviceMocks.cancelGenerationJob,
-  buildAdapterListQuery: vi.fn(),
-}));
+vi.mock('@/services', async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    fetchActiveGenerationJobs: serviceMocks.fetchActiveGenerationJobs,
+    cancelGenerationJob: serviceMocks.cancelGenerationJob,
+    buildAdapterListQuery: vi.fn(),
+  };
+});
 
 vi.mock('@/services/generation/generationService', () => ({
   fetchActiveGenerationJobs: serviceMocks.fetchActiveGenerationJobs,

--- a/tests/vue/useJobQueueActions.spec.ts
+++ b/tests/vue/useJobQueueActions.spec.ts
@@ -10,11 +10,15 @@ const serviceMocks = vi.hoisted(() => ({
   fetchActiveGenerationJobs: vi.fn(),
 }));
 
-vi.mock('@/services', () => ({
-  cancelGenerationJob: serviceMocks.cancelGenerationJob,
-  fetchActiveGenerationJobs: serviceMocks.fetchActiveGenerationJobs,
-  buildAdapterListQuery: vi.fn(),
-}));
+vi.mock('@/services', async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    cancelGenerationJob: serviceMocks.cancelGenerationJob,
+    fetchActiveGenerationJobs: serviceMocks.fetchActiveGenerationJobs,
+    buildAdapterListQuery: vi.fn(),
+  };
+});
 
 vi.mock('@/services/generation/generationService', () => ({
   cancelGenerationJob: serviceMocks.cancelGenerationJob,

--- a/tests/vue/useJobQueueTransport.spec.ts
+++ b/tests/vue/useJobQueueTransport.spec.ts
@@ -7,10 +7,14 @@ const serviceMocks = vi.hoisted(() => ({
   fetchActiveGenerationJobs: vi.fn(),
 }));
 
-vi.mock('@/services', () => ({
-  fetchActiveGenerationJobs: serviceMocks.fetchActiveGenerationJobs,
-  cancelGenerationJob: vi.fn(),
-}));
+vi.mock('@/services', async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    fetchActiveGenerationJobs: serviceMocks.fetchActiveGenerationJobs,
+    cancelGenerationJob: vi.fn(),
+  };
+});
 
 const createTransport = () => {
   const scope = effectScope();


### PR DESCRIPTION
## Summary
- add a backend-aware client helper that centralises URL resolution and HTTP methods
- refactor generation, lora, analytics, history, and system services plus dependent stores to use the shared client
- update unit tests and component consumers to reflect the new helper and URL resolution behaviour

## Testing
- npm run test:unit

------
https://chatgpt.com/codex/tasks/task_e_68dacbb1e6f48329806738aafe4d8974