### PR TITLE
Add store action for applying generation result parameters

### DIFF
--- a/app/frontend/src/composables/generation/useGenerationUI.ts
+++ b/app/frontend/src/composables/generation/useGenerationUI.ts
@@ -41,26 +41,7 @@ export const useGenerationUI = ({ notify }: UseGenerationUIOptions) => {
   }
 
   const reuseParameters = (result: GenerationResult): void => {
-    if (typeof result.prompt === 'string') {
-      params.value.prompt = result.prompt
-    }
-    params.value.negative_prompt = typeof result.negative_prompt === 'string' ? result.negative_prompt : ''
-    if (typeof result.width === 'number') {
-      params.value.width = result.width
-    }
-    if (typeof result.height === 'number') {
-      params.value.height = result.height
-    }
-    if (typeof result.steps === 'number') {
-      params.value.steps = result.steps
-    }
-    if (typeof result.cfg_scale === 'number') {
-      params.value.cfg_scale = result.cfg_scale
-    }
-    if (typeof result.seed === 'number') {
-      params.value.seed = result.seed
-    }
-
+    formStore.applyResultParameters(result)
     notify('Parameters loaded from result', 'success')
   }
 

--- a/app/frontend/src/stores/generation/form.ts
+++ b/app/frontend/src/stores/generation/form.ts
@@ -21,6 +21,38 @@ const createInitialParams = (): GenerationFormState => ({
   ...DEFAULT_FORM_STATE,
 });
 
+const extractParamsFromResult = (
+  result: GenerationResult,
+): Partial<GenerationFormState> => {
+  const updates: Partial<GenerationFormState> = {
+    negative_prompt:
+      typeof result.negative_prompt === 'string'
+        ? result.negative_prompt
+        : DEFAULT_FORM_STATE.negative_prompt,
+  };
+
+  if (typeof result.prompt === 'string') {
+    updates.prompt = result.prompt;
+  }
+  if (typeof result.width === 'number') {
+    updates.width = result.width;
+  }
+  if (typeof result.height === 'number') {
+    updates.height = result.height;
+  }
+  if (typeof result.steps === 'number') {
+    updates.steps = result.steps;
+  }
+  if (typeof result.cfg_scale === 'number') {
+    updates.cfg_scale = result.cfg_scale;
+  }
+  if (typeof result.seed === 'number') {
+    updates.seed = result.seed;
+  }
+
+  return updates;
+};
+
 export const useGenerationFormStore = defineStore('generation-form', () => {
   const params = ref<GenerationFormState>(createInitialParams());
   const isGenerating = ref(false);
@@ -60,6 +92,10 @@ export const useGenerationFormStore = defineStore('generation-form', () => {
     params.value = createInitialParams();
   };
 
+  const applyResultParameters = (result: GenerationResult): void => {
+    updateParams(extractParamsFromResult(result));
+  };
+
   const reset = (): void => {
     resetParams();
     isGenerating.value = false;
@@ -79,6 +115,7 @@ export const useGenerationFormStore = defineStore('generation-form', () => {
     toggleHistory,
     setShowModal,
     selectResult,
+    applyResultParameters,
     updateParams,
     resetParams,
     reset,

--- a/tests/vue/stores/generationFormStore.spec.ts
+++ b/tests/vue/stores/generationFormStore.spec.ts
@@ -1,0 +1,63 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import { createPinia, setActivePinia } from 'pinia'
+
+import { useGenerationFormStore } from '@/stores/generation'
+import type { GenerationResult } from '@/types'
+
+describe('generation form store', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  it('maps generation results to form state', () => {
+    const store = useGenerationFormStore()
+    const initialParams = store.params
+
+    const result: GenerationResult = {
+      id: 'result-1',
+      prompt: 'A scenic mountain landscape',
+      negative_prompt: 'low quality, blurry',
+      width: 768,
+      height: 512,
+      steps: 30,
+      cfg_scale: 12,
+      seed: 42,
+    }
+
+    store.applyResultParameters(result)
+
+    expect(store.params).not.toBe(initialParams)
+    expect(store.params.prompt).toBe(result.prompt)
+    expect(store.params.negative_prompt).toBe(result.negative_prompt)
+    expect(store.params.width).toBe(result.width)
+    expect(store.params.height).toBe(result.height)
+    expect(store.params.steps).toBe(result.steps)
+    expect(store.params.cfg_scale).toBe(result.cfg_scale)
+    expect(store.params.seed).toBe(result.seed)
+  })
+
+  it('resets missing values to defaults while preserving existing ones', () => {
+    const store = useGenerationFormStore()
+
+    store.updateParams({
+      prompt: 'keep me',
+      steps: 35,
+      negative_prompt: 'should be cleared',
+    })
+
+    const result: GenerationResult = {
+      id: 'result-2',
+      width: 1024,
+      height: 768,
+      negative_prompt: null,
+    }
+
+    store.applyResultParameters(result)
+
+    expect(store.params.prompt).toBe('keep me')
+    expect(store.params.steps).toBe(35)
+    expect(store.params.width).toBe(1024)
+    expect(store.params.height).toBe(768)
+    expect(store.params.negative_prompt).toBe('')
+  })
+})


### PR DESCRIPTION
## Summary
- add a helper-driven `applyResultParameters` action to the generation form store
- update the generation UI composable to reuse the new store action when loading result parameters
- cover the new action with unit tests to confirm mapping and default handling

## Testing
- npm run test -- tests/vue/stores/generationFormStore.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68db161d0fa48329a3d3f63b6299b909