### PR TITLE
Refactor system status controller lifecycle management

### DIFF
--- a/app/frontend/src/composables/system/useSystemStatus.ts
+++ b/app/frontend/src/composables/system/useSystemStatus.ts
@@ -1,7 +1,10 @@
-import { computed } from 'vue';
+import { computed, onScopeDispose } from 'vue';
 import { storeToRefs } from 'pinia';
 
-import { useGenerationConnectionStore, useSystemStatusController } from '@/stores/generation';
+import {
+  acquireSystemStatusController,
+  useGenerationConnectionStore,
+} from '@/stores/generation';
 
 const formatMemory = (used: number, total: number) => {
   if (!total) {
@@ -74,7 +77,11 @@ export const useSystemStatus = () => {
     systemStatusLastUpdated: lastUpdate,
   } = storeToRefs(connectionStore);
 
-  const controller = useSystemStatusController();
+  const { controller, release } = acquireSystemStatusController();
+
+  onScopeDispose(() => {
+    release();
+  });
 
   void controller.ensureHydrated();
 


### PR DESCRIPTION
## Summary
- replace the system status singleton with a shared, reference-counted controller that starts polling on first acquire and stops when released
- expose acquire/release handles and update system status and generation queue composables to join the lifecycle and dispose their handles with Vue scope cleanup

## Testing
- npm run lint *(fails: existing lint restrictions in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68daec80c3d0832996c2c0c64b5bcd15