### PR TITLE
Guard orchestrator operations on settings hydration

### DIFF
--- a/app/frontend/src/main.ts
+++ b/app/frontend/src/main.ts
@@ -18,16 +18,14 @@ const bootstrap = () => {
   app.use(pinia);
   app.use(router);
 
-  const settingsStore = useSettingsStore(pinia);
-  settingsStore
-    .loadSettings()
-    .catch((error) => {
-      if (import.meta.env.DEV) {
-        console.warn('Failed to preload frontend settings', error);
-      }
-    });
-
   app.mount('#app');
+
+  const settingsStore = useSettingsStore(pinia);
+  void settingsStore.loadSettings().catch((error) => {
+    if (import.meta.env.DEV) {
+      console.warn('Failed to preload frontend settings', error);
+    }
+  });
 };
 
 bootstrap();


### PR DESCRIPTION
## Summary
- mount the Vue app before kicking off the asynchronous settings load and log failures without delaying boot
- require the generation orchestrator manager to wait for frontend settings hydration before running backend-bound operations
- extend the orchestrator manager unit specs to cover the new hydration flow

## Testing
- npx vitest run tests/vue/App.spec.ts tests/vue/composables/useGenerationOrchestratorManager.spec.ts tests/vue/RecommendationsPanel.spec.js

------
https://chatgpt.com/codex/tasks/task_e_68dbd19c5e808329b80c177121235d75