### PR TITLE
Refactor generation orchestrator factory into composables

### DIFF
--- a/app/frontend/src/composables/generation/createGenerationOrchestrator.ts
+++ b/app/frontend/src/composables/generation/createGenerationOrchestrator.ts
@@ -4,17 +4,17 @@ import { storeToRefs } from 'pinia';
 import {
   useGenerationTransport,
   type GenerationNotificationAdapter,
-} from '@/composables/generation';
+} from './useGenerationTransport';
+import type {
+  GenerationQueueClient,
+  GenerationWebSocketManager,
+} from '@/services/generation/updates';
 import { DEFAULT_HISTORY_LIMIT } from '@/stores/generation';
 import type {
   GenerationConnectionStore,
   GenerationQueueStore,
   GenerationResultsStore,
 } from '@/stores/generation';
-import type {
-  GenerationQueueClient,
-  GenerationWebSocketManager,
-} from './updates';
 import type {
   GenerationJob,
   GenerationRequestPayload,
@@ -46,7 +46,7 @@ export interface GenerationOrchestrator {
   deleteResult: (resultId: string | number) => Promise<void>;
 }
 
-export const createGenerationOrchestrator = ({
+export const createGenerationOrchestratorFactory = ({
   showHistory,
   configuredBackendUrl,
   notificationAdapter,
@@ -226,3 +226,7 @@ export const createGenerationOrchestrator = ({
     deleteResult,
   };
 };
+
+export type CreateGenerationOrchestratorFactoryReturn = ReturnType<
+  typeof createGenerationOrchestratorFactory
+>;

--- a/app/frontend/src/composables/generation/index.ts
+++ b/app/frontend/src/composables/generation/index.ts
@@ -1,5 +1,6 @@
 export * from './useGenerationStudio';
 export * from './useGenerationStudioController';
+export * from './createGenerationOrchestrator';
 export * from './useGenerationTransport';
 export * from './useGenerationUI';
 export * from './useGenerationUpdates';

--- a/app/frontend/src/composables/generation/useGenerationOrchestrator.ts
+++ b/app/frontend/src/composables/generation/useGenerationOrchestrator.ts
@@ -1,4 +1,7 @@
-import type { GenerationQueueClient, GenerationWebSocketManager } from '@/services'
+import type {
+  GenerationQueueClient,
+  GenerationWebSocketManager,
+} from '@/services/generation/updates'
 
 import type { GenerationNotificationAdapter } from './useGenerationTransport'
 import {

--- a/app/frontend/src/composables/generation/useGenerationOrchestratorManager.ts
+++ b/app/frontend/src/composables/generation/useGenerationOrchestratorManager.ts
@@ -1,12 +1,15 @@
 import { effectScope, type EffectScope, type Ref } from 'vue'
 import { storeToRefs } from 'pinia'
 
+import {
+  createGenerationOrchestratorFactory,
+  type GenerationOrchestrator,
+} from './createGenerationOrchestrator'
 import type { GenerationNotificationAdapter } from './useGenerationTransport'
-import { createGenerationOrchestrator } from '@/services'
 import type {
   GenerationQueueClient,
   GenerationWebSocketManager,
-} from '@/services'
+} from '@/services/generation/updates'
 import {
   useGenerationConnectionStore,
   useGenerationFormStore,
@@ -21,7 +24,6 @@ import type {
   GenerationStartResponse,
   SystemStatusState,
 } from '@/types'
-import type { GenerationOrchestrator } from '@/services'
 
 export interface GenerationOrchestratorAcquireOptions {
   notify: GenerationNotificationAdapter['notify']
@@ -80,7 +82,7 @@ const ensureOrchestrator = (
     orchestratorState.scope = effectScope(true)
 
     const createdOrchestrator = orchestratorState.scope.run(() =>
-      createGenerationOrchestrator({
+      createGenerationOrchestratorFactory({
         showHistory: context.showHistory,
         configuredBackendUrl: context.configuredBackendUrl,
         notificationAdapter: {

--- a/app/frontend/src/composables/generation/useGenerationQueueClient.ts
+++ b/app/frontend/src/composables/generation/useGenerationQueueClient.ts
@@ -4,7 +4,7 @@ import {
   createGenerationQueueClient,
   DEFAULT_POLL_INTERVAL,
   type GenerationQueueClient,
-} from '@/services';
+} from '@/services/generation/updates';
 import type {
   GenerationRequestPayload,
   GenerationResult,

--- a/app/frontend/src/composables/generation/useGenerationSocketBridge.ts
+++ b/app/frontend/src/composables/generation/useGenerationSocketBridge.ts
@@ -3,7 +3,7 @@ import { shallowRef } from 'vue';
 import {
   createGenerationWebSocketManager,
   type GenerationWebSocketManager,
-} from '@/services';
+} from '@/services/generation/updates';
 import type {
   GenerationCompleteMessage,
   GenerationErrorMessage,

--- a/app/frontend/src/composables/generation/useGenerationStudioController.ts
+++ b/app/frontend/src/composables/generation/useGenerationStudioController.ts
@@ -1,6 +1,6 @@
 import { onMounted, onUnmounted, shallowRef, type Ref } from 'vue'
 
-import { toGenerationRequestPayload } from '@/services'
+import { toGenerationRequestPayload } from '@/services/generation/generationService'
 import {
   useGenerationOrchestratorManager,
   type GenerationOrchestratorBinding,

--- a/app/frontend/src/composables/generation/useGenerationTransport.ts
+++ b/app/frontend/src/composables/generation/useGenerationTransport.ts
@@ -2,7 +2,7 @@ import {
   extractGenerationErrorMessage,
   type GenerationQueueClient,
   type GenerationWebSocketManager,
-} from '@/services';
+} from '@/services/generation/updates';
 import type {
   GenerationCompleteMessage,
   GenerationErrorMessage,

--- a/app/frontend/src/composables/generation/useGenerationUpdates.ts
+++ b/app/frontend/src/composables/generation/useGenerationUpdates.ts
@@ -8,7 +8,7 @@ import {
 import type {
   GenerationQueueClient,
   GenerationWebSocketManager,
-} from '@/services';
+} from '@/services/generation/updates';
 import type {
   GenerationJob,
   GenerationRequestPayload,

--- a/app/frontend/src/composables/generation/useJobQueueActions.ts
+++ b/app/frontend/src/composables/generation/useJobQueueActions.ts
@@ -1,7 +1,7 @@
 import { ref, unref, type MaybeRefOrGetter } from 'vue';
 import { storeToRefs } from 'pinia';
 
-import { cancelGenerationJob } from '@/services';
+import { cancelGenerationJob } from '@/services/generation/generationService';
 import { useGenerationQueueStore } from '@/stores/generation';
 import { useNotifications } from '@/composables/shared';
 import { useBackendBase } from '@/utils/backend';

--- a/app/frontend/src/composables/generation/useJobQueueTransport.ts
+++ b/app/frontend/src/composables/generation/useJobQueueTransport.ts
@@ -1,6 +1,6 @@
 import { ref, unref, type MaybeRefOrGetter, type Ref } from 'vue';
 
-import { fetchActiveGenerationJobs } from '@/services';
+import { fetchActiveGenerationJobs } from '@/services/generation/generationService';
 import { DEFAULT_BACKEND_BASE } from '@/utils/backend';
 import type { GenerationJobStatus } from '@/types';
 

--- a/app/frontend/src/composables/import-export/useBackupWorkflow.ts
+++ b/app/frontend/src/composables/import-export/useBackupWorkflow.ts
@@ -28,8 +28,10 @@ export function useBackupWorkflow(options: UseBackupWorkflowOptions): UseBackupW
 
   const loadHistory = async () => {
     try {
-      const response = await backendClient.getJson('/api/v1/backups/history');
-      const data = response?.data;
+      const data =
+        (await backendClient.getJson<BackupHistoryItem[] | { history?: BackupHistoryItem[] }>(
+          '/api/v1/backups/history',
+        )) ?? null;
 
       if (Array.isArray(data)) {
         history.value = data as BackupHistoryItem[];

--- a/app/frontend/src/services/generation/index.ts
+++ b/app/frontend/src/services/generation/index.ts
@@ -1,3 +1,2 @@
-export * from './orchestrator';
 export * from './updates';
 export * from './generationService';


### PR DESCRIPTION
## Summary
- move the generation orchestrator factory into the composables folder as createGenerationOrchestratorFactory
- update generation composables to depend directly on transport helpers and service modules instead of the services barrel
- tighten backup workflow history loading types to satisfy the stricter import graph

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68db0a2584dc8329896caf5006788729