### PR TITLE
Refactor generation studio domain logic

### DIFF
--- a/app/frontend/src/composables/generation/index.ts
+++ b/app/frontend/src/composables/generation/index.ts
@@ -1,4 +1,5 @@
 export * from './useGenerationStudio';
+export * from './useGenerationStudioDomain';
 export * from './useGenerationStudioController';
 export * from './createGenerationOrchestrator';
 export * from './useGenerationTransport';

--- a/app/frontend/src/composables/generation/useGenerationStudio.ts
+++ b/app/frontend/src/composables/generation/useGenerationStudio.ts
@@ -2,7 +2,7 @@ import { computed, onMounted } from 'vue'
 
 import {
   useGenerationPersistence,
-  useGenerationStudioController,
+  useGenerationStudioDomain,
   useGenerationUI,
 } from '@/composables/generation'
 import { useDialogService, useNotifications } from '@/composables/shared'
@@ -53,11 +53,12 @@ export const useGenerationStudio = () => {
     showToast: notify,
   })
 
-  const controller = useGenerationStudioController({
+  const domain = useGenerationStudioDomain({
     params: uiParams,
     notify,
     debug: logDebug,
     onAfterStart: persistParams,
+    onAfterInitialize: loadParams,
   })
 
   const params = computed(() => uiParams.value)
@@ -66,17 +67,17 @@ export const useGenerationStudio = () => {
   const showModal = computed(() => showModalRef.value)
   const selectedResult = computed(() => selectedResultRef.value)
   const recentResults = computed(() => recentResultsRef.value)
-  const activeJobs = computed(() => controller.activeJobs.value)
-  const sortedActiveJobs = computed(() => controller.sortedActiveJobs.value)
-  const systemStatus = computed(() => controller.systemStatus.value)
-  const isConnected = computed(() => controller.isConnected.value)
+  const activeJobs = computed(() => domain.activeJobs.value)
+  const sortedActiveJobs = computed(() => domain.sortedActiveJobs.value)
+  const systemStatus = computed(() => domain.systemStatus.value)
+  const isConnected = computed(() => domain.isConnected.value)
 
   const startGeneration = async (): Promise<void> => {
-    await controller.startGeneration()
+    await domain.startGeneration()
   }
 
   const clearQueueWithConfirmation = async (): Promise<void> => {
-    if (controller.activeJobs.value.length === 0) {
+    if (domain.activeJobs.value.length === 0) {
       return
     }
 
@@ -91,7 +92,7 @@ export const useGenerationStudio = () => {
       return
     }
 
-    await controller.clearQueue()
+    await domain.clearQueue()
   }
 
   const deleteResult = async (resultId: string | number): Promise<void> => {
@@ -106,11 +107,11 @@ export const useGenerationStudio = () => {
       return
     }
 
-    await controller.deleteResult(resultId)
+    await domain.deleteResult(resultId)
   }
 
   const refreshResults = async (): Promise<void> => {
-    await controller.refreshResults(true)
+    await domain.refreshResults(true)
   }
 
   const updateParams = (value: GenerationFormState): void => {
@@ -123,8 +124,7 @@ export const useGenerationStudio = () => {
 
   onMounted(async () => {
     logDebug('Initializing Generation Studio composable...')
-    await controller.initialize()
-    loadParams()
+    await domain.initialize()
   })
 
   return {
@@ -139,7 +139,7 @@ export const useGenerationStudio = () => {
     sortedActiveJobs,
     isConnected,
     startGeneration,
-    cancelJob: controller.cancelJob,
+    cancelJob: domain.cancelJob,
     clearQueue: clearQueueWithConfirmation,
     refreshResults,
     loadFromComposer,
@@ -152,7 +152,7 @@ export const useGenerationStudio = () => {
     formatTime,
     getJobStatusClasses,
     getJobStatusText,
-    canCancelJob: controller.canCancelJob,
+    canCancelJob: domain.canCancelJob,
     getSystemStatusClasses,
     updateParams,
     toggleHistory,

--- a/app/frontend/src/composables/generation/useGenerationStudioDomain.ts
+++ b/app/frontend/src/composables/generation/useGenerationStudioDomain.ts
@@ -1,0 +1,54 @@
+import type { Ref } from 'vue'
+
+import { useGenerationStudioController } from './useGenerationStudioController'
+import type { GenerationFormState, NotificationType } from '@/types'
+
+export interface UseGenerationStudioDomainOptions {
+  params: Ref<GenerationFormState>
+  notify: (message: string, type?: NotificationType) => void
+  debug?: (...args: unknown[]) => void
+  onAfterStart?: (params: GenerationFormState) => void
+  onAfterInitialize?: () => void | Promise<void>
+}
+
+export const useGenerationStudioDomain = ({
+  params,
+  notify,
+  debug,
+  onAfterStart,
+  onAfterInitialize,
+}: UseGenerationStudioDomainOptions) => {
+  const controller = useGenerationStudioController({
+    params,
+    notify,
+    debug,
+    onAfterStart,
+  })
+
+  const initialize = async (): Promise<void> => {
+    await controller.initialize()
+    await onAfterInitialize?.()
+  }
+
+  const startGeneration = async (): Promise<boolean> => controller.startGeneration()
+
+  const refreshResults = async (notifySuccess?: boolean): Promise<void> =>
+    controller.refreshResults(notifySuccess)
+
+  return {
+    activeJobs: controller.activeJobs,
+    sortedActiveJobs: controller.sortedActiveJobs,
+    recentResults: controller.recentResults,
+    systemStatus: controller.systemStatus,
+    isConnected: controller.isConnected,
+    initialize,
+    startGeneration,
+    cancelJob: controller.cancelJob,
+    clearQueue: controller.clearQueue,
+    refreshResults,
+    deleteResult: controller.deleteResult,
+    canCancelJob: controller.canCancelJob,
+  }
+}
+
+export type UseGenerationStudioDomainReturn = ReturnType<typeof useGenerationStudioDomain>

--- a/tests/vue/composables/useGenerationStudioDomain.spec.ts
+++ b/tests/vue/composables/useGenerationStudioDomain.spec.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { ref } from 'vue'
+
+const controllerBindings = vi.hoisted(() => {
+  const { ref } = require('vue')
+
+  const controllerMock = {
+    activeJobs: ref([] as unknown[]),
+    sortedActiveJobs: ref([] as unknown[]),
+    recentResults: ref([] as unknown[]),
+    systemStatus: ref({ status: 'healthy' }),
+    isConnected: ref(true),
+    initialize: vi.fn(async () => {}),
+    startGeneration: vi.fn(async () => true),
+    cancelJob: vi.fn(async (_jobId: string) => {}),
+    clearQueue: vi.fn(async () => {}),
+    refreshResults: vi.fn(async (_notify?: boolean) => {}),
+    deleteResult: vi.fn(async (_resultId: string | number) => {}),
+    canCancelJob: vi.fn(() => true),
+  }
+
+  const controllerFactory = vi.fn(() => controllerMock)
+
+  return { controllerMock, controllerFactory }
+})
+
+vi.mock('@/composables/generation/useGenerationStudioController', () => ({
+  useGenerationStudioController: controllerBindings.controllerFactory,
+}))
+
+const controllerMock = controllerBindings.controllerMock
+const controllerFactory = controllerBindings.controllerFactory
+
+import { useGenerationStudioDomain } from '@/composables/generation/useGenerationStudioDomain'
+import type { GenerationFormState } from '@/types'
+
+const createParams = (): GenerationFormState => ({
+  prompt: 'test prompt',
+  negative_prompt: '',
+  sampler_name: 'Euler',
+  width: 512,
+  height: 512,
+  steps: 20,
+  cfg_scale: 7,
+  seed: 1,
+  batch_size: 1,
+  batch_count: 1,
+})
+
+describe('useGenerationStudioDomain', () => {
+  beforeEach(() => {
+    controllerFactory.mockClear()
+    Object.values(controllerMock).forEach((value) => {
+      if (typeof value === 'function' && 'mockClear' in value) {
+        ;(value as { mockClear: () => void }).mockClear()
+      }
+    })
+    controllerMock.activeJobs.value = []
+    controllerMock.sortedActiveJobs.value = []
+    controllerMock.recentResults.value = []
+    controllerMock.systemStatus.value = { status: 'healthy' }
+    controllerMock.isConnected.value = true
+  })
+
+  it('creates a controller binding without triggering side effects', () => {
+    const params = ref(createParams())
+    const notify = vi.fn()
+
+    useGenerationStudioDomain({
+      params,
+      notify,
+    })
+
+    expect(controllerFactory).toHaveBeenCalledWith(
+      expect.objectContaining({ params, notify }),
+    )
+    expect(controllerMock.initialize).not.toHaveBeenCalled()
+    expect(controllerMock.startGeneration).not.toHaveBeenCalled()
+  })
+
+  it('initializes the orchestrator when requested and triggers onAfterInitialize', async () => {
+    const params = ref(createParams())
+    const notify = vi.fn()
+    const afterInitialize = vi.fn()
+
+    const domain = useGenerationStudioDomain({
+      params,
+      notify,
+      onAfterInitialize: afterInitialize,
+    })
+
+    await domain.initialize()
+
+    expect(controllerMock.initialize).toHaveBeenCalledTimes(1)
+    expect(afterInitialize).toHaveBeenCalledTimes(1)
+  })
+
+  it('forwards queue actions to the controller', async () => {
+    const params = ref(createParams())
+    const notify = vi.fn()
+
+    const domain = useGenerationStudioDomain({
+      params,
+      notify,
+    })
+
+    await domain.startGeneration()
+    await domain.cancelJob('job-1')
+    await domain.clearQueue()
+    await domain.refreshResults(true)
+    await domain.deleteResult('result-1')
+
+    expect(controllerMock.startGeneration).toHaveBeenCalledTimes(1)
+    expect(controllerMock.cancelJob).toHaveBeenCalledWith('job-1')
+    expect(controllerMock.clearQueue).toHaveBeenCalledTimes(1)
+    expect(controllerMock.refreshResults).toHaveBeenCalledWith(true)
+    expect(controllerMock.deleteResult).toHaveBeenCalledWith('result-1')
+  })
+
+  it('exposes the reactive state provided by the controller', () => {
+    const params = ref(createParams())
+    const notify = vi.fn()
+
+    const domain = useGenerationStudioDomain({
+      params,
+      notify,
+    })
+
+    controllerMock.activeJobs.value = [{ id: 'job-123' }]
+    controllerMock.systemStatus.value = { status: 'degraded' }
+    controllerMock.isConnected.value = false
+
+    expect(domain.activeJobs.value).toEqual([{ id: 'job-123' }])
+    expect(domain.systemStatus.value).toEqual({ status: 'degraded' })
+    expect(domain.isConnected.value).toBe(false)
+    expect(domain.canCancelJob({ id: 'job-123' } as never)).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary
- add a headless `useGenerationStudioDomain` composable to encapsulate orchestrator lifecycle and queue management
- update `useGenerationStudio` to delegate domain responsibilities while leaving notifications, dialogs, and persistence wiring in place
- add focused unit coverage for the domain composable alongside the existing integration tests

## Testing
- npx vitest run tests/vue/composables/useGenerationStudio.integration.spec.ts tests/vue/composables/useGenerationStudioDomain.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68db4f5013388329b24ceb38fe115ae5