### PR TITLE
Refactor import/export workflows to use backend client

### DIFF
--- a/app/frontend/src/composables/import-export/useBackupWorkflow.ts
+++ b/app/frontend/src/composables/import-export/useBackupWorkflow.ts
@@ -1,11 +1,13 @@
 import { ref, type Ref } from 'vue';
 
-import { ensureData, getJson, postJson } from '@/services/apiClient';
+import { ensureData } from '@/services/apiClient';
+import { useBackendClient, type BackendClient } from '@/services';
 import type { BackupCreateRequest, BackupHistoryItem } from '@/types';
 import type { NotifyFn } from './useExportWorkflow';
 
 interface UseBackupWorkflowOptions {
   notify: NotifyFn;
+  backendClient?: BackendClient | null;
 }
 
 export interface UseBackupWorkflow {
@@ -21,11 +23,12 @@ export interface UseBackupWorkflow {
 
 export function useBackupWorkflow(options: UseBackupWorkflowOptions): UseBackupWorkflow {
   const { notify } = options;
+  const backendClient = options.backendClient ?? useBackendClient();
   const history = ref<BackupHistoryItem[]>([]);
 
   const loadHistory = async () => {
     try {
-      const response = await getJson('/api/v1/backups/history');
+      const response = await backendClient.getJson('/api/v1/backups/history');
       const data = response?.data;
 
       if (Array.isArray(data)) {
@@ -51,7 +54,7 @@ export function useBackupWorkflow(options: UseBackupWorkflowOptions): UseBackupW
     try {
       const result =
         ensureData(
-          await postJson<{ backup_id?: string }, BackupCreateRequest>(
+          await backendClient.postJson<{ backup_id?: string }, BackupCreateRequest>(
             '/api/v1/backup/create',
             { backup_type: backupType },
           ),

--- a/app/frontend/src/composables/import-export/useImportWorkflow.ts
+++ b/app/frontend/src/composables/import-export/useImportWorkflow.ts
@@ -1,6 +1,7 @@
 import { computed, reactive, ref, type ComputedRef } from 'vue';
 
-import { ensureData, requestJson } from '@/services/apiClient';
+import { ensureData } from '@/services/apiClient';
+import { useBackendClient, type BackendClient } from '@/services';
 import type { ImportConfig } from '@/types';
 import type { NotifyFn, ProgressCallbacks } from './useExportWorkflow';
 
@@ -15,6 +16,7 @@ export interface ImportPreviewItem {
 interface UseImportWorkflowOptions {
   notify: NotifyFn;
   progress: ProgressCallbacks;
+  backendClient?: BackendClient | null;
 }
 
 export interface UseImportWorkflow {
@@ -35,6 +37,7 @@ export interface UseImportWorkflow {
 
 export function useImportWorkflow(options: UseImportWorkflowOptions): UseImportWorkflow {
   const { notify, progress } = options;
+  const backendClient = options.backendClient ?? useBackendClient();
 
   const importConfig = reactive<ImportConfig>({
     mode: 'merge',
@@ -160,7 +163,7 @@ export function useImportWorkflow(options: UseImportWorkflowOptions): UseImportW
       progress.update({ value: 30, step: 'Uploading files...', message: 'Sending files to server' });
 
       const result = ensureData(
-        await requestJson('/api/v1/import', {
+        await backendClient.requestJson('/api/v1/import', {
           method: 'POST',
           body: formData
         })

--- a/tests/vue/useBackupWorkflow.spec.ts
+++ b/tests/vue/useBackupWorkflow.spec.ts
@@ -1,24 +1,50 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 
 import { useBackupWorkflow } from '../../app/frontend/src/composables/import-export/useBackupWorkflow';
+import type { BackendClient } from '../../app/frontend/src/services/backendClient';
 
 const getJson = vi.fn();
 const postJson = vi.fn();
+
+const createBackendClientMock = (base = 'https://api.example'): BackendClient => {
+  const resolvePath = (path = ''): string => {
+    if (!path) {
+      return base.replace(/\/+$/, '');
+    }
+    if (/^https?:\/\//i.test(path)) {
+      return path;
+    }
+    const trimmedBase = base.replace(/\/+$/, '');
+    const trimmedPath = path.replace(/^\/+/, '');
+    return `${trimmedBase}/${trimmedPath}`;
+  };
+
+  return {
+    resolve: vi.fn((path?: string) => resolvePath(path ?? '')),
+    requestJson: vi.fn(),
+    getJson: vi.fn((path: string, init?: RequestInit) => getJson(resolvePath(path), init)),
+    postJson: vi.fn((path: string, body: unknown, init?: RequestInit) => postJson(resolvePath(path), body, init)),
+    putJson: vi.fn(),
+    patchJson: vi.fn(),
+    delete: vi.fn(),
+    requestBlob: vi.fn(),
+  } as unknown as BackendClient;
+};
 
 vi.mock('@/services/apiClient', async () => {
   const actual = await vi.importActual<typeof import('@/services/apiClient')>('@/services/apiClient');
   return {
     ...actual,
-    getJson: (...args: unknown[]) => getJson(...args),
-    postJson: (...args: unknown[]) => postJson(...args),
     ensureData: (value: unknown) => value
   };
 });
 
 describe('useBackupWorkflow', () => {
   const notify = vi.fn();
+  let backendClient: BackendClient;
 
   beforeEach(() => {
+    backendClient = createBackendClientMock('https://custom.example');
     getJson.mockReset();
     postJson.mockReset();
     notify.mockReset();
@@ -28,29 +54,29 @@ describe('useBackupWorkflow', () => {
   });
 
   it('loads backup history on initialize', async () => {
-    const workflow = useBackupWorkflow({ notify });
+    const workflow = useBackupWorkflow({ notify, backendClient });
     await workflow.initialize();
 
-    expect(getJson).toHaveBeenCalledWith('/api/v1/backups/history');
+    expect(getJson).toHaveBeenCalledWith('https://custom.example/api/v1/backups/history');
     expect(workflow.backupHistory.value).toHaveLength(1);
     expect(workflow.backupHistory.value[0].id).toBe('b1');
   });
 
   it('creates backups and refreshes history', async () => {
-    const workflow = useBackupWorkflow({ notify });
+    const workflow = useBackupWorkflow({ notify, backendClient });
     await workflow.initialize();
 
     await workflow.createFullBackup();
-    expect(postJson).toHaveBeenCalledWith('/api/v1/backup/create', { backup_type: 'full' });
+    expect(postJson).toHaveBeenCalledWith('https://custom.example/api/v1/backup/create', { backup_type: 'full' });
     expect(notify).toHaveBeenCalledWith('Full backup initiated: b2', 'success');
 
     await workflow.createQuickBackup();
-    expect(postJson).toHaveBeenCalledWith('/api/v1/backup/create', { backup_type: 'quick' });
+    expect(postJson).toHaveBeenCalledWith('https://custom.example/api/v1/backup/create', { backup_type: 'quick' });
     expect(notify).toHaveBeenCalledWith('Quick backup initiated: b2', 'success');
   });
 
   it('emits informational notifications for other actions', () => {
-    const workflow = useBackupWorkflow({ notify });
+    const workflow = useBackupWorkflow({ notify, backendClient });
 
     workflow.scheduleBackup();
     workflow.downloadBackup('b1');

--- a/tests/vue/useExportWorkflow.spec.ts
+++ b/tests/vue/useExportWorkflow.spec.ts
@@ -2,18 +2,42 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { nextTick } from 'vue';
 
 import { useExportWorkflow, type ProgressCallbacks } from '../../app/frontend/src/composables/import-export/useExportWorkflow';
+import type { BackendClient } from '../../app/frontend/src/services/backendClient';
 
 const postJson = vi.fn();
 const requestBlob = vi.fn();
 const getFilenameFromContentDisposition = vi.fn();
 const downloadFile = vi.fn();
 
+const createBackendClientMock = (base = 'https://api.example'): BackendClient => {
+  const resolvePath = (path = ''): string => {
+    if (!path) {
+      return base.replace(/\/+$/, '');
+    }
+    if (/^https?:\/\//i.test(path)) {
+      return path;
+    }
+    const trimmedBase = base.replace(/\/+$/, '');
+    const trimmedPath = path.replace(/^\/+/, '');
+    return `${trimmedBase}/${trimmedPath}`;
+  };
+
+  return {
+    resolve: vi.fn((path?: string) => resolvePath(path ?? '')),
+    requestJson: vi.fn(),
+    getJson: vi.fn(),
+    postJson: vi.fn((path: string, body: unknown, init?: unknown) => postJson(resolvePath(path), body, init)),
+    putJson: vi.fn(),
+    patchJson: vi.fn(),
+    delete: vi.fn(),
+    requestBlob: vi.fn((path: string, init?: RequestInit) => requestBlob(resolvePath(path), init)),
+  } as unknown as BackendClient;
+};
+
 vi.mock('@/services/apiClient', async () => {
   const actual = await vi.importActual<typeof import('@/services/apiClient')>('@/services/apiClient');
   return {
     ...actual,
-    postJson: (...args: unknown[]) => postJson(...args),
-    requestBlob: (...args: unknown[]) => requestBlob(...args),
     ensureData: (value: unknown) => value,
     getFilenameFromContentDisposition: (...args: unknown[]) => getFilenameFromContentDisposition(...args)
   };
@@ -29,9 +53,11 @@ vi.mock('@/utils/browser', async () => {
 
 describe('useExportWorkflow', () => {
   const notify = vi.fn();
+  let backendClient: BackendClient;
   let progress: ProgressCallbacks;
 
   beforeEach(() => {
+    backendClient = createBackendClientMock('https://custom.example');
     postJson.mockReset();
     requestBlob.mockReset();
     getFilenameFromContentDisposition.mockReset();
@@ -53,18 +79,18 @@ describe('useExportWorkflow', () => {
   });
 
   it('initializes and updates estimates', async () => {
-    const workflow = useExportWorkflow({ notify, progress });
+    const workflow = useExportWorkflow({ notify, progress, backendClient });
 
     await workflow.initialize();
     await nextTick();
 
-    expect(postJson).toHaveBeenCalledWith('/api/v1/export/estimate', expect.any(Object));
+    expect(postJson).toHaveBeenCalledWith('https://custom.example/api/v1/export/estimate', expect.any(Object));
     expect(workflow.estimatedSize.value).toBe('10 MB');
     expect(workflow.estimatedTime.value).toBe('5 minutes');
   });
 
   it('validates configuration and triggers notifications', () => {
-    const workflow = useExportWorkflow({ notify, progress });
+    const workflow = useExportWorkflow({ notify, progress, backendClient });
 
     workflow.updateConfig('loras', false);
     workflow.updateConfig('generations', false);
@@ -81,19 +107,22 @@ describe('useExportWorkflow', () => {
   });
 
   it('starts export and downloads file', async () => {
-    const workflow = useExportWorkflow({ notify, progress });
+    const workflow = useExportWorkflow({ notify, progress, backendClient });
 
     await workflow.startExport();
 
     expect(progress.begin).toHaveBeenCalled();
-    expect(requestBlob).toHaveBeenCalledWith('/api/v1/export', expect.objectContaining({ method: 'POST' }));
+    expect(requestBlob).toHaveBeenCalledWith(
+      'https://custom.example/api/v1/export',
+      expect.objectContaining({ method: 'POST' })
+    );
     expect(downloadFile).toHaveBeenCalledWith(expect.any(Blob), 'export.zip');
     expect(progress.end).toHaveBeenCalled();
     expect(notify).toHaveBeenCalledWith('Export completed successfully', 'success');
   });
 
   it('quick export enables primary datasets and triggers export', async () => {
-    const workflow = useExportWorkflow({ notify, progress });
+    const workflow = useExportWorkflow({ notify, progress, backendClient });
 
     requestBlob.mockClear();
     await workflow.quickExportAll();
@@ -107,7 +136,7 @@ describe('useExportWorkflow', () => {
   });
 
   it('cancels export by resetting state', () => {
-    const workflow = useExportWorkflow({ notify, progress });
+    const workflow = useExportWorkflow({ notify, progress, backendClient });
     workflow.cancelExport();
     expect(workflow.isExporting.value).toBe(false);
   });


### PR DESCRIPTION
## Summary
- update the export, import, and backup workflows to resolve requests through `useBackendClient` so the configured backend base URL is reused
- allow callers to inject a backend client override while keeping existing APIs intact
- refresh the associated unit tests to supply backend client mocks and assert that customized backend URLs are honored

## Testing
- npm run test:unit -- tests/vue/useExportWorkflow.spec.ts tests/vue/useImportWorkflow.spec.ts tests/vue/useBackupWorkflow.spec.ts *(fails: Vitest setup references '@/config/backendSettings', which is absent in the repository)*

------
https://chatgpt.com/codex/tasks/task_e_68db0390b57c8329a32aad50bfae4d0b