### PR TITLE
Introduce Zod validation for generation queue payloads

### DIFF
--- a/app/frontend/src/schemas/generation.ts
+++ b/app/frontend/src/schemas/generation.ts
@@ -1,0 +1,104 @@
+import { z } from 'zod';
+
+import type { GenerationJobStatus } from '@/types/generation';
+import type { GenerationResult } from '@/types/app';
+
+import { JsonObjectSchema } from './json';
+
+const NormalizedStatusSchema = z.string();
+
+const NullableString = z.union([z.string(), z.null()]).optional();
+
+const NullableIsoString = z.union([z.string(), z.null()]).optional();
+
+const RequiredIdSchema = z.preprocess(
+  (value) => {
+    if (typeof value === 'number' || typeof value === 'string') {
+      return String(value);
+    }
+    return value;
+  },
+  z.string(),
+);
+
+const OptionalJobIdSchema = z.preprocess(
+  (value) => {
+    if (value == null) {
+      return null;
+    }
+    if (typeof value === 'number' || typeof value === 'string') {
+      return String(value);
+    }
+    return value;
+  },
+  z.union([z.string(), z.null()]).optional(),
+);
+
+export const GenerationJobStatusSchema = z
+  .object({
+    id: RequiredIdSchema,
+    jobId: OptionalJobIdSchema,
+    prompt: NullableString,
+    name: NullableString,
+    status: NormalizedStatusSchema,
+    progress: z.coerce.number().finite().min(0),
+    message: NullableString,
+    error: NullableString,
+    params: JsonObjectSchema.nullish(),
+    created_at: z.string(),
+    startTime: NullableIsoString,
+    finished_at: NullableIsoString,
+    result: JsonObjectSchema.nullish(),
+  })
+  .passthrough()
+  .transform((value) => ({
+    ...value,
+    jobId: value.jobId ?? null,
+    prompt: value.prompt ?? null,
+    name: value.name ?? null,
+    message: value.message ?? null,
+    error: value.error ?? null,
+    params: value.params ?? null,
+    startTime: value.startTime ?? null,
+    finished_at: value.finished_at ?? null,
+    result: value.result ?? null,
+  })) satisfies z.ZodType<GenerationJobStatus>;
+
+export const GenerationResultSchema = z
+  .object({
+    id: z.union([z.string(), z.number()]),
+    job_id: z
+      .preprocess((value) => {
+        if (value == null) {
+          return undefined;
+        }
+        if (typeof value === 'number' || typeof value === 'string') {
+          return String(value);
+        }
+        return value;
+      }, z.string().optional()),
+    result_id: z.union([z.string(), z.number()]).optional(),
+    prompt: z.string().optional(),
+    negative_prompt: NullableString,
+    image_url: NullableString,
+    thumbnail_url: NullableString,
+    width: z.number().finite().optional(),
+    height: z.number().finite().optional(),
+    steps: z.number().finite().optional(),
+    cfg_scale: z.number().finite().optional(),
+    seed: z.number().finite().nullable().optional(),
+    created_at: z.string().optional(),
+    finished_at: NullableIsoString,
+    status: NormalizedStatusSchema.optional(),
+    generation_info: JsonObjectSchema.nullish(),
+  })
+  .passthrough()
+  .transform((value) => ({
+    ...value,
+    negative_prompt: value.negative_prompt ?? null,
+    image_url: value.image_url ?? null,
+    thumbnail_url: value.thumbnail_url ?? null,
+    seed: value.seed ?? null,
+    finished_at: value.finished_at ?? null,
+    generation_info: value.generation_info ?? null,
+  })) satisfies z.ZodType<GenerationResult>;

--- a/app/frontend/src/schemas/index.ts
+++ b/app/frontend/src/schemas/index.ts
@@ -1,0 +1,3 @@
+export * from './json';
+export * from './generation';
+export * from './system';

--- a/app/frontend/src/schemas/json.ts
+++ b/app/frontend/src/schemas/json.ts
@@ -1,0 +1,16 @@
+import { z } from 'zod';
+
+import type { JsonObject, JsonValue } from '@/types/json';
+
+export const JsonValueSchema: z.ZodType<JsonValue> = z.lazy(() =>
+  z.union([
+    z.string(),
+    z.number(),
+    z.boolean(),
+    z.null(),
+    z.array(JsonValueSchema),
+    z.record(JsonValueSchema),
+  ]),
+);
+
+export const JsonObjectSchema: z.ZodType<JsonObject> = z.record(JsonValueSchema);

--- a/app/frontend/src/schemas/system.ts
+++ b/app/frontend/src/schemas/system.ts
@@ -1,0 +1,159 @@
+import { z } from 'zod';
+
+import type {
+  CpuTelemetry,
+  GpuTelemetry,
+  MemoryTelemetry,
+  DiskTelemetry,
+  RecommendationRuntimeStatus,
+  SystemImporterStatus,
+  SystemMetricsSnapshot,
+  SystemQueueStatistics,
+  SystemQueueThresholds,
+  SystemSdNextStatus,
+  SystemStatusPayload,
+  SystemThresholds,
+} from '@/types/system';
+
+const NullableString = z.union([z.string(), z.null()]).optional();
+const NullableNumber = z.union([z.number().finite(), z.null()]).optional();
+
+export const RecommendationRuntimeStatusSchema = z
+  .object({
+    models_loaded: z.boolean().optional(),
+    gpu_available: z.boolean().optional(),
+  })
+  .passthrough() satisfies z.ZodType<RecommendationRuntimeStatus>;
+
+export const SystemQueueStatisticsSchema = z
+  .object({
+    active: z.number().int().nonnegative().optional(),
+    failed: z.number().int().nonnegative().optional(),
+    running: z.number().int().nonnegative().optional(),
+  })
+  .passthrough() satisfies z.ZodType<SystemQueueStatistics>;
+
+export const SystemQueueThresholdsSchema = z
+  .object({
+    active_warning: NullableNumber,
+    failed_warning: NullableNumber,
+  })
+  .passthrough() satisfies z.ZodType<SystemQueueThresholds>;
+
+export const SystemThresholdsSchema = z
+  .object({
+    queue: SystemQueueThresholdsSchema.nullish(),
+    importer: z
+      .object({
+        stale_hours: NullableNumber,
+      })
+      .passthrough()
+      .nullish(),
+  })
+  .passthrough() satisfies z.ZodType<SystemThresholds>;
+
+export const SystemSdNextStatusSchema = z
+  .object({
+    configured: z.boolean(),
+    base_url: NullableString,
+    available: z.boolean().optional(),
+    error: NullableString,
+    checked_at: NullableString,
+  })
+  .passthrough() satisfies z.ZodType<SystemSdNextStatus>;
+
+export const SystemImporterStatusSchema = z
+  .object({
+    import_path: NullableString,
+    last_ingested_at: NullableString,
+    recent_imports: NullableNumber,
+    total_adapters: NullableNumber,
+    stale: z.boolean().nullable().optional(),
+    stale_threshold_hours: NullableNumber,
+  })
+  .passthrough() satisfies z.ZodType<SystemImporterStatus>;
+
+export const GpuTelemetrySchema = z
+  .object({
+    id: z.union([z.string(), z.number()]),
+    name: z.string(),
+    memory_total: NullableNumber,
+    memory_used: NullableNumber,
+    memory_percent: NullableNumber,
+    temperature: NullableNumber,
+    utilization: NullableNumber,
+    fan_speed: NullableNumber,
+    power_draw_watts: NullableNumber,
+  })
+  .passthrough() satisfies z.ZodType<GpuTelemetry>;
+
+export const CpuTelemetrySchema = z
+  .object({
+    percent: z.number().finite(),
+    cores: z.number().int().positive().optional(),
+    frequency_mhz: NullableNumber,
+    load_average: z
+      .tuple([z.number().finite(), z.number().finite(), z.number().finite()])
+      .optional(),
+  })
+  .passthrough() satisfies z.ZodType<CpuTelemetry>;
+
+export const MemoryTelemetrySchema = z
+  .object({
+    total: z.number().finite(),
+    used: z.number().finite(),
+    available: NullableNumber,
+    percent: z.number().finite(),
+  })
+  .passthrough() satisfies z.ZodType<MemoryTelemetry>;
+
+export const DiskTelemetrySchema = z
+  .object({
+    total: NullableNumber,
+    used: NullableNumber,
+    percent: NullableNumber,
+    path: NullableString,
+  })
+  .passthrough() satisfies z.ZodType<DiskTelemetry>;
+
+export const SystemMetricsSnapshotSchema = z
+  .object({
+    cpu_percent: z.number().finite(),
+    memory_percent: z.number().finite(),
+    memory_used: z.number().finite(),
+    memory_total: z.number().finite(),
+    disk_percent: NullableNumber,
+    disk_used: NullableNumber,
+    disk_total: NullableNumber,
+    cpu: CpuTelemetrySchema.nullish(),
+    memory: MemoryTelemetrySchema.nullish(),
+    disk: DiskTelemetrySchema.nullish(),
+    gpus: z.array(GpuTelemetrySchema),
+    uptime_seconds: NullableNumber,
+    timestamp: NullableString,
+  })
+  .passthrough() satisfies z.ZodType<SystemMetricsSnapshot>;
+
+export const SystemStatusPayloadSchema = z
+  .object({
+    gpu_available: z.boolean().optional(),
+    queue_length: z.number().int().nonnegative().optional(),
+    status: z.string().optional(),
+    gpu_status: z.string().optional(),
+    memory_used: z.number().finite().optional(),
+    memory_total: z.number().finite().optional(),
+    active_workers: NullableNumber,
+    backend: NullableString,
+    queue_eta_seconds: NullableNumber,
+    last_updated: NullableString,
+    warnings: z.array(z.string()).optional(),
+    metrics: SystemMetricsSnapshotSchema.nullish(),
+    message: NullableString,
+    updated_at: NullableString,
+    sdnext: SystemSdNextStatusSchema.nullish(),
+    importer: SystemImporterStatusSchema.nullish(),
+    recommendations: RecommendationRuntimeStatusSchema.nullish(),
+    queue: SystemQueueStatisticsSchema.nullish(),
+    thresholds: SystemThresholdsSchema.nullish(),
+  })
+  .passthrough() satisfies z.ZodType<SystemStatusPayload>;

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,8 @@
         "pinia": "^2.1.7",
         "vue": "^3.5.0",
         "vue-router": "^4.4.5",
-        "vue-virtual-scroller": "^2.0.0-beta.8"
+        "vue-virtual-scroller": "^2.0.0-beta.8",
+        "zod": "^3.23.8"
       },
       "devDependencies": {
         "@lhci/cli": "^0.13.0",
@@ -12003,6 +12004,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -64,7 +64,8 @@
     "pinia": "^2.1.7",
     "vue": "^3.5.0",
     "vue-router": "^4.4.5",
-    "vue-virtual-scroller": "^2.0.0-beta.8"
+    "vue-virtual-scroller": "^2.0.0-beta.8",
+    "zod": "^3.23.8"
   },
   "keywords": [
     "lora",

--- a/tests/vue/services/generation/updates.spec.ts
+++ b/tests/vue/services/generation/updates.spec.ts
@@ -1,0 +1,106 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Mock } from 'vitest';
+
+import { createGenerationQueueClient } from '@/services/generation/updates';
+import type { ApiResponseMeta } from '@/types';
+
+vi.mock('@/services/apiClient', async () => {
+  const actual = await vi.importActual<typeof import('@/services/apiClient')>(
+    '@/services/apiClient',
+  );
+  return {
+    ...actual,
+    requestJson: vi.fn(),
+  };
+});
+
+import { requestJson } from '@/services/apiClient';
+
+const createMeta = (overrides: Partial<ApiResponseMeta> = {}): ApiResponseMeta => ({
+  ok: true,
+  status: 200,
+  statusText: 'OK',
+  ...overrides,
+});
+
+const createClient = () =>
+  createGenerationQueueClient({
+    getBackendUrl: () => 'https://backend.example/api',
+  });
+
+describe('createGenerationQueueClient', () => {
+  beforeEach(() => {
+    (requestJson as unknown as Mock).mockReset();
+  });
+
+  it('filters malformed active job records', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    (requestJson as unknown as Mock).mockResolvedValueOnce({
+      data: [
+        {
+          id: 'job-1',
+          status: 'processing',
+          progress: 0.5,
+          created_at: '2024-01-01T00:00:00Z',
+        },
+        {
+          id: null,
+          status: 'processing',
+          progress: 0.1,
+          created_at: '2024-01-01T00:00:00Z',
+        },
+      ],
+      meta: createMeta(),
+    });
+
+    const client = createClient();
+    const jobs = await client.fetchActiveJobs();
+
+    expect(jobs).toHaveLength(1);
+    expect(jobs[0]).toMatchObject({ id: 'job-1', status: 'processing', progress: 0.5 });
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+
+    warnSpy.mockRestore();
+  });
+
+  it('returns null when the system status payload is invalid', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    (requestJson as unknown as Mock).mockResolvedValueOnce({
+      data: { status: 42 },
+      meta: createMeta(),
+    });
+
+    const client = createClient();
+    const status = await client.fetchSystemStatus();
+
+    expect(status).toBeNull();
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+
+    warnSpy.mockRestore();
+  });
+
+  it('filters malformed generation results', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    (requestJson as unknown as Mock).mockResolvedValueOnce({
+      data: [
+        {
+          id: 'result-1',
+          job_id: 'job-1',
+        },
+        {
+          job_id: 'job-2',
+        },
+      ],
+      meta: createMeta(),
+    });
+
+    const client = createClient();
+    const results = await client.fetchRecentResults(5);
+
+    expect(results).toHaveLength(1);
+    expect(results[0]).toMatchObject({ id: 'result-1', job_id: 'job-1' });
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+
+    warnSpy.mockRestore();
+  });
+});

--- a/tests/vue/useGenerationQueueClient.spec.ts
+++ b/tests/vue/useGenerationQueueClient.spec.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { useGenerationQueueClient } from '@/composables/generation';
+import type { GenerationQueueClient } from '@/services/generation/updates';
+import type { GenerationJobStatus, GenerationResult, SystemStatusPayload } from '@/types';
+
+const iso = '2024-01-01T00:00:00Z';
+
+const createQueueClient = (overrides: Partial<GenerationQueueClient> = {}): GenerationQueueClient => ({
+  startGeneration: vi.fn().mockResolvedValue(undefined as never),
+  cancelJob: vi.fn().mockResolvedValue(undefined),
+  deleteResult: vi.fn().mockResolvedValue(undefined),
+  fetchSystemStatus: vi.fn().mockResolvedValue(null),
+  fetchActiveJobs: vi.fn().mockResolvedValue([]),
+  fetchRecentResults: vi.fn().mockResolvedValue([]),
+  ...overrides,
+});
+
+describe('useGenerationQueueClient validation', () => {
+  it('ignores malformed active jobs before updating the queue store', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const validJob: GenerationJobStatus = {
+      id: 'job-1',
+      jobId: null,
+      prompt: 'prompt',
+      name: null,
+      status: 'processing',
+      progress: 0.5,
+      message: null,
+      error: null,
+      params: null,
+      created_at: iso,
+      startTime: null,
+      finished_at: null,
+      result: null,
+    };
+    const invalidJob = { ...validJob, id: null } as unknown as GenerationJobStatus;
+
+    const queueClient = createQueueClient({
+      fetchActiveJobs: vi.fn().mockResolvedValue([validJob, invalidJob]),
+    });
+
+    const onQueueUpdate = vi.fn();
+    const composable = useGenerationQueueClient(
+      {
+        getBackendUrl: () => null,
+        queueClient,
+      },
+      {
+        onQueueUpdate,
+      },
+    );
+
+    await composable.refreshActiveJobs();
+
+    expect(onQueueUpdate).toHaveBeenCalledTimes(1);
+    expect(onQueueUpdate.mock.calls[0][0]).toEqual([
+      expect.objectContaining({ id: 'job-1', status: 'processing', progress: 0.5 }),
+    ]);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+
+    warnSpy.mockRestore();
+  });
+
+  it('ignores malformed generation results before notifying listeners', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const validResult: GenerationResult = {
+      id: 'result-1',
+      job_id: 'job-1',
+      prompt: 'ok',
+      negative_prompt: null,
+      image_url: null,
+      thumbnail_url: null,
+      created_at: iso,
+      finished_at: null,
+      generation_info: null,
+    };
+    const invalidResult = { ...validResult, id: undefined } as unknown as GenerationResult;
+
+    const queueClient = createQueueClient({
+      fetchRecentResults: vi.fn().mockResolvedValue([validResult, invalidResult]),
+    });
+
+    const onRecentResults = vi.fn();
+    const composable = useGenerationQueueClient(
+      {
+        getBackendUrl: () => null,
+        queueClient,
+      },
+      {
+        onRecentResults,
+      },
+    );
+
+    await composable.refreshRecentResults(5);
+
+    expect(onRecentResults).toHaveBeenCalledTimes(1);
+    expect(onRecentResults.mock.calls[0][0]).toEqual([
+      expect.objectContaining({ id: 'result-1', job_id: 'job-1' }),
+    ]);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+
+    warnSpy.mockRestore();
+  });
+
+  it('skips invalid system status payloads', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const invalidStatus = { status: 123 } as unknown as SystemStatusPayload;
+
+    const queueClient = createQueueClient({
+      fetchSystemStatus: vi.fn().mockResolvedValue(invalidStatus),
+    });
+
+    const onSystemStatus = vi.fn();
+    const composable = useGenerationQueueClient(
+      {
+        getBackendUrl: () => null,
+        queueClient,
+      },
+      {
+        onSystemStatus,
+      },
+    );
+
+    await composable.refreshSystemStatus();
+
+    expect(onSystemStatus).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+
+    warnSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
- add runtime Zod schemas for generation job status, recent result, and system status payloads
- validate queue API responses in the generation queue client and composable, logging and skipping malformed entries
- cover corrupted payload handling with targeted unit tests and add the zod dependency

## Testing
- npm run test:unit *(fails: known pre-existing GenerationStudio/useExportWorkflow/useBackupWorkflow/useJobQueueTransport specs and missing orchestrator import)*

------
https://chatgpt.com/codex/tasks/task_e_68db18c74b7c8329a00b84e8f02ee90f