### PR TITLE
Fix ResizeObserver typing in gallery grid

### DIFF
--- a/app/frontend/src/components/lora-gallery/LoraGalleryGrid.vue
+++ b/app/frontend/src/components/lora-gallery/LoraGalleryGrid.vue
@@ -196,12 +196,13 @@ onMounted(() => {
     }
   });
 
-  resizeObserver.observe(element);
+  resizeObserver.observe(element as unknown as Element);
 });
 
 onBeforeUnmount(() => {
-  if (resizeObserver && containerRef.value) {
-    resizeObserver.unobserve(containerRef.value);
+  const element = containerRef.value;
+  if (resizeObserver && element) {
+    resizeObserver.unobserve(element as unknown as Element);
   }
   resizeObserver?.disconnect();
   resizeObserver = null;


### PR DESCRIPTION
## Summary
- ensure the gallery grid's ResizeObserver operates on DOM elements with compatible typings
- guard unobserve logic against null refs while maintaining the virtualization update flow

## Testing
- npm run type-check

------
https://chatgpt.com/codex/tasks/task_e_68dae887f4848329854c176a21ebace1