### PR TITLE
Fix dashboard panel key placement

### DIFF
--- a/app/frontend/src/views/DashboardView.vue
+++ b/app/frontend/src/views/DashboardView.vue
@@ -34,7 +34,6 @@
     <section class="grid gap-6 xl:grid-cols-2">
       <template v-for="panel in panels" :key="panel.key">
         <DashboardLazyModuleCard
-          :key="panel.key"
           :title="panel.title"
           :description="panel.description"
           :route="panel.route"


### PR DESCRIPTION
## Summary
- remove the redundant key binding from the dashboard lazy module card so the Vue compiler no longer flags the template loop

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68daf1eb76648329902e4331e3626205