### PR TITLE
Use relative imports for generation composables

### DIFF
--- a/app/frontend/src/composables/generation/useGenerationStudio.ts
+++ b/app/frontend/src/composables/generation/useGenerationStudio.ts
@@ -1,10 +1,8 @@
 import { computed, onMounted } from 'vue'
 
-import {
-  useGenerationPersistence,
-  useGenerationStudioDomain,
-  useGenerationUI,
-} from '@/composables/generation'
+import { useGenerationPersistence } from './useGenerationPersistence'
+import { useGenerationStudioDomain } from './useGenerationStudioDomain'
+import { useGenerationUI } from './useGenerationUI'
 import { useDialogService, useNotifications } from '@/composables/shared'
 import { useGenerationFormStore } from '@/stores/generation'
 import type { GenerationFormState, NotificationType } from '@/types'

--- a/app/frontend/src/composables/generation/useGenerationStudioController.ts
+++ b/app/frontend/src/composables/generation/useGenerationStudioController.ts
@@ -4,7 +4,7 @@ import { toGenerationRequestPayload } from '@/services'
 import {
   useGenerationOrchestratorManager,
   type GenerationOrchestratorBinding,
-} from '@/composables/generation'
+} from './useGenerationOrchestratorManager'
 import { useGenerationFormStore } from '@/stores/generation'
 import type { GenerationFormState, NotificationType, GenerationJob } from '@/types'
 

--- a/app/frontend/src/composables/generation/useGenerationTransport.ts
+++ b/app/frontend/src/composables/generation/useGenerationTransport.ts
@@ -15,8 +15,8 @@ import type {
 } from '@/types';
 import type { GenerationJobInput } from '@/stores/generation';
 
-import { useGenerationQueueClient } from '@/composables/generation';
-import { useGenerationSocketBridge } from '@/composables/generation';
+import { useGenerationQueueClient } from './useGenerationQueueClient';
+import { useGenerationSocketBridge } from './useGenerationSocketBridge';
 
 export interface GenerationNotificationAdapter {
   notify(message: string, type?: NotificationType): void;

--- a/app/frontend/src/composables/generation/useJobQueue.ts
+++ b/app/frontend/src/composables/generation/useJobQueue.ts
@@ -12,8 +12,8 @@ import { normalizeJobStatus } from '@/utils/status';
 import { useNotifications } from '@/composables/shared';
 import type { UseNotificationsReturn } from '@/composables/shared';
 
-import { useJobQueueTransport } from '@/composables/generation';
-import { useJobQueuePolling } from '@/composables/generation';
+import { useJobQueueTransport } from './useJobQueueTransport';
+import { useJobQueuePolling } from './useJobQueuePolling';
 
 const DEFAULT_POLL_INTERVAL = 2000;
 

--- a/app/frontend/src/services/generation/index.ts
+++ b/app/frontend/src/services/generation/index.ts
@@ -2,3 +2,5 @@
 export * from './updates';
 export * from './generationService';
 export * from './validation';
+export * from './queueClient';
+export * from './websocketManager';


### PR DESCRIPTION
## Summary
- update generation-related composables to import local helpers via relative paths instead of the generation barrel
- keep the generation barrel available for external consumers by re-exporting queue and websocket helpers from the services index

## Testing
- npm run build
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dbc894b8d08329b0a111b7d817f403