### PR TITLE
Ensure settings load before mounting frontend

### DIFF
--- a/app/frontend/src/components/dashboard/DashboardGenerationSummary.vue
+++ b/app/frontend/src/components/dashboard/DashboardGenerationSummary.vue
@@ -105,13 +105,13 @@ import type {
   GenerationHistoryResult,
   GenerationHistoryStats,
 } from '@/types';
-import { useSettingsStore, waitForSettingsHydration } from '@/stores';
+import { useSettingsStore } from '@/stores';
 
 const SUMMARY_QUERY = Object.freeze({ page_size: 4, sort: 'created_at_desc' as const });
 
 const backendClient = useBackendClient();
 const settingsStore = useSettingsStore();
-const { isLoaded: settingsLoaded, backendUrl } = storeToRefs(settingsStore);
+const { backendUrl } = storeToRefs(settingsStore);
 const resultsStore = useGenerationResultsStore();
 const { recentResults: storeResults } = storeToRefs(resultsStore);
 
@@ -163,8 +163,6 @@ const refresh = async () => {
     return;
   }
 
-  await waitForSettingsHydration(settingsStore);
-
   isLoading.value = true;
   error.value = null;
 
@@ -188,18 +186,9 @@ onMounted(() => {
 });
 
 watch(
-  () => settingsLoaded.value,
-  (loaded) => {
-    if (loaded) {
-      void refresh();
-    }
-  },
-);
-
-watch(
   backendUrl,
   (next, previous) => {
-    if (next === previous || !settingsLoaded.value) {
+    if (next === previous) {
       return;
     }
 

--- a/app/frontend/src/components/recommendations/RecommendationsPanel.vue
+++ b/app/frontend/src/components/recommendations/RecommendationsPanel.vue
@@ -120,7 +120,6 @@ import { useRecommendationApi } from '@/composables/shared';
 import { useAdapterCatalogStore } from '@/stores';
 import type { AdapterSummary, RecommendationItem, RecommendationResponse } from '@/types';
 import { useBackendUrl } from '@/utils/backend';
-import { useSettingsStore, waitForSettingsHydration } from '@/stores';
 
 const WEIGHT_KEYS = ['semantic', 'artistic', 'technical'] as const;
 type WeightKey = (typeof WEIGHT_KEYS)[number];
@@ -143,9 +142,7 @@ const toErrorMessage = (error: unknown, fallback: string): string => {
 };
 
 const adapterCatalog = useAdapterCatalogStore();
-const settingsStore = useSettingsStore();
 const { adapters: catalogAdapters, error: lorasErr, isLoading: lorasLoading } = storeToRefs(adapterCatalog);
-const { isLoaded: settingsLoaded } = storeToRefs(settingsStore);
 
 void adapterCatalog.ensureLoaded({ perPage: 200 });
 
@@ -219,8 +216,6 @@ const fetchRecommendations = async (): Promise<void> => {
     return;
   }
 
-  await waitForSettingsHydration(settingsStore);
-
   if (!recommendationUrl.value) {
     recsError.value = 'Unable to resolve recommendation endpoint.';
     return;
@@ -252,23 +247,13 @@ watch(selectedLoraId, (nextId) => {
 });
 
 onMounted(async () => {
-  await waitForSettingsHydration(settingsStore);
   await adapterCatalog.ensureLoaded({ perPage: 200 });
 });
 
 watch([selectedLoraId, limit, similarityThreshold], () => {
-  if (selectedLora.value && settingsLoaded.value) {
+  if (selectedLora.value) {
     void fetchRecommendations();
   }
 });
-
-watch(
-  () => settingsLoaded.value,
-  (loaded) => {
-    if (loaded && selectedLora.value) {
-      void fetchRecommendations();
-    }
-  },
-);
 
 </script>

--- a/app/frontend/src/composables/generation/useGenerationOrchestratorManager.ts
+++ b/app/frontend/src/composables/generation/useGenerationOrchestratorManager.ts
@@ -18,7 +18,7 @@ import {
   useGenerationOrchestratorManagerStore,
   type GenerationOrchestratorConsumer,
 } from '@/stores/generation';
-import { useSettingsStore, waitForSettingsHydration } from '@/stores';
+import { useSettingsStore } from '@/stores';
 import type {
   GenerationJob,
   GenerationRequestPayload,
@@ -45,7 +45,6 @@ export interface UseGenerationOrchestratorManagerDependencies {
     typeof useGenerationConnectionStore
   >;
   useSettingsStore: () => ReturnType<typeof useSettingsStore>;
-  waitForSettingsHydration: typeof waitForSettingsHydration;
 }
 
 const defaultDependencies: UseGenerationOrchestratorManagerDependencies = {
@@ -55,7 +54,6 @@ const defaultDependencies: UseGenerationOrchestratorManagerDependencies = {
   useGenerationResultsStore,
   useGenerationConnectionStore,
   useSettingsStore,
-  waitForSettingsHydration,
 };
 
 export interface GenerationOrchestratorBinding {
@@ -131,21 +129,6 @@ export const createUseGenerationOrchestratorManager = (
   const { pollIntervalMs, systemStatus, isConnected } = storeToRefs(connectionStore);
   const { activeJobs, sortedActiveJobs } = storeToRefs(queueStore);
 
-  const ensureSettingsHydrated = async (): Promise<void> => {
-    await dependencies.waitForSettingsHydration(settingsStore);
-  };
-
-  const callWithSettings = async <T>(operation: () => Promise<T>): Promise<T> => {
-    await ensureSettingsHydrated();
-    return operation();
-  };
-
-  const wrapWithSettings = <Args extends unknown[], T>(
-    operation: (...args: Args) => Promise<T>,
-  ) =>
-    (...args: Args): Promise<T> =>
-      callWithSettings(() => operation(...args));
-
   const notifyAll: GenerationNotificationAdapter['notify'] = (
     message,
     type: Parameters<GenerationNotificationAdapter['notify']>[1] = 'info',
@@ -185,8 +168,6 @@ export const createUseGenerationOrchestratorManager = (
     if (isInitialized.value) {
       return;
     }
-
-    await ensureSettingsHydrated();
 
     const orchestrator = orchestratorRef.value;
 
@@ -242,16 +223,18 @@ export const createUseGenerationOrchestratorManager = (
 
     const orchestrator = ensureOrchestrator(options);
 
-    const loadSystemStatusData = wrapWithSettings(orchestrator.loadSystemStatusData);
-    const loadActiveJobsData = wrapWithSettings(orchestrator.loadActiveJobsData);
-    const loadRecentResultsData = wrapWithSettings(orchestrator.loadRecentResultsData);
-    const startGeneration = wrapWithSettings(orchestrator.startGeneration);
-    const cancelJob = wrapWithSettings(orchestrator.cancelJob);
-    const clearQueue = wrapWithSettings(orchestrator.clearQueue);
-    const deleteResult = wrapWithSettings(orchestrator.deleteResult);
-    const refreshResults = wrapWithSettings((notifySuccess = false) =>
-      orchestrator.loadRecentResultsData(notifySuccess),
-    );
+    const loadSystemStatusData = (): Promise<void> => orchestrator.loadSystemStatusData();
+    const loadActiveJobsData = (): Promise<void> => orchestrator.loadActiveJobsData();
+    const loadRecentResultsData = (notifySuccess?: boolean): Promise<void> =>
+      orchestrator.loadRecentResultsData(notifySuccess);
+    const startGeneration = (payload: GenerationRequestPayload): Promise<GenerationStartResponse> =>
+      orchestrator.startGeneration(payload);
+    const cancelJob = (jobId: string): Promise<void> => orchestrator.cancelJob(jobId);
+    const clearQueue = (): Promise<void> => orchestrator.clearQueue();
+    const deleteResult = (resultId: string | number): Promise<void> =>
+      orchestrator.deleteResult(resultId);
+    const refreshResults = (notifySuccess = false): Promise<void> =>
+      orchestrator.loadRecentResultsData(notifySuccess);
 
     const initialize = async (): Promise<void> => {
       await ensureInitialized();

--- a/app/frontend/src/main.ts
+++ b/app/frontend/src/main.ts
@@ -11,21 +11,24 @@ import './assets/css/loading-animations.css';
 import './assets/css/accessibility.css';
 import 'vue-virtual-scroller/dist/vue-virtual-scroller.css';
 
-const bootstrap = () => {
+const bootstrap = async () => {
   const app = createApp(App);
   const pinia = createPinia();
 
   app.use(pinia);
   app.use(router);
 
-  app.mount('#app');
-
   const settingsStore = useSettingsStore(pinia);
-  void settingsStore.loadSettings().catch((error) => {
+
+  try {
+    await settingsStore.loadSettings();
+  } catch (error) {
     if (import.meta.env.DEV) {
       console.warn('Failed to preload frontend settings', error);
     }
-  });
+  }
+
+  app.mount('#app');
 };
 
-bootstrap();
+void bootstrap();

--- a/app/frontend/src/stores/adapterCatalog.ts
+++ b/app/frontend/src/stores/adapterCatalog.ts
@@ -3,7 +3,7 @@ import { defineStore, storeToRefs } from 'pinia';
 
 import { ApiError } from '@/composables/shared';
 import { fetchAdapterList, fetchAdapterTags, performBulkLoraAction, useBackendClient } from '@/services';
-import { useSettingsStore, waitForSettingsHydration } from '@/stores/settings';
+import { useSettingsStore } from '@/stores/settings';
 
 import type {
   AdapterRead,
@@ -57,7 +57,7 @@ export const useAdapterCatalogStore = defineStore('adapterCatalog', () => {
   const isLoading = ref(false);
 
   const settingsStore = useSettingsStore();
-  const { backendUrl, isLoaded: settingsLoaded } = storeToRefs(settingsStore);
+  const { backendUrl } = storeToRefs(settingsStore);
 
   const backendClient = useBackendClient();
   const query = reactive<AdapterListQuery>({ ...DEFAULT_QUERY });
@@ -129,8 +129,6 @@ export const useAdapterCatalogStore = defineStore('adapterCatalog', () => {
     const requestQuery: AdapterListQuery = { ...query, ...overrides };
 
     const request = (async () => {
-      await waitForSettingsHydration(settingsStore);
-
       isLoading.value = true;
       lastError.value = null;
 
@@ -185,7 +183,6 @@ export const useAdapterCatalogStore = defineStore('adapterCatalog', () => {
     }
 
     const request = (async () => {
-      await waitForSettingsHydration(settingsStore);
       try {
         const tags = await fetchAdapterTags(backendClient);
         availableTags.value = tags;
@@ -221,8 +218,6 @@ export const useAdapterCatalogStore = defineStore('adapterCatalog', () => {
       return;
     }
 
-    await waitForSettingsHydration(settingsStore);
-
     await performBulkLoraAction({
       action,
       lora_ids: loraIds,
@@ -249,10 +244,6 @@ export const useAdapterCatalogStore = defineStore('adapterCatalog', () => {
     backendUrl,
     (next, previous) => {
       if (next === previous) {
-        return;
-      }
-
-      if (!settingsLoaded.value) {
         return;
       }
 

--- a/app/frontend/src/stores/adminMetrics.ts
+++ b/app/frontend/src/stores/adminMetrics.ts
@@ -15,7 +15,7 @@ import {
   mergeStatusLevels,
   normaliseStatus,
 } from '@/utils/systemMetrics';
-import { useSettingsStore, waitForSettingsHydration } from '@/stores/settings';
+import { useSettingsStore } from '@/stores/settings';
 
 import type {
   DashboardStatsSummary,
@@ -30,7 +30,7 @@ interface RefreshOptions {
 
 export const useAdminMetricsStore = defineStore('adminMetrics', () => {
   const settingsStore = useSettingsStore();
-  const { backendUrl, isLoaded: settingsLoaded } = storeToRefs(settingsStore);
+  const { backendUrl } = storeToRefs(settingsStore);
   const backendClient = useBackendClient();
 
   const summary = ref<DashboardStatsSummary | null>(null);
@@ -79,7 +79,6 @@ export const useAdminMetricsStore = defineStore('adminMetrics', () => {
     }
 
     try {
-      await waitForSettingsHydration(settingsStore);
       const payload = await fetchDashboardStats(backendClient);
       applySummary(payload);
     } catch (err) {
@@ -116,7 +115,7 @@ export const useAdminMetricsStore = defineStore('adminMetrics', () => {
   watch(
     backendUrl,
     (next, previous) => {
-      if (next === previous || !settingsLoaded.value) {
+      if (next === previous) {
         return;
       }
 

--- a/app/frontend/src/stores/performanceAnalytics.ts
+++ b/app/frontend/src/stores/performanceAnalytics.ts
@@ -8,7 +8,7 @@ import {
   useBackendClient,
 } from '@/services';
 import { formatDuration as formatDurationLabel } from '@/utils/format';
-import { useSettingsStore, waitForSettingsHydration } from '@/stores/settings';
+import { useSettingsStore } from '@/stores/settings';
 
 import type {
   ErrorAnalysisEntry,
@@ -83,7 +83,7 @@ const createDevTopLoras = (): TopLoraPerformance[] => [
 
 export const usePerformanceAnalyticsStore = defineStore('performanceAnalytics', () => {
   const settingsStore = useSettingsStore();
-  const { backendUrl, isLoaded: settingsLoaded } = storeToRefs(settingsStore);
+  const { backendUrl } = storeToRefs(settingsStore);
   const backendClient = useBackendClient();
 
   const timeRange = ref<PerformanceTimeRange>('24h');
@@ -173,7 +173,6 @@ export const usePerformanceAnalyticsStore = defineStore('performanceAnalytics', 
 
     isLoading.value = true;
     try {
-      await waitForSettingsHydration(settingsStore);
       await loadAnalyticsSummary();
       await loadTopLoras();
       hasLoaded.value = true;
@@ -221,7 +220,7 @@ export const usePerformanceAnalyticsStore = defineStore('performanceAnalytics', 
   watch(
     backendUrl,
     (next, previous) => {
-      if (next === previous || !settingsLoaded.value) {
+      if (next === previous) {
         return;
       }
 

--- a/app/frontend/src/stores/settings.ts
+++ b/app/frontend/src/stores/settings.ts
@@ -1,6 +1,4 @@
 import { defineStore } from 'pinia';
-import { watch } from 'vue';
-
 import { runtimeConfig } from '@/config/runtime';
 import type { FrontendRuntimeSettings, SettingsState } from '@/types';
 
@@ -146,44 +144,6 @@ export const tryGetSettingsStore = (): SettingsStore | null => {
   } catch (_error) {
     return null;
   }
-};
-
-export const waitForSettingsHydration = async (
-  store: SettingsStore | null | undefined = tryGetSettingsStore(),
-): Promise<void> => {
-  const target = store ?? tryGetSettingsStore();
-  if (!target) {
-    return;
-  }
-
-  if (target.isLoaded) {
-    return;
-  }
-
-  if (!target.isLoading) {
-    void target.loadSettings().catch((error) => {
-      if (import.meta.env.DEV) {
-        console.warn('Failed to hydrate frontend settings during wait', error);
-      }
-    });
-  }
-
-  await new Promise<void>((resolve) => {
-    const stop = watch(
-      () => ({
-        loaded: target.isLoaded,
-        loading: target.isLoading,
-        error: target.error,
-      }),
-      ({ loaded, loading, error }) => {
-        if (loaded || (!loading && error)) {
-          stop();
-          resolve();
-        }
-      },
-      { immediate: true, deep: false },
-    );
-  });
 };
 
 export const getResolvedBackendSettings = (): {

--- a/tests/vue/composables/useGenerationOrchestratorManager.spec.ts
+++ b/tests/vue/composables/useGenerationOrchestratorManager.spec.ts
@@ -135,13 +135,6 @@ const createDependencies = () => {
     backendUrl: 'http://localhost',
   } satisfies Partial<SettingsStore> & { backendUrl: string };
 
-  const waitForSettingsHydrationMock = vi
-    .fn<
-      Parameters<UseGenerationOrchestratorManagerDependencies['waitForSettingsHydration']>,
-      ReturnType<UseGenerationOrchestratorManagerDependencies['waitForSettingsHydration']>
-    >()
-    .mockResolvedValue(undefined);
-
   return {
     orchestratorManagerStore,
     queueStore,
@@ -149,7 +142,6 @@ const createDependencies = () => {
     connectionStore,
     formStore,
     settingsStore,
-    waitForSettingsHydrationMock,
     dependencies: {
       useGenerationOrchestratorManagerStore: () =>
         orchestratorManagerStore as GenerationOrchestratorManagerStore,
@@ -159,7 +151,6 @@ const createDependencies = () => {
         connectionStore as GenerationConnectionStore,
       useGenerationFormStore: () => formStore as GenerationFormStore,
       useSettingsStore: () => settingsStore as SettingsStore,
-      waitForSettingsHydration: waitForSettingsHydrationMock,
     },
   };
 };
@@ -204,11 +195,8 @@ describe('createUseGenerationOrchestratorManager', () => {
     await binding.initialize();
     expect(orchestrator.initialize).toHaveBeenCalledTimes(1);
     expect(stores.orchestratorManagerStore.isInitialized.value).toBe(true);
-    expect(stores.waitForSettingsHydrationMock).toHaveBeenCalledTimes(1);
-
     await binding.initialize();
     expect(orchestrator.initialize).toHaveBeenCalledTimes(1);
-    expect(stores.waitForSettingsHydrationMock).toHaveBeenCalledTimes(1);
   });
 
   it('cleans up last consumer and destroys orchestrator', () => {
@@ -234,7 +222,7 @@ describe('createUseGenerationOrchestratorManager', () => {
     expect(debug).toHaveBeenCalledWith('details');
   });
 
-  it('waits for settings hydration before orchestrator operations', async () => {
+  it('delegates orchestrator operations for consumers', async () => {
     const { binding, orchestrator, stores } = createBinding();
 
     await binding.initialize();
@@ -242,7 +230,6 @@ describe('createUseGenerationOrchestratorManager', () => {
     await binding.startGeneration({} as GenerationRequestPayload);
     await binding.refreshResults(true);
 
-    expect(stores.waitForSettingsHydrationMock).toHaveBeenCalledTimes(4);
     expect(orchestrator.loadSystemStatusData).toHaveBeenCalledTimes(1);
     expect(orchestrator.startGeneration).toHaveBeenCalledTimes(1);
     expect(orchestrator.loadRecentResultsData).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
## Summary
- refactor the SPA bootstrap to await settings loading and keep the app mounting resilient to failures
- remove redundant settings hydration guards from generation, analytics, and catalog stores/components now that hydration is guaranteed
- update the orchestrator manager tests to match the streamlined initialization flow

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dbd8f991b0832984b2328a61cd61c0