### PR TITLE
Refactor backend URL utilities to use resolved settings

### DIFF
--- a/app/frontend/src/composables/import-export/useBackupWorkflow.ts
+++ b/app/frontend/src/composables/import-export/useBackupWorkflow.ts
@@ -28,15 +28,17 @@ export function useBackupWorkflow(options: UseBackupWorkflowOptions): UseBackupW
 
   const loadHistory = async () => {
     try {
-      const response = await backendClient.getJson('/api/v1/backups/history');
-      const data = response?.data;
+      const response = await backendClient.getJson<
+        BackupHistoryItem[] | { history?: BackupHistoryItem[] | null } | null
+      >('/api/v1/backups/history');
+      const data = response ?? null;
 
       if (Array.isArray(data)) {
         history.value = data as BackupHistoryItem[];
       } else if (
         data &&
         typeof data === 'object' &&
-        Array.isArray((data as { history?: BackupHistoryItem[] }).history)
+        Array.isArray((data as { history?: BackupHistoryItem[] | null }).history)
       ) {
         history.value = (data as { history: BackupHistoryItem[] }).history;
       } else {

--- a/app/frontend/src/config/runtime.ts
+++ b/app/frontend/src/config/runtime.ts
@@ -1,4 +1,4 @@
-import { DEFAULT_BACKEND_BASE, sanitizeBackendBaseUrl } from '@/utils/backend';
+import { DEFAULT_BACKEND_BASE, sanitizeBackendBaseUrl } from '@/utils/backend/helpers';
 
 interface WindowRuntimeSettings {
   backendUrl?: string | null;

--- a/app/frontend/src/stores/settings.ts
+++ b/app/frontend/src/stores/settings.ts
@@ -1,7 +1,6 @@
 import { defineStore } from 'pinia';
 
 import { runtimeConfig } from '@/config/runtime';
-import { loadFrontendSettings } from '@/services';
 import type { FrontendRuntimeSettings, SettingsState } from '@/types';
 
 import { sanitizeBackendBaseUrl } from '@/utils/backend/helpers';
@@ -107,6 +106,7 @@ export const useSettingsStore = defineStore('app-settings', {
       this.error = null;
 
       try {
+        const { loadFrontendSettings } = await import('@/services/system/systemService');
         const payload = await loadFrontendSettings();
         if (!payload) {
           throw new Error('Received empty settings response');

--- a/tests/mocks/api-mocks.js
+++ b/tests/mocks/api-mocks.js
@@ -203,7 +203,7 @@ const apiMocks = {
     'POST /api/loras/upload': (url, options) => {
         // Check if proper form data was sent
         const hasFormData = options.body instanceof FormData;
-        
+
         if (!hasFormData) {
             throw new Error('File is required');
         }
@@ -242,6 +242,41 @@ const apiMocks = {
         }
 
         return { success: true };
+    },
+
+    'POST /api/generation/generate': () => ({
+        job_id: 'job-1',
+        status: 'queued',
+        images: [],
+        progress: 0,
+        generation_info: null,
+    }),
+
+    'POST /api/generation/jobs/:id/cancel': (url) => {
+        const id = url.split('/').slice(-2)[0];
+        return {
+            success: true,
+            status: 'cancelled',
+            message: `Cancelled ${id}`,
+        };
+    },
+
+    'POST /custom/api/generation/jobs/:id/cancel': (url) => {
+        const id = url.split('/').slice(-2)[0];
+        return {
+            success: true,
+            status: 'cancelled',
+            message: `Cancelled ${id}`,
+        };
+    },
+
+    'DELETE /api/generation/results/:id': () => ({ success: true }),
+
+    'DELETE /prefixed/api/generation/results/:id': () => ({ success: true }),
+
+    'GET /api/generation/results/:id/download': (url) => {
+        const id = url.split('/').slice(-2)[0];
+        return new Blob([`result-${id}`], { type: 'image/png' });
     },
     
     // Recommendations

--- a/tests/vue/useJobQueue.spec.ts
+++ b/tests/vue/useJobQueue.spec.ts
@@ -61,11 +61,15 @@ vi.mock('@/composables/shared', async () => {
   };
 });
 
-vi.mock('@/utils/backend', () => ({
-  DEFAULT_BACKEND_BASE: '/api/v1',
-  useBackendBase: () => computed(() => '/api/v1'),
-  resolveBackendUrl: (path: string) => `/api/v1${path}`,
-}));
+vi.mock('@/utils/backend', async () => {
+  const actual = await vi.importActual<typeof import('@/utils/backend')>('@/utils/backend');
+  return {
+    ...actual,
+    DEFAULT_BACKEND_BASE: '/api/v1',
+    useBackendBase: () => computed(() => '/api/v1'),
+    resolveBackendUrl: (path: string) => `/api/v1${path}`,
+  };
+});
 
 const withQueue = async (
   run: (queue: ReturnType<typeof useJobQueue>) => Promise<void>,

--- a/tests/vue/useJobQueueActions.spec.ts
+++ b/tests/vue/useJobQueueActions.spec.ts
@@ -61,11 +61,15 @@ vi.mock('@/composables/shared', async () => {
   };
 });
 
-vi.mock('@/utils/backend', () => ({
-  DEFAULT_BACKEND_BASE: '/api/v1',
-  useBackendBase: () => computed(() => '/api/v1'),
-  resolveBackendUrl: (path: string) => `/api/v1${path}`,
-}));
+vi.mock('@/utils/backend', async () => {
+  const actual = await vi.importActual<typeof import('@/utils/backend')>('@/utils/backend');
+  return {
+    ...actual,
+    DEFAULT_BACKEND_BASE: '/api/v1',
+    useBackendBase: () => computed(() => '/api/v1'),
+    resolveBackendUrl: (path: string) => `/api/v1${path}`,
+  };
+});
 
 const withActions = async (
   run: (actions: ReturnType<typeof useJobQueueActions>) => Promise<void>,


### PR DESCRIPTION
## Summary
- update backend URL helpers to rely on resolved settings defaults and allow optional store injection
- guard settings store access when Pinia is unavailable and lazy-load frontend settings to avoid circular dependencies
- adjust mocks and tests to accommodate the new helpers and ensure fetch-based expectations succeed

## Testing
- npm run type-check
- npx vitest run tests/vue/generationService.spec.ts tests/vue/useJobQueue.spec.ts tests/vue/useJobQueueActions.spec.ts --reporter basic

------
https://chatgpt.com/codex/tasks/task_e_68db0a61ae348329a1acaed9d550a3c4