### PR TITLE
Refactor orchestrator manager to allow dependency injection

### DIFF
--- a/app/frontend/src/composables/generation/useGenerationOrchestratorManager.ts
+++ b/app/frontend/src/composables/generation/useGenerationOrchestratorManager.ts
@@ -15,8 +15,6 @@ import {
   useGenerationFormStore,
   useGenerationQueueStore,
   useGenerationResultsStore,
-} from '@/stores/generation';
-import {
   useGenerationOrchestratorManagerStore,
   type GenerationOrchestratorConsumer,
 } from '@/stores/generation';
@@ -35,6 +33,28 @@ export interface GenerationOrchestratorAcquireOptions {
   queueClient?: GenerationQueueClient;
   websocketManager?: GenerationWebSocketManager;
 }
+
+export interface UseGenerationOrchestratorManagerDependencies {
+  useGenerationOrchestratorManagerStore: () => ReturnType<
+    typeof useGenerationOrchestratorManagerStore
+  >;
+  useGenerationFormStore: () => ReturnType<typeof useGenerationFormStore>;
+  useGenerationQueueStore: () => ReturnType<typeof useGenerationQueueStore>;
+  useGenerationResultsStore: () => ReturnType<typeof useGenerationResultsStore>;
+  useGenerationConnectionStore: () => ReturnType<
+    typeof useGenerationConnectionStore
+  >;
+  useSettingsStore: () => ReturnType<typeof useSettingsStore>;
+}
+
+const defaultDependencies: UseGenerationOrchestratorManagerDependencies = {
+  useGenerationOrchestratorManagerStore,
+  useGenerationFormStore,
+  useGenerationQueueStore,
+  useGenerationResultsStore,
+  useGenerationConnectionStore,
+  useSettingsStore,
+};
 
 export interface GenerationOrchestratorBinding {
   activeJobs: Ref<GenerationJob[]>;
@@ -86,8 +106,10 @@ const createOrchestratorFactory = (
     websocketManager: options.websocketManager,
   });
 
-export const useGenerationOrchestratorManager = () => {
-  const orchestratorManagerStore = useGenerationOrchestratorManagerStore();
+export const createUseGenerationOrchestratorManager = (
+  dependencies: UseGenerationOrchestratorManagerDependencies = defaultDependencies,
+) => () => {
+  const orchestratorManagerStore = dependencies.useGenerationOrchestratorManagerStore();
   const {
     orchestrator: orchestratorRef,
     initializationPromise,
@@ -95,11 +117,11 @@ export const useGenerationOrchestratorManager = () => {
     consumers,
   } = storeToRefs(orchestratorManagerStore);
 
-  const formStore = useGenerationFormStore();
-  const queueStore = useGenerationQueueStore();
-  const resultsStore = useGenerationResultsStore();
-  const connectionStore = useGenerationConnectionStore();
-  const settingsStore = useSettingsStore();
+  const formStore = dependencies.useGenerationFormStore();
+  const queueStore = dependencies.useGenerationQueueStore();
+  const resultsStore = dependencies.useGenerationResultsStore();
+  const connectionStore = dependencies.useGenerationConnectionStore();
+  const settingsStore = dependencies.useSettingsStore();
 
   const { showHistory } = storeToRefs(formStore);
   const { backendUrl: configuredBackendUrl } = storeToRefs(settingsStore);
@@ -246,6 +268,8 @@ export const useGenerationOrchestratorManager = () => {
     acquire,
   };
 };
+
+export const useGenerationOrchestratorManager = createUseGenerationOrchestratorManager();
 
 export type UseGenerationOrchestratorManagerReturn = ReturnType<
   typeof useGenerationOrchestratorManager

--- a/app/frontend/src/stores/generation/orchestratorManagerStore.ts
+++ b/app/frontend/src/stores/generation/orchestratorManagerStore.ts
@@ -147,3 +147,7 @@ export const useGenerationOrchestratorManagerStore = defineStore('generation-orc
     reset,
   };
 });
+
+export type GenerationOrchestratorManagerStore = ReturnType<
+  typeof useGenerationOrchestratorManagerStore
+>;

--- a/tests/vue/composables/useGenerationOrchestratorManager.spec.ts
+++ b/tests/vue/composables/useGenerationOrchestratorManager.spec.ts
@@ -1,0 +1,222 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ref, type Ref } from 'vue';
+
+import { createUseGenerationOrchestratorManager } from '@/composables/generation/useGenerationOrchestratorManager';
+import { createGenerationOrchestratorFactory } from '@/composables/generation/createGenerationOrchestrator';
+import type { GenerationNotificationAdapter } from '@/composables/generation/useGenerationTransport';
+import type {
+  GenerationConnectionStore,
+  GenerationFormStore,
+  GenerationOrchestratorConsumer,
+  GenerationOrchestratorManagerStore,
+  GenerationQueueStore,
+  GenerationResultsStore,
+} from '@/stores/generation';
+import type { SettingsStore } from '@/stores';
+import type { GenerationOrchestrator } from '@/composables/generation/createGenerationOrchestrator';
+import type {
+  GenerationJob,
+  GenerationRequestPayload,
+  GenerationResult,
+  GenerationStartResponse,
+  SystemStatusState,
+} from '@/types';
+
+vi.mock('@/composables/generation/createGenerationOrchestrator', () => ({
+  createGenerationOrchestratorFactory: vi.fn(),
+}));
+
+vi.mock('@/services', () => ({}));
+
+const createOrchestratorMock = () => ({
+  initialize: vi.fn<[], Promise<void>>().mockResolvedValue(undefined),
+  cleanup: vi.fn<[], void>(),
+  loadSystemStatusData: vi.fn<[], Promise<void>>().mockResolvedValue(undefined),
+  loadActiveJobsData: vi.fn<[], Promise<void>>().mockResolvedValue(undefined),
+  loadRecentResultsData: vi
+    .fn<[boolean?], Promise<void>>()
+    .mockResolvedValue(undefined),
+  startGeneration: vi
+    .fn<[GenerationRequestPayload], Promise<GenerationStartResponse>>()
+    .mockResolvedValue({} as GenerationStartResponse),
+  cancelJob: vi.fn<[string], Promise<void>>().mockResolvedValue(undefined),
+  clearQueue: vi.fn<[], Promise<void>>().mockResolvedValue(undefined),
+  deleteResult: vi
+    .fn<[string | number], Promise<void>>()
+    .mockResolvedValue(undefined),
+});
+
+type OrchestratorMock = ReturnType<typeof createOrchestratorMock>;
+
+const createDependencies = () => {
+  const orchestratorManagerStore = {
+    orchestrator: ref<GenerationOrchestrator | null>(null),
+    initializationPromise: ref<Promise<void> | null>(null),
+    isInitialized: ref(false),
+    consumers: ref(new Map<symbol, GenerationOrchestratorConsumer>()),
+    ensureOrchestrator: vi.fn((factory: () => GenerationOrchestrator) => {
+      if (!orchestratorManagerStore.orchestrator.value) {
+        orchestratorManagerStore.orchestrator.value = factory();
+      }
+      return orchestratorManagerStore.orchestrator.value as GenerationOrchestrator;
+    }),
+    destroyOrchestrator: vi.fn(() => {
+      orchestratorManagerStore.orchestrator.value?.cleanup();
+      orchestratorManagerStore.orchestrator.value = null;
+      orchestratorManagerStore.initializationPromise.value = null;
+      orchestratorManagerStore.isInitialized.value = false;
+    }),
+    registerConsumer: vi.fn((consumer: GenerationOrchestratorConsumer) => {
+      orchestratorManagerStore.consumers.value.set(consumer.id, consumer);
+    }),
+    unregisterConsumer: vi.fn((id: symbol) => {
+      orchestratorManagerStore.consumers.value.delete(id);
+    }),
+  } satisfies Partial<GenerationOrchestratorManagerStore> & {
+    orchestrator: Ref<GenerationOrchestrator | null>;
+    initializationPromise: Ref<Promise<void> | null>;
+    isInitialized: Ref<boolean>;
+    consumers: Ref<Map<symbol, GenerationOrchestratorConsumer>>;
+  };
+
+  const queueStore = {
+    activeJobs: ref<GenerationJob[]>([]),
+    sortedActiveJobs: ref<GenerationJob[]>([]),
+    hasActiveJobs: ref(false),
+    ingestQueue: vi.fn(),
+    handleProgressMessage: vi.fn(),
+    handleCompletionMessage: vi.fn<(message: unknown) => GenerationResult>().mockReturnValue({} as GenerationResult),
+    handleErrorMessage: vi.fn(),
+    enqueueJob: vi.fn(),
+    removeJob: vi.fn(),
+    getCancellableJobs: vi.fn<[], GenerationJob[]>().mockReturnValue([]),
+    isJobCancellable: vi.fn<(job: GenerationJob) => boolean>().mockReturnValue(true),
+  } satisfies Partial<GenerationQueueStore> & {
+    activeJobs: Ref<GenerationJob[]>;
+    sortedActiveJobs: Ref<GenerationJob[]>;
+    hasActiveJobs: Ref<boolean>;
+  };
+
+  const resultsStore = {
+    recentResults: ref<GenerationResult[]>([]),
+    historyLimit: ref(5),
+    addResult: vi.fn(),
+    setResults: vi.fn(),
+    removeResult: vi.fn(),
+    setHistoryLimit: vi.fn(),
+  } satisfies Partial<GenerationResultsStore> & {
+    recentResults: Ref<GenerationResult[]>;
+    historyLimit: Ref<number>;
+  };
+
+  const connectionStore = {
+    systemStatus: ref<SystemStatusState>({} as SystemStatusState),
+    isConnected: ref(false),
+    pollIntervalMs: ref(1000),
+    applySystemStatusPayload: vi.fn(),
+    setConnectionState: vi.fn(),
+    setQueueManagerActive: vi.fn(),
+  } satisfies Partial<GenerationConnectionStore> & {
+    systemStatus: Ref<SystemStatusState>;
+    isConnected: Ref<boolean>;
+    pollIntervalMs: Ref<number>;
+  };
+
+  const formStore = {
+    showHistory: ref(false),
+  } satisfies Partial<GenerationFormStore> & {
+    showHistory: Ref<boolean>;
+  };
+
+  const settingsStore = {
+    backendUrl: 'http://localhost',
+  } satisfies Partial<SettingsStore> & { backendUrl: string };
+
+  return {
+    orchestratorManagerStore,
+    queueStore,
+    resultsStore,
+    connectionStore,
+    formStore,
+    settingsStore,
+    dependencies: {
+      useGenerationOrchestratorManagerStore: () =>
+        orchestratorManagerStore as GenerationOrchestratorManagerStore,
+      useGenerationQueueStore: () => queueStore as GenerationQueueStore,
+      useGenerationResultsStore: () => resultsStore as GenerationResultsStore,
+      useGenerationConnectionStore: () =>
+        connectionStore as GenerationConnectionStore,
+      useGenerationFormStore: () => formStore as GenerationFormStore,
+      useSettingsStore: () => settingsStore as SettingsStore,
+    },
+  };
+};
+
+const createBinding = () => {
+  const orchestrator: OrchestratorMock = createOrchestratorMock();
+  const createGenerationOrchestratorFactoryMock = vi.mocked(
+    createGenerationOrchestratorFactory,
+  );
+  let notificationAdapter: GenerationNotificationAdapter | null = null;
+  createGenerationOrchestratorFactoryMock.mockImplementation((options) => {
+    notificationAdapter = options.notificationAdapter;
+    return orchestrator as unknown as GenerationOrchestrator;
+  });
+
+  const stores = createDependencies();
+  const useManager = createUseGenerationOrchestratorManager(stores.dependencies);
+  const manager = useManager();
+  const notify = vi.fn();
+  const debug = vi.fn();
+  const binding = manager.acquire({ notify, debug });
+
+  return {
+    orchestrator,
+    binding,
+    notify,
+    debug,
+    stores,
+    notificationAdapter: notificationAdapter!,
+    factoryMock: createGenerationOrchestratorFactoryMock,
+  };
+};
+
+describe('createUseGenerationOrchestratorManager', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('initializes orchestrator once and updates manager state', async () => {
+    const { binding, orchestrator, stores } = createBinding();
+
+    await binding.initialize();
+    expect(orchestrator.initialize).toHaveBeenCalledTimes(1);
+    expect(stores.orchestratorManagerStore.isInitialized.value).toBe(true);
+
+    await binding.initialize();
+    expect(orchestrator.initialize).toHaveBeenCalledTimes(1);
+  });
+
+  it('cleans up last consumer and destroys orchestrator', () => {
+    const { binding, orchestrator, stores } = createBinding();
+
+    expect(stores.orchestratorManagerStore.consumers.value.size).toBe(1);
+
+    binding.cleanup();
+
+    expect(stores.orchestratorManagerStore.unregisterConsumer).toHaveBeenCalled();
+    expect(stores.orchestratorManagerStore.destroyOrchestrator).toHaveBeenCalled();
+    expect(orchestrator.cleanup).toHaveBeenCalled();
+    expect(stores.orchestratorManagerStore.consumers.value.size).toBe(0);
+  });
+
+  it('notifies all registered consumers through the aggregated adapter', () => {
+    const { notificationAdapter, notify, debug } = createBinding();
+
+    notificationAdapter.notify('hello', 'success');
+    expect(notify).toHaveBeenCalledWith('hello', 'success');
+
+    notificationAdapter.debug?.('details');
+    expect(debug).toHaveBeenCalledWith('details');
+  });
+});


### PR DESCRIPTION
## Summary
- add a factory for `useGenerationOrchestratorManager` so callers can inject custom store instances
- export the orchestrator manager store type for reuse in tests and consumers
- cover initialization, cleanup, and notification flows with new unit tests built on stub stores

## Testing
- npm run test:unit -- --run tests/vue/composables/useGenerationOrchestratorManager.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68db48ae52248329aa707bd7151d2dce