### PR TITLE
Refine system status orchestration for generation queue

### DIFF
--- a/app/frontend/src/composables/generation/useGenerationTransport.ts
+++ b/app/frontend/src/composables/generation/useGenerationTransport.ts
@@ -42,6 +42,8 @@ export interface GenerationTransportCallbacks {
   shouldPollQueue?: () => boolean;
   onNotify?: (message: string, type?: NotificationType) => void;
   logger?: (...args: unknown[]) => void;
+  onHydrateSystemStatus?: () => Promise<void> | void;
+  onReleaseSystemStatus?: () => void;
 }
 
 export const useGenerationTransport = (
@@ -80,6 +82,8 @@ export const useGenerationTransport = (
       logger: (...args: unknown[]) => {
         logDebug(...args);
       },
+      onHydrateSystemStatus: callbacks.onHydrateSystemStatus,
+      onReleaseSystemStatus: callbacks.onReleaseSystemStatus,
     },
   );
 

--- a/tests/mocks/api-mocks.js
+++ b/tests/mocks/api-mocks.js
@@ -252,6 +252,37 @@ const apiMocks = {
         generation_info: null,
     }),
 
+    'GET /api/v1/generation/jobs/active': () => ({
+        data: [
+            {
+                id: 'job-1',
+                status: 'queued',
+                progress: 0,
+                prompt: 'Test prompt',
+                created_at: '2024-01-01T00:00:00Z',
+            },
+        ],
+    }),
+
+    'GET /api/v1/generation/results': (url) => {
+        const urlObj = new URL(url, 'http://localhost');
+        const limit = parseInt(urlObj.searchParams.get('limit')) || 10;
+
+        return {
+            data: mockData.loras.slice(0, limit).map((item, index) => ({
+                id: `result-${index + 1}`,
+                prompt: `Prompt ${index + 1}`,
+                image_url: `/images/result-${index + 1}.png`,
+                created_at: item.created_at,
+                width: 512,
+                height: 512,
+                steps: 30,
+                cfg_scale: 7,
+                seed: 1234 + index,
+            })),
+        };
+    },
+
     'POST /api/generation/jobs/:id/cancel': (url) => {
         const id = url.split('/').slice(-2)[0];
         return {

--- a/tests/vue/GenerationStudio.spec.js
+++ b/tests/vue/GenerationStudio.spec.js
@@ -15,6 +15,21 @@ import {
 } from '../../app/frontend/src/stores/generation'
 import { PERSISTENCE_KEYS } from '../../app/frontend/src/constants/persistence'
 
+const mockStatusController = vi.hoisted(() => ({
+  ensureHydrated: vi.fn().mockResolvedValue(undefined),
+  refresh: vi.fn().mockResolvedValue(undefined),
+  start: vi.fn(),
+  stop: vi.fn(),
+}))
+
+vi.mock('../../app/frontend/src/stores/generation/systemStatusController', () => ({
+  acquireSystemStatusController: () => ({
+    controller: mockStatusController,
+    release: vi.fn(),
+  }),
+  useSystemStatusController: () => mockStatusController,
+}))
+
 const orchestratorMocks = vi.hoisted(() => ({
   initialize: vi.fn(),
   cleanup: vi.fn(),

--- a/tests/vue/SystemStatusCard.spec.js
+++ b/tests/vue/SystemStatusCard.spec.js
@@ -15,6 +15,10 @@ const mockController = {
 
 vi.mock('../../app/frontend/src/stores/generation/systemStatusController', () => ({
   useSystemStatusController: () => mockController,
+  acquireSystemStatusController: () => ({
+    controller: mockController,
+    release: vi.fn(),
+  }),
 }));
 
 const flush = async () => {


### PR DESCRIPTION
## Summary
- decouple `useGenerationQueueClient` from the system-status controller by introducing optional hydration and release callbacks
- ensure the generation orchestrator acquires/releases the shared system-status controller and forwards callbacks through the transport layer
- extend API mocks and unit tests to provide mocked system-status controllers and generation endpoints during hydration

## Testing
- npx vitest run tests/vue/SystemStatusCard.spec.js

------
https://chatgpt.com/codex/tasks/task_e_68db11ac8b208329af64c0f58eadbeae