### PR TITLE
Refactor backend URL helper utilities

### DIFF
--- a/app/frontend/src/config/runtime.ts
+++ b/app/frontend/src/config/runtime.ts
@@ -1,4 +1,4 @@
-const DEFAULT_BACKEND_BASE = '/api/v1';
+import { DEFAULT_BACKEND_BASE, sanitizeBackendBaseUrl } from '@/utils/backend';
 
 interface WindowRuntimeSettings {
   backendUrl?: string | null;
@@ -10,20 +10,6 @@ interface AugmentedWindow extends Window {
   BACKEND_API_KEY?: string | null;
   __APP_SETTINGS__?: WindowRuntimeSettings | null;
 }
-
-const sanitizeBasePath = (value?: string | null): string => {
-  if (!value) {
-    return DEFAULT_BACKEND_BASE;
-  }
-
-  const trimmed = value.trim();
-  if (!trimmed) {
-    return DEFAULT_BACKEND_BASE;
-  }
-
-  const withoutTrailing = trimmed.replace(/\/+$/, '');
-  return withoutTrailing || DEFAULT_BACKEND_BASE;
-};
 
 const normalizeApiKey = (value?: string | null): string | null => {
   if (value == null) {
@@ -85,7 +71,7 @@ const envBackendApiKey =
   ?? readEnvString(import.meta.env.VITE_API_KEY);
 const windowSettings = readWindowSettings();
 
-const backendBasePath = sanitizeBasePath(
+const backendBasePath = sanitizeBackendBaseUrl(
   envBackendBase ?? windowSettings.backendUrl ?? undefined,
 );
 

--- a/app/frontend/src/services/generation/generationService.ts
+++ b/app/frontend/src/services/generation/generationService.ts
@@ -16,7 +16,7 @@ import {
   type ApiRequestInit,
   type BackendClient,
 } from '@/services/backendClient';
-import { trimLeadingSlash } from '@/utils/backend';
+import { resolveGenerationRoute as buildGenerationRoute } from '@/utils/backend';
 
 export type GenerationParamOverrides =
   & Pick<SDNextGenerationParams, 'prompt'>
@@ -28,10 +28,7 @@ export type GenerationRequestBody = SDNextGenerationParams & {
 
 type GenerationClientInput = BackendClient | string | null | undefined;
 
-const generationPath = (path = ''): string => {
-  const trimmed = trimLeadingSlash(path);
-  return `/generation${trimmed ? `/${trimmed}` : ''}`;
-};
+const generationPath = (path = ''): string => buildGenerationRoute(path);
 
 const resolveClient = (input?: GenerationClientInput): BackendClient => {
   if (typeof input === 'string') {

--- a/app/frontend/src/stores/settings.ts
+++ b/app/frontend/src/stores/settings.ts
@@ -1,38 +1,10 @@
 import { defineStore } from 'pinia';
 
-import { DEFAULT_BACKEND_BASE, runtimeConfig } from '@/config/runtime';
+import { runtimeConfig } from '@/config/runtime';
 import { loadFrontendSettings } from '@/services';
 import type { FrontendRuntimeSettings, SettingsState } from '@/types';
 
-export const trimTrailingSlash = (value: string): string => value.replace(/\/+$/, '');
-
-export const trimLeadingSlash = (value: string): string => value.replace(/^\/+/, '');
-
-export const normaliseBackendBase = (base: string): string => {
-  if (/^https?:\/\//i.test(base)) {
-    return trimTrailingSlash(base);
-  }
-
-  const withoutTrailing = trimTrailingSlash(base);
-  if (!withoutTrailing) {
-    return DEFAULT_BACKEND_BASE;
-  }
-
-  return withoutTrailing.startsWith('/') ? withoutTrailing : `/${withoutTrailing}`;
-};
-
-export const sanitizeBackendBaseUrl = (value?: string | null): string => {
-  if (typeof value !== 'string') {
-    return DEFAULT_BACKEND_BASE;
-  }
-
-  const trimmed = value.trim();
-  if (!trimmed) {
-    return DEFAULT_BACKEND_BASE;
-  }
-
-  return normaliseBackendBase(trimmed);
-};
+import { sanitizeBackendBaseUrl } from '@/utils/backend/helpers';
 
 export const normaliseBackendApiKey = (value?: string | null): string | null => {
   if (value == null) {

--- a/app/frontend/src/utils/backend/helpers.ts
+++ b/app/frontend/src/utils/backend/helpers.ts
@@ -1,0 +1,64 @@
+export const DEFAULT_BACKEND_BASE = '/api/v1';
+
+export const trimTrailingSlash = (value: string): string => value.replace(/\/+$/, '');
+
+export const trimLeadingSlash = (value: string): string => value.replace(/^\/+/, '');
+
+export const normaliseBackendBase = (base: string): string => {
+  if (/^https?:\/\//i.test(base)) {
+    return trimTrailingSlash(base);
+  }
+
+  const withoutTrailing = trimTrailingSlash(base);
+  if (!withoutTrailing) {
+    return DEFAULT_BACKEND_BASE;
+  }
+
+  return withoutTrailing.startsWith('/') ? withoutTrailing : `/${withoutTrailing}`;
+};
+
+export const sanitizeBackendBaseUrl = (value?: string | null): string => {
+  if (typeof value !== 'string') {
+    return DEFAULT_BACKEND_BASE;
+  }
+
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return DEFAULT_BACKEND_BASE;
+  }
+
+  return normaliseBackendBase(trimmed);
+};
+
+const splitPathSuffix = (input: string): { pathname: string; suffix: string } => {
+  const match = input.match(/^([^?#]*)(.*)$/);
+  if (!match) {
+    return { pathname: input, suffix: '' };
+  }
+  return { pathname: match[1] ?? '', suffix: match[2] ?? '' };
+};
+
+export const joinBackendPath = (base: string, path: string): string => {
+  const { pathname, suffix } = splitPathSuffix(path);
+  const normalisedBase = trimTrailingSlash(base);
+  const normalisedPathname = trimLeadingSlash(pathname);
+
+  if (!normalisedPathname) {
+    return normalisedBase || DEFAULT_BACKEND_BASE;
+  }
+
+  if (!normalisedBase) {
+    return `/${normalisedPathname}${suffix}`;
+  }
+
+  const combined = /^https?:\/\//i.test(normalisedBase)
+    ? `${normalisedBase}/${normalisedPathname}`
+    : `${normalisedBase}/${normalisedPathname}`.replace(/^\/+/, '/');
+
+  return `${combined}${suffix}`;
+};
+
+export const resolveGenerationRoute = (path = ''): string => {
+  const trimmed = trimLeadingSlash(path);
+  return `/generation${trimmed ? `/${trimmed}` : ''}`;
+};


### PR DESCRIPTION
## Summary
- centralize backend URL trimming, sanitizing, and route helpers in `utils/backend`
- update runtime config, settings store, and generation service to consume the shared helpers
- expose new helper module while keeping existing backend utility APIs intact

## Testing
- `npm run test:unit` *(fails: Vitest cannot resolve @/config/backendSettings, existing setup issue)*

------
https://chatgpt.com/codex/tasks/task_e_68daec7af53c83298e3a9504ced23126