### PR TITLE
Use shared persistence in generation composable

### DIFF
--- a/tests/vue/GenerationStudio.spec.js
+++ b/tests/vue/GenerationStudio.spec.js
@@ -13,6 +13,7 @@ import {
   useGenerationQueueStore,
   useGenerationResultsStore,
 } from '../../app/frontend/src/stores/generation'
+import { PERSISTENCE_KEYS } from '../../app/frontend/src/constants/persistence'
 
 const orchestratorMocks = vi.hoisted(() => ({
   initialize: vi.fn(),
@@ -290,7 +291,7 @@ describe('GenerationStudio.vue', () => {
     await nextTick()
 
     expect(localStorageMock.setItem).toHaveBeenCalledWith(
-      'generation_params',
+      PERSISTENCE_KEYS.generationParams,
       expect.stringContaining('test prompt for saving')
     )
 

--- a/tests/vue/composables/useGenerationStudio.integration.spec.ts
+++ b/tests/vue/composables/useGenerationStudio.integration.spec.ts
@@ -6,6 +6,7 @@ import { createPinia, setActivePinia } from 'pinia'
 import { useGenerationStudio } from '@/composables/generation/useGenerationStudio'
 import { useGenerationFormStore } from '@/stores/generation'
 import type { UseGenerationStudioReturn } from '@/composables/generation'
+import { PERSISTENCE_KEYS } from '@/constants/persistence'
 
 const orchestratorBindingMocks = vi.hoisted(() => {
   const { ref } = require('vue')
@@ -131,7 +132,7 @@ describe('useGenerationStudio integration', () => {
     const payload = orchestratorBindingMocks.startGeneration.mock.calls[0][0]
     expect(payload.prompt).toBe('integration test prompt')
     expect(localStorageMock.setItem).toHaveBeenCalledWith(
-      'generation_params',
+      PERSISTENCE_KEYS.generationParams,
       expect.stringContaining('"integration test prompt"'),
     )
     expect(formStore.isGenerating).toBe(false)


### PR DESCRIPTION
## Summary
- refactor `useGenerationPersistence` to use the shared persistence helper and guard browser APIs
- update generation studio tests to reference the shared persistence keys

## Testing
- npx vitest run tests/vue/composables/useGenerationStudio.integration.spec.ts tests/vue/GenerationStudio.spec.js *(fails: missing @/config/backendSettings module in test setup)*

------
https://chatgpt.com/codex/tasks/task_e_68daec81f31c8329bf3dfda65907c474