### PR TITLE
Fix recommendations API URL base handling

### DIFF
--- a/app/frontend/src/components/recommendations/RecommendationsPanel.vue
+++ b/app/frontend/src/components/recommendations/RecommendationsPanel.vue
@@ -119,6 +119,7 @@ import { storeToRefs } from 'pinia';
 import { useRecommendationApi } from '@/composables/shared';
 import { useAdapterCatalogStore } from '@/stores';
 import type { AdapterSummary, RecommendationItem, RecommendationResponse } from '@/types';
+import { useBackendUrl } from '@/utils/backend';
 
 const WEIGHT_KEYS = ['semantic', 'artistic', 'technical'] as const;
 type WeightKey = (typeof WEIGHT_KEYS)[number];
@@ -168,11 +169,11 @@ const recsError = ref<string>('');
 const fmtScore = (value: number | null | undefined): string =>
   value == null ? '-' : Number(value).toFixed(3);
 
-const recommendationUrl = computed<string>(() => {
+const recommendationPath = computed<string>(() => {
   if (!selectedLoraId.value) {
     return '';
   }
-  const base = `/api/v1/recommendations/similar/${encodeURIComponent(selectedLoraId.value)}`;
+  const base = `recommendations/similar/${encodeURIComponent(selectedLoraId.value)}`;
   const params = new URLSearchParams();
   params.set('limit', String(limit.value));
   params.set('similarity_threshold', String(similarityThreshold.value));
@@ -182,12 +183,14 @@ const recommendationUrl = computed<string>(() => {
   return `${base}?${params.toString()}`;
 });
 
+const recommendationUrl = useBackendUrl(recommendationPath);
+
 const {
   data: recsData,
   error: recsErrObj,
   isLoading: recsLoading,
   fetchData: loadRecs,
-} = useRecommendationApi(() => recommendationUrl.value);
+} = useRecommendationApi(recommendationPath);
 
 const isLoadingLoras = computed<boolean>(() => lorasLoading.value);
 const isLoadingRecs = computed<boolean>(() => recsLoading.value);

--- a/tests/vue/RecommendationsPanel.spec.js
+++ b/tests/vue/RecommendationsPanel.spec.js
@@ -1,9 +1,27 @@
 import { mount } from '@vue/test-utils';
 import { nextTick } from 'vue';
 
+vi.mock('../../app/frontend/src/config/runtime.ts', () => {
+  const config = {
+    mode: 'test',
+    isDev: false,
+    isProd: false,
+    isTest: true,
+    backendBasePath: '/api/v1',
+    backendApiKey: null,
+  };
+
+  return {
+    runtimeConfig: config,
+    DEFAULT_BACKEND_BASE: '/api/v1',
+    default: config,
+  };
+});
+
 import RecommendationsPanel from '../../app/frontend/src/components/recommendations/RecommendationsPanel.vue';
 import { useAppStore } from '../../app/frontend/src/stores/app';
 import { useAdapterCatalogStore } from '../../app/frontend/src/stores/adapterCatalog';
+import { useSettingsStore } from '../../app/frontend/src/stores/settings';
 
 const flush = async () => {
   await Promise.resolve();
@@ -16,6 +34,7 @@ describe('RecommendationsPanel.vue', () => {
   beforeEach(() => {
     useAppStore().$reset();
     useAdapterCatalogStore().reset();
+    useSettingsStore().reset();
     const jsonResponse = (payload) => ({
       ok: true,
       status: 200,
@@ -24,15 +43,16 @@ describe('RecommendationsPanel.vue', () => {
       text: async () => JSON.stringify(payload),
     });
     // Simple fetch stub that returns different payloads per URL
+    const extractUrl = (input) => (typeof input === 'string' ? input : input?.url || '');
     global.fetch = vi.fn(async (input) => {
-      const url = typeof input === 'string' ? input : input.url || '';
-      if (url.includes('/api/v1/adapters')) {
+      const url = extractUrl(input);
+      if (url.includes('/adapters')) {
         return jsonResponse({ items: [
           { id: '1', name: 'Lora One', description: 'First' },
           { id: '2', name: 'Lora Two', description: 'Second' },
         ] });
       }
-      if (url.includes('/api/v1/recommendations/similar/')) {
+      if (url.includes('/recommendations/similar/')) {
         return jsonResponse({ recommendations: [
           { lora_id: '2', lora_name: 'Rec Two', lora_description: 'Nice', similarity_score: 0.91, final_score: 0.88 },
         ] });
@@ -59,5 +79,27 @@ describe('RecommendationsPanel.vue', () => {
     // Rendered recommendation
     expect(wrapper.text()).toContain('Rec Two');
     expect(wrapper.text()).toContain('0.910'); // similarity score formatted
+
+    const calledUrls = global.fetch.mock.calls
+      .map(([request]) => (typeof request === 'string' ? request : request?.url || ''));
+    expect(calledUrls.some((url) => url.includes('/api/v1/recommendations/similar/1'))).toBe(true);
+  });
+
+  it('respects backend URL overrides when fetching recommendations', async () => {
+    const settingsStore = useSettingsStore();
+    settingsStore.setSettings({ backendUrl: 'https://override.test/api/custom' });
+
+    const wrapper = mount(RecommendationsPanel);
+
+    await flush();
+
+    const select = wrapper.find('select');
+    await select.setValue('1');
+    await flush();
+
+    const calledUrls = global.fetch.mock.calls
+      .map(([request]) => (typeof request === 'string' ? request : request?.url || ''));
+    const recommendationCall = calledUrls.find((url) => url.includes('/recommendations/similar/1'));
+    expect(recommendationCall).toContain('https://override.test/api/custom/recommendations/similar/1');
   });
 });


### PR DESCRIPTION
## Summary
- compute recommendation requests using the configured backend base instead of hard-coded paths
- update the recommendation API composable to resolve backend-relative paths before requesting
- expand RecommendationsPanel tests to cover default and overridden backend URLs

## Testing
- npm run test -- tests/vue/RecommendationsPanel.spec.js

------
https://chatgpt.com/codex/tasks/task_e_68db085d2df083299f354dae94cd8780