### PR TITLE
feat: centralize performance analytics state

### DIFF
--- a/app/frontend/src/composables/usePerformanceAnalytics.ts
+++ b/app/frontend/src/composables/usePerformanceAnalytics.ts
@@ -1,193 +1,20 @@
-/**
- * Performance Analytics Composable
- *
- * Manages data fetching and state for performance analytics dashboards.
- */
+import { storeToRefs } from 'pinia';
 
-import { ref } from 'vue';
-
-import {
-  exportAnalyticsReport,
-  fetchPerformanceAnalytics,
-  fetchTopAdapters,
-  useBackendClient,
-} from '@/services';
-import { formatDuration as formatDurationLabel } from '@/utils/format';
-
-import type {
-  ErrorAnalysisEntry,
-  PerformanceAnalyticsCharts,
-  PerformanceInsightEntry,
-  PerformanceKpiSummary,
-  PerformanceTimeRange,
-  TopLoraPerformance,
-} from '@/types';
-import type { AnalyticsExportOptions, AnalyticsExportResult } from '@/types';
-
-const DEFAULT_KPIS: PerformanceKpiSummary = {
-  total_generations: 0,
-  generation_growth: 0,
-  avg_generation_time: 0,
-  time_improvement: 0,
-  success_rate: 0,
-  total_failed: 0,
-  active_loras: 0,
-  total_loras: 0,
-};
-
-const createEmptyCharts = (): PerformanceAnalyticsCharts => ({
-  generationVolume: [],
-  performance: [],
-  loraUsage: [],
-  resourceUsage: [],
-});
-
-const createDevTopLoras = (): TopLoraPerformance[] => [
-  {
-    id: 1,
-    name: 'Anime Style v2.1',
-    version: 'v2.1',
-    usage_count: 342,
-    success_rate: 96.8,
-    avg_time: 42.3,
-  },
-  {
-    id: 2,
-    name: 'Realistic Portrait',
-    version: 'v1.5',
-    usage_count: 289,
-    success_rate: 94.2,
-    avg_time: 38.7,
-  },
-  {
-    id: 3,
-    name: 'Fantasy Art',
-    version: 'v3.0',
-    usage_count: 267,
-    success_rate: 92.1,
-    avg_time: 51.2,
-  },
-  {
-    id: 4,
-    name: 'Cyberpunk Style',
-    version: 'v1.8',
-    usage_count: 198,
-    success_rate: 89.4,
-    avg_time: 47.9,
-  },
-  {
-    id: 5,
-    name: 'Nature Photography',
-    version: 'v2.0',
-    usage_count: 156,
-    success_rate: 97.1,
-    avg_time: 35.8,
-  },
-];
+import { usePerformanceAnalyticsStore } from '@/stores';
 
 export function usePerformanceAnalytics() {
-  const backendClient = useBackendClient();
-
-  const timeRange = ref<PerformanceTimeRange>('24h');
-  const autoRefresh = ref<boolean>(false);
-  const refreshInterval = ref<ReturnType<typeof setInterval> | null>(null);
-  const isLoading = ref<boolean>(false);
-
-  const kpis = ref<PerformanceKpiSummary>({ ...DEFAULT_KPIS });
-  const topLoras = ref<TopLoraPerformance[]>([]);
-  const errorAnalysis = ref<ErrorAnalysisEntry[]>([]);
-  const performanceInsights = ref<PerformanceInsightEntry[]>([]);
-  const chartData = ref<PerformanceAnalyticsCharts>(createEmptyCharts());
-
-  const loadTopLoras = async (): Promise<void> => {
-    try {
-      const adapters = await fetchTopAdapters(10, backendClient);
-      topLoras.value = adapters;
-
-      if (!topLoras.value.length && import.meta.env.DEV) {
-        topLoras.value = createDevTopLoras();
-      }
-
-      if (topLoras.value.length && chartData.value.loraUsage.length === 0) {
-        chartData.value = {
-          ...chartData.value,
-          loraUsage: topLoras.value.map((lora) => ({
-            name: lora.name,
-            usage_count: lora.usage_count,
-          })),
-        } satisfies PerformanceAnalyticsCharts;
-      }
-    } catch (error) {
-      console.error('Error loading top LoRAs:', error);
-      if (import.meta.env.DEV) {
-        topLoras.value = createDevTopLoras();
-      } else {
-        topLoras.value = [];
-      }
-    }
-  };
-
-  const loadAnalyticsSummary = async (): Promise<void> => {
-    try {
-      const summary = await fetchPerformanceAnalytics(timeRange.value, backendClient);
-
-      kpis.value = {
-        ...DEFAULT_KPIS,
-        ...(summary.kpis ?? {}),
-      } satisfies PerformanceKpiSummary;
-
-      chartData.value = {
-        ...createEmptyCharts(),
-        ...summary.chartData,
-      } satisfies PerformanceAnalyticsCharts;
-
-      errorAnalysis.value = [...summary.errorAnalysis];
-      performanceInsights.value = [...summary.performanceInsights];
-    } catch (error) {
-      console.error('Error loading analytics summary:', error);
-      kpis.value = { ...DEFAULT_KPIS };
-      chartData.value = createEmptyCharts();
-      errorAnalysis.value = [];
-      performanceInsights.value = [];
-    }
-  };
-
-  const loadAllData = async (): Promise<void> => {
-    isLoading.value = true;
-    try {
-      await loadAnalyticsSummary();
-      await loadTopLoras();
-    } finally {
-      isLoading.value = false;
-    }
-  };
-
-  const toggleAutoRefresh = (): void => {
-    if (autoRefresh.value) {
-      if (refreshInterval.value) {
-        clearInterval(refreshInterval.value);
-      }
-      refreshInterval.value = setInterval(() => {
-        void loadAllData();
-      }, 30_000);
-    } else if (refreshInterval.value) {
-      clearInterval(refreshInterval.value);
-      refreshInterval.value = null;
-    }
-  };
-
-  const cleanup = (): void => {
-    if (refreshInterval.value) {
-      clearInterval(refreshInterval.value);
-      refreshInterval.value = null;
-    }
-  };
-
-  const exportAnalytics = async (
-    format: string,
-    overrides: Partial<AnalyticsExportOptions> = {},
-  ): Promise<AnalyticsExportResult> =>
-    exportAnalyticsReport({ format, ...overrides }, backendClient);
+  const store = usePerformanceAnalyticsStore();
+  const {
+    timeRange,
+    autoRefresh,
+    kpis,
+    topLoras,
+    errorAnalysis,
+    performanceInsights,
+    chartData,
+    isLoading,
+    isInitialized,
+  } = storeToRefs(store);
 
   return {
     timeRange,
@@ -198,11 +25,14 @@ export function usePerformanceAnalytics() {
     performanceInsights,
     chartData,
     isLoading,
-    loadAllData,
-    toggleAutoRefresh,
-    formatDuration: formatDurationLabel,
-    cleanup,
-    exportAnalytics,
+    isInitialized,
+    loadAllData: store.loadAllData,
+    ensureLoaded: store.ensureLoaded,
+    toggleAutoRefresh: store.toggleAutoRefresh,
+    setTimeRange: store.setTimeRange,
+    cleanup: store.cleanup,
+    exportAnalytics: store.exportAnalytics,
+    formatDuration: store.formatDuration,
   };
 }
 

--- a/app/frontend/src/stores/index.ts
+++ b/app/frontend/src/stores/index.ts
@@ -3,4 +3,5 @@ export * from './app';
 export * from './adminMetrics';
 export * from './generation';
 export * from './adapterCatalog';
+export * from './performanceAnalytics';
 

--- a/app/frontend/src/stores/performanceAnalytics.ts
+++ b/app/frontend/src/stores/performanceAnalytics.ts
@@ -1,0 +1,237 @@
+import { computed, ref } from 'vue';
+import { defineStore } from 'pinia';
+
+import {
+  exportAnalyticsReport,
+  fetchPerformanceAnalytics,
+  fetchTopAdapters,
+  useBackendClient,
+} from '@/services';
+import { formatDuration as formatDurationLabel } from '@/utils/format';
+
+import type {
+  ErrorAnalysisEntry,
+  PerformanceAnalyticsCharts,
+  PerformanceInsightEntry,
+  PerformanceKpiSummary,
+  PerformanceTimeRange,
+  TopLoraPerformance,
+} from '@/types';
+import type { AnalyticsExportOptions, AnalyticsExportResult } from '@/types';
+
+const DEFAULT_KPIS: PerformanceKpiSummary = {
+  total_generations: 0,
+  generation_growth: 0,
+  avg_generation_time: 0,
+  time_improvement: 0,
+  success_rate: 0,
+  total_failed: 0,
+  active_loras: 0,
+  total_loras: 0,
+};
+
+const createEmptyCharts = (): PerformanceAnalyticsCharts => ({
+  generationVolume: [],
+  performance: [],
+  loraUsage: [],
+  resourceUsage: [],
+});
+
+const createDevTopLoras = (): TopLoraPerformance[] => [
+  {
+    id: 1,
+    name: 'Anime Style v2.1',
+    version: 'v2.1',
+    usage_count: 342,
+    success_rate: 96.8,
+    avg_time: 42.3,
+  },
+  {
+    id: 2,
+    name: 'Realistic Portrait',
+    version: 'v1.5',
+    usage_count: 289,
+    success_rate: 94.2,
+    avg_time: 38.7,
+  },
+  {
+    id: 3,
+    name: 'Fantasy Art',
+    version: 'v3.0',
+    usage_count: 267,
+    success_rate: 92.1,
+    avg_time: 51.2,
+  },
+  {
+    id: 4,
+    name: 'Cyberpunk Style',
+    version: 'v1.8',
+    usage_count: 198,
+    success_rate: 89.4,
+    avg_time: 47.9,
+  },
+  {
+    id: 5,
+    name: 'Nature Photography',
+    version: 'v2.0',
+    usage_count: 156,
+    success_rate: 97.1,
+    avg_time: 35.8,
+  },
+];
+
+export const usePerformanceAnalyticsStore = defineStore('performanceAnalytics', () => {
+  const backendClient = useBackendClient();
+
+  const timeRange = ref<PerformanceTimeRange>('24h');
+  const autoRefresh = ref(false);
+  const isLoading = ref(false);
+  const hasLoaded = ref(false);
+
+  const kpis = ref<PerformanceKpiSummary>({ ...DEFAULT_KPIS });
+  const topLoras = ref<TopLoraPerformance[]>([]);
+  const errorAnalysis = ref<ErrorAnalysisEntry[]>([]);
+  const performanceInsights = ref<PerformanceInsightEntry[]>([]);
+  const chartData = ref<PerformanceAnalyticsCharts>(createEmptyCharts());
+
+  let refreshInterval: ReturnType<typeof setInterval> | null = null;
+
+  const stopAutoRefresh = () => {
+    if (refreshInterval) {
+      clearInterval(refreshInterval);
+      refreshInterval = null;
+    }
+  };
+
+  const startAutoRefresh = () => {
+    stopAutoRefresh();
+    refreshInterval = setInterval(() => {
+      void loadAllData();
+    }, 30_000);
+  };
+
+  const loadTopLoras = async (): Promise<void> => {
+    try {
+      const adapters = await fetchTopAdapters(10, backendClient);
+      topLoras.value = adapters;
+
+      if (!topLoras.value.length && import.meta.env.DEV) {
+        topLoras.value = createDevTopLoras();
+      }
+
+      if (topLoras.value.length && chartData.value.loraUsage.length === 0) {
+        chartData.value = {
+          ...chartData.value,
+          loraUsage: topLoras.value.map((lora) => ({
+            name: lora.name,
+            usage_count: lora.usage_count,
+          })),
+        } satisfies PerformanceAnalyticsCharts;
+      }
+    } catch (error) {
+      if (import.meta.env.DEV) {
+        console.error('[performanceAnalytics] Error loading top LoRAs', error);
+      }
+      topLoras.value = import.meta.env.DEV ? createDevTopLoras() : [];
+    }
+  };
+
+  const loadAnalyticsSummary = async (): Promise<void> => {
+    try {
+      const summary = await fetchPerformanceAnalytics(timeRange.value, backendClient);
+
+      kpis.value = {
+        ...DEFAULT_KPIS,
+        ...(summary.kpis ?? {}),
+      } satisfies PerformanceKpiSummary;
+
+      chartData.value = {
+        ...createEmptyCharts(),
+        ...summary.chartData,
+      } satisfies PerformanceAnalyticsCharts;
+
+      errorAnalysis.value = [...summary.errorAnalysis];
+      performanceInsights.value = [...summary.performanceInsights];
+    } catch (error) {
+      if (import.meta.env.DEV) {
+        console.error('[performanceAnalytics] Error loading analytics summary', error);
+      }
+      kpis.value = { ...DEFAULT_KPIS };
+      chartData.value = createEmptyCharts();
+      errorAnalysis.value = [];
+      performanceInsights.value = [];
+    }
+  };
+
+  const loadAllData = async (): Promise<void> => {
+    if (isLoading.value) {
+      return;
+    }
+
+    isLoading.value = true;
+    try {
+      await loadAnalyticsSummary();
+      await loadTopLoras();
+      hasLoaded.value = true;
+    } finally {
+      isLoading.value = false;
+    }
+  };
+
+  const ensureLoaded = async (force = false): Promise<void> => {
+    if (force || !hasLoaded.value) {
+      await loadAllData();
+    }
+  };
+
+  const toggleAutoRefresh = (): void => {
+    if (autoRefresh.value) {
+      if (!hasLoaded.value) {
+        void ensureLoaded();
+      }
+      startAutoRefresh();
+    } else {
+      stopAutoRefresh();
+    }
+  };
+
+  const setTimeRange = (range: PerformanceTimeRange): void => {
+    timeRange.value = range;
+  };
+
+  const cleanup = (): void => {
+    stopAutoRefresh();
+    autoRefresh.value = false;
+  };
+
+  const exportAnalytics = async (
+    format: string,
+    overrides: Partial<AnalyticsExportOptions> = {},
+  ): Promise<AnalyticsExportResult> =>
+    exportAnalyticsReport({ format, ...overrides }, backendClient);
+
+  const formatDuration = (value: number): string => formatDurationLabel(value);
+
+  const isInitialized = computed(() => hasLoaded.value);
+
+  return {
+    timeRange,
+    autoRefresh,
+    kpis,
+    topLoras,
+    errorAnalysis,
+    performanceInsights,
+    chartData,
+    isLoading,
+    isInitialized,
+    loadAllData,
+    ensureLoaded,
+    toggleAutoRefresh,
+    setTimeRange,
+    cleanup,
+    exportAnalytics,
+    formatDuration,
+  };
+});
+
+export type PerformanceAnalyticsStore = ReturnType<typeof usePerformanceAnalyticsStore>;

--- a/app/frontend/src/views/DashboardView.vue
+++ b/app/frontend/src/views/DashboardView.vue
@@ -80,6 +80,7 @@ import RecommendationsPanel from '@/components/recommendations/RecommendationsPa
 import SystemAdminStatusCard from '@/components/system/SystemAdminStatusCard.vue';
 import SystemStatusCard from '@/components/system/SystemStatusCard.vue';
 import SystemStatusPanel from '@/components/system/SystemStatusPanel.vue';
+import { usePerformanceAnalyticsStore } from '@/stores';
 
 type PanelKey = 'analytics' | 'composer' | 'studio' | 'gallery' | 'history' | 'importExport';
 
@@ -172,6 +173,8 @@ const panels = panelConfigs.map((panel) => ({
   component: defineAsyncComponent(panel.loader),
 }));
 
+const performanceAnalyticsStore = usePerformanceAnalyticsStore();
+
 const panelStates = reactive<Record<PanelKey, PanelState>>(
   panels.reduce((state, panel) => {
     state[panel.key] = { active: false, loading: false, hasEverLoaded: false };
@@ -199,5 +202,13 @@ const handlePanelToggle = (key: PanelKey) => {
   }
 
   setPanelState(key, { active: true, loading: !state.hasEverLoaded });
+
+  if (key === 'analytics') {
+    void performanceAnalyticsStore.ensureLoaded().catch((error) => {
+      if (import.meta.env.DEV) {
+        console.error('[DashboardView] Failed to prefetch analytics data', error);
+      }
+    });
+  }
 };
 </script>

--- a/app/frontend/src/views/analytics/PerformanceAnalyticsPage.vue
+++ b/app/frontend/src/views/analytics/PerformanceAnalyticsPage.vue
@@ -163,7 +163,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted, onUnmounted, ref } from 'vue';
+import { computed, onMounted, onUnmounted } from 'vue';
 
 import PageHeader from '@/components/layout/PageHeader.vue';
 import SystemStatusCard from '@/components/system/SystemStatusCard.vue';
@@ -197,24 +197,14 @@ const {
   performanceInsights,
   chartData,
   isLoading,
+  isInitialized,
+  ensureLoaded,
   loadAllData,
   toggleAutoRefresh,
   formatDuration,
   cleanup,
   exportAnalytics,
 } = usePerformanceAnalytics();
-
-const isInitialized = ref(false);
-
-const init = async () => {
-  try {
-    await loadAllData();
-    isInitialized.value = true;
-  } catch (error) {
-    console.error('Failed to initialize performance analytics:', error);
-    notifications.showError('Failed to load analytics data');
-  }
-};
 
 const handleTimeRangeChange = async () => {
   await loadAllData();
@@ -249,7 +239,10 @@ const handleApplyRecommendation = (insight: PerformanceInsightEntry) => {
 };
 
 onMounted(() => {
-  void init();
+  void ensureLoaded().catch((error) => {
+    console.error('Failed to initialize performance analytics:', error);
+    notifications.showError('Failed to load analytics data');
+  });
 });
 
 onUnmounted(() => {


### PR DESCRIPTION
## Summary
- add a dedicated Pinia store that persists performance analytics KPIs, charts, top LoRAs, and auto-refresh timers
- refactor the performance analytics composable to proxy the shared store so data is reused across mounts
- update the dashboard and analytics views to rely on the store lifecycle helpers instead of per-mount fetch logic

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68db36ec839083299ef0ac5d4a9ec1ad