### PR TITLE
Refactor frontend services to share backend helpers

### DIFF
--- a/app/frontend/src/services/history/historyService.ts
+++ b/app/frontend/src/services/history/historyService.ts
@@ -1,6 +1,10 @@
 import { getFilenameFromContentDisposition } from '@/services/apiClient';
-import { resolveBackendClient, type ApiRequestInit, type BackendClient } from '@/services/backendClient';
-import { trimLeadingSlash } from '@/utils/backend';
+import type { BackendClient } from '@/services/backendClient';
+import {
+  createBackendPathResolver,
+  resolveClient,
+  withSameOrigin,
+} from '@/services/shared/backendHelpers';
 
 import type {
   GenerationBulkDeleteRequest,
@@ -16,17 +20,8 @@ import type {
   GenerationRatingUpdate,
 } from '@/types';
 
-const withSameOrigin = (init: ApiRequestInit = {}): ApiRequestInit => ({
-  credentials: 'same-origin',
-  ...init,
-});
-
-const resolveClient = (client?: BackendClient | null): BackendClient => resolveBackendClient(client ?? undefined);
-
-const historyPath = (path: string): string => {
-  const trimmed = trimLeadingSlash(path);
-  return `/generation${trimmed ? `/${trimmed}` : ''}`;
-};
+const historyPaths = createBackendPathResolver('generation');
+const historyPath = historyPaths.path;
 
 const toStats = (stats?: GenerationHistoryStats | null): GenerationHistoryStats => ({
   total_results: stats?.total_results ?? 0,

--- a/app/frontend/src/services/lora/loraService.ts
+++ b/app/frontend/src/services/lora/loraService.ts
@@ -1,4 +1,5 @@
-import { resolveBackendClient, type BackendClient } from '@/services/backendClient';
+import type { BackendClient } from '@/services/backendClient';
+import { createBackendPathResolver, resolveClient } from '@/services/shared/backendHelpers';
 
 import type {
   AdapterListQuery,
@@ -95,9 +96,8 @@ export const buildAdapterListQuery = (query: AdapterListQuery = {}): string => {
   return suffix ? `?${suffix}` : '';
 };
 
-const resolveClient = (client?: BackendClient | null): BackendClient => resolveBackendClient(client ?? undefined);
-
-const adaptersPath = (suffix = ''): string => `/adapters${suffix}`;
+const adaptersPaths = createBackendPathResolver('adapters');
+const adaptersPath = adaptersPaths.path;
 
 export const fetchAdapterTags = async (client?: BackendClient | null): Promise<string[]> => {
   const backend = resolveClient(client);

--- a/app/frontend/src/services/shared/backendHelpers.ts
+++ b/app/frontend/src/services/shared/backendHelpers.ts
@@ -1,0 +1,61 @@
+import {
+  createBackendClient,
+  resolveBackendClient,
+  type ApiRequestInit,
+  type BackendClient,
+} from '@/services/backendClient';
+import { trimLeadingSlash } from '@/utils/backend';
+
+export type BackendClientInput = BackendClient | string | null | undefined;
+
+export const resolveClient = (input?: BackendClientInput): BackendClient => {
+  if (typeof input === 'string') {
+    return createBackendClient(input);
+  }
+
+  if (input == null) {
+    return resolveBackendClient();
+  }
+
+  return resolveBackendClient(input);
+};
+
+export const withSameOrigin = (init: ApiRequestInit = {}): ApiRequestInit => ({
+  credentials: 'same-origin',
+  ...init,
+});
+
+const joinSegments = (segments: readonly string[]): string => {
+  const parts = segments
+    .map((segment) => (typeof segment === 'string' ? trimLeadingSlash(segment) : ''))
+    .filter((segment) => segment.length > 0);
+
+  if (!parts.length) {
+    return '';
+  }
+
+  return `/${parts.join('/')}`;
+};
+
+export type BackendPathBuilder = (path?: string) => string;
+
+export const createBackendPathBuilder = (basePath: string): BackendPathBuilder => {
+  const base = trimLeadingSlash(basePath);
+  return (path = '') => joinSegments([base, path]);
+};
+
+export const resolveBackendPath = (path: string, input?: BackendClientInput): string =>
+  resolveClient(input).resolve(path);
+
+export interface BackendPathResolver {
+  path: BackendPathBuilder;
+  resolve: (path?: string, input?: BackendClientInput) => string;
+}
+
+export const createBackendPathResolver = (basePath: string): BackendPathResolver => {
+  const path = createBackendPathBuilder(basePath);
+  const resolve = (suffix = '', input?: BackendClientInput): string =>
+    resolveBackendPath(path(suffix), input);
+
+  return { path, resolve };
+};

--- a/app/frontend/src/services/system/systemService.ts
+++ b/app/frontend/src/services/system/systemService.ts
@@ -1,4 +1,5 @@
-import { resolveBackendClient, type ApiRequestInit, type BackendClient } from '@/services/backendClient';
+import type { BackendClient } from '@/services/backendClient';
+import { resolveBackendPath, withSameOrigin } from '@/services/shared/backendHelpers';
 
 import type {
   DashboardStatsSummary,
@@ -8,15 +9,8 @@ import type {
 } from '@/types';
 import { requestConfiguredJson, type ApiRequestConfig } from '@/services/apiClient';
 
-const withSameOrigin = (init: ApiRequestInit = {}): ApiRequestInit => ({
-  credentials: 'same-origin',
-  ...init,
-});
-
-const resolveClient = (client?: BackendClient | null): BackendClient => resolveBackendClient(client ?? undefined);
-
 const createRequestConfig = (path: string, client?: BackendClient | null): ApiRequestConfig => ({
-  target: resolveClient(client).resolve(path),
+  target: resolveBackendPath(path, client ?? undefined),
   init: withSameOrigin(),
 });
 


### PR DESCRIPTION
## Summary
- add shared backend helper utilities for resolving clients, paths, and same-origin requests
- refactor generation, history, lora, and system services to reuse the shared helpers

## Testing
- npm run lint *(fails: repository currently violates existing no-restricted-imports rules outside this change)*
- npm run test *(fails: existing Vitest suite cannot resolve zod and related mocks in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68db30aa30708329b187bdcfe0490a48