### PR TITLE
feat: separate generation studio ui state handling

### DIFF
--- a/app/frontend/src/features/generation/composables/useGenerationOrchestratorManager.ts
+++ b/app/frontend/src/features/generation/composables/useGenerationOrchestratorManager.ts
@@ -12,10 +12,10 @@ import type {
 } from '@/services';
 import {
   useGenerationConnectionStore,
-  useGenerationFormStore,
   useGenerationQueueStore,
   useGenerationResultsStore,
   useGenerationOrchestratorManagerStore,
+  useGenerationStudioUiStore,
   type GenerationOrchestratorConsumer,
 } from '@/features/generation';
 import { useSettingsStore } from '@/stores';
@@ -38,7 +38,7 @@ export interface UseGenerationOrchestratorManagerDependencies {
   useGenerationOrchestratorManagerStore: () => ReturnType<
     typeof useGenerationOrchestratorManagerStore
   >;
-  useGenerationFormStore: () => ReturnType<typeof useGenerationFormStore>;
+  useGenerationStudioUiStore: () => ReturnType<typeof useGenerationStudioUiStore>;
   useGenerationQueueStore: () => ReturnType<typeof useGenerationQueueStore>;
   useGenerationResultsStore: () => ReturnType<typeof useGenerationResultsStore>;
   useGenerationConnectionStore: () => ReturnType<
@@ -49,7 +49,7 @@ export interface UseGenerationOrchestratorManagerDependencies {
 
 const defaultDependencies: UseGenerationOrchestratorManagerDependencies = {
   useGenerationOrchestratorManagerStore,
-  useGenerationFormStore,
+  useGenerationStudioUiStore,
   useGenerationQueueStore,
   useGenerationResultsStore,
   useGenerationConnectionStore,
@@ -117,13 +117,13 @@ export const createUseGenerationOrchestratorManager = (
     consumers,
   } = storeToRefs(orchestratorManagerStore);
 
-  const formStore = dependencies.useGenerationFormStore();
+  const uiStore = dependencies.useGenerationStudioUiStore();
   const queueStore = dependencies.useGenerationQueueStore();
   const resultsStore = dependencies.useGenerationResultsStore();
   const connectionStore = dependencies.useGenerationConnectionStore();
   const settingsStore = dependencies.useSettingsStore();
 
-  const { showHistory } = storeToRefs(formStore);
+  const { showHistory } = storeToRefs(uiStore);
   const { backendUrl: configuredBackendUrl } = storeToRefs(settingsStore);
   const { historyLimit, recentResults } = storeToRefs(resultsStore);
   const { pollIntervalMs, systemStatus, isConnected } = storeToRefs(connectionStore);

--- a/app/frontend/src/features/generation/composables/useGenerationStudio.ts
+++ b/app/frontend/src/features/generation/composables/useGenerationStudio.ts
@@ -38,6 +38,7 @@ export const useGenerationStudio = () => {
     getJobStatusClasses,
     getJobStatusText,
     getSystemStatusClasses,
+    toggleHistory,
   } = useGenerationUI({ notify })
 
   const {
@@ -114,10 +115,6 @@ export const useGenerationStudio = () => {
 
   const updateParams = (value: GenerationFormState): void => {
     formStore.updateParams(value)
-  }
-
-  const toggleHistory = (): void => {
-    formStore.toggleHistory()
   }
 
   onMounted(async () => {

--- a/app/frontend/src/features/generation/composables/useGenerationUI.ts
+++ b/app/frontend/src/features/generation/composables/useGenerationUI.ts
@@ -1,6 +1,10 @@
 import { storeToRefs } from 'pinia'
 
-import { useGenerationFormStore, useGenerationResultsStore } from '@/features/generation'
+import {
+  useGenerationFormStore,
+  useGenerationResultsStore,
+  useGenerationStudioUiStore,
+} from '@/features/generation'
 import type { GenerationResult, NotificationType } from '@/types'
 
 const STATUS_CLASS_MAP = {
@@ -23,9 +27,11 @@ export interface UseGenerationUIOptions {
 
 export const useGenerationUI = ({ notify }: UseGenerationUIOptions) => {
   const formStore = useGenerationFormStore()
+  const uiStore = useGenerationStudioUiStore()
   const resultsStore = useGenerationResultsStore()
 
-  const { params, isGenerating, showHistory, showModal, selectedResult } = storeToRefs(formStore)
+  const { params, isGenerating } = storeToRefs(formStore)
+  const { showHistory, showModal, selectedResult } = storeToRefs(uiStore)
   const { recentResults } = storeToRefs(resultsStore)
 
   const showImageModal = (result: GenerationResult | null): void => {
@@ -33,11 +39,11 @@ export const useGenerationUI = ({ notify }: UseGenerationUIOptions) => {
       return
     }
 
-    formStore.selectResult(result)
+    uiStore.selectResult(result)
   }
 
   const hideImageModal = (): void => {
-    formStore.setShowModal(false)
+    uiStore.setShowModal(false)
   }
 
   const reuseParameters = (result: GenerationResult): void => {
@@ -96,6 +102,8 @@ export const useGenerationUI = ({ notify }: UseGenerationUIOptions) => {
     getJobStatusClasses,
     getJobStatusText,
     getSystemStatusClasses,
+    toggleHistory: uiStore.toggleHistory,
+    setShowHistory: uiStore.setShowHistory,
   }
 }
 

--- a/app/frontend/src/features/generation/stores/form.ts
+++ b/app/frontend/src/features/generation/stores/form.ts
@@ -56,32 +56,9 @@ const extractParamsFromResult = (
 export const useGenerationFormStore = defineStore('generation-form', () => {
   const params = ref<GenerationFormState>(createInitialParams());
   const isGenerating = ref(false);
-  const showHistory = ref(false);
-  const showModal = ref(false);
-  const selectedResult = ref<GenerationResult | null>(null);
 
   const setGenerating = (value: boolean): void => {
     isGenerating.value = value;
-  };
-
-  const setShowHistory = (value: boolean): void => {
-    showHistory.value = value;
-  };
-
-  const toggleHistory = (): void => {
-    showHistory.value = !showHistory.value;
-  };
-
-  const setShowModal = (value: boolean): void => {
-    showModal.value = value;
-    if (!value) {
-      selectedResult.value = null;
-    }
-  };
-
-  const selectResult = (result: GenerationResult | null): void => {
-    selectedResult.value = result;
-    showModal.value = result != null;
   };
 
   const updateParams = (updates: Partial<GenerationFormState>): void => {
@@ -138,22 +115,12 @@ export const useGenerationFormStore = defineStore('generation-form', () => {
   const reset = (): void => {
     resetParams();
     isGenerating.value = false;
-    showHistory.value = false;
-    showModal.value = false;
-    selectedResult.value = null;
   };
 
   return {
     params,
     isGenerating,
-    showHistory,
-    showModal,
-    selectedResult,
     setGenerating,
-    setShowHistory,
-    toggleHistory,
-    setShowModal,
-    selectResult,
     applyResultParameters,
     updateParams,
     setPrompt,

--- a/app/frontend/src/features/generation/stores/index.ts
+++ b/app/frontend/src/features/generation/stores/index.ts
@@ -4,3 +4,4 @@ export * from './connection';
 export * from './form';
 export * from './systemStatusController';
 export * from './orchestratorManagerStore';
+export * from './ui';

--- a/app/frontend/src/features/generation/stores/ui.ts
+++ b/app/frontend/src/features/generation/stores/ui.ts
@@ -1,0 +1,50 @@
+import { ref } from 'vue'
+import { defineStore } from 'pinia'
+
+import type { GenerationResult } from '@/types'
+
+export const useGenerationStudioUiStore = defineStore('generation-studio-ui', () => {
+  const showHistory = ref(false)
+  const showModal = ref(false)
+  const selectedResult = ref<GenerationResult | null>(null)
+
+  const setShowHistory = (value: boolean): void => {
+    showHistory.value = value
+  }
+
+  const toggleHistory = (): void => {
+    showHistory.value = !showHistory.value
+  }
+
+  const setShowModal = (value: boolean): void => {
+    showModal.value = value
+
+    if (!value) {
+      selectedResult.value = null
+    }
+  }
+
+  const selectResult = (result: GenerationResult | null): void => {
+    selectedResult.value = result
+    showModal.value = result != null
+  }
+
+  const reset = (): void => {
+    showHistory.value = false
+    showModal.value = false
+    selectedResult.value = null
+  }
+
+  return {
+    showHistory,
+    showModal,
+    selectedResult,
+    setShowHistory,
+    toggleHistory,
+    setShowModal,
+    selectResult,
+    reset,
+  }
+})
+
+export type GenerationStudioUiStore = ReturnType<typeof useGenerationStudioUiStore>

--- a/tests/vue/GenerationStudio.spec.js
+++ b/tests/vue/GenerationStudio.spec.js
@@ -12,6 +12,7 @@ import {
   useGenerationFormStore,
   useGenerationQueueStore,
   useGenerationResultsStore,
+  useGenerationStudioUiStore,
 } from '../../app/frontend/src/stores/generation'
 import { PERSISTENCE_KEYS } from '../../app/frontend/src/composables/shared/usePersistence'
 
@@ -143,6 +144,7 @@ describe('GenerationStudio.vue', () => {
   let resultsStore
   let connectionStore
   let formStore
+  let uiStore
 
   beforeEach(() => {
     vi.clearAllMocks()
@@ -152,10 +154,12 @@ describe('GenerationStudio.vue', () => {
     resultsStore = useGenerationResultsStore()
     connectionStore = useGenerationConnectionStore()
     formStore = useGenerationFormStore()
+    uiStore = useGenerationStudioUiStore()
     queueStore.reset()
     resultsStore.reset()
     connectionStore.reset()
     formStore.reset()
+    uiStore.reset()
     localStorageMock.getItem.mockReturnValue(null)
     controllerMocks.activeJobs.value = []
     controllerMocks.sortedActiveJobs.value = []

--- a/tests/vue/composables/useGenerationOrchestratorManager.spec.ts
+++ b/tests/vue/composables/useGenerationOrchestratorManager.spec.ts
@@ -9,11 +9,11 @@ import { createGenerationOrchestratorFactory } from '@/composables/generation/cr
 import type { GenerationNotificationAdapter } from '@/composables/generation/useGenerationTransport';
 import type {
   GenerationConnectionStore,
-  GenerationFormStore,
   GenerationOrchestratorConsumer,
   GenerationOrchestratorManagerStore,
   GenerationQueueStore,
   GenerationResultsStore,
+  GenerationStudioUiStore,
 } from '@/stores/generation';
 import type { SettingsStore } from '@/stores';
 import type { GenerationOrchestrator } from '@/composables/generation/createGenerationOrchestrator';
@@ -125,9 +125,9 @@ const createDependencies = () => {
     pollIntervalMs: Ref<number>;
   };
 
-  const formStore = {
+  const uiStore = {
     showHistory: ref(false),
-  } satisfies Partial<GenerationFormStore> & {
+  } satisfies Partial<GenerationStudioUiStore> & {
     showHistory: Ref<boolean>;
   };
 
@@ -140,7 +140,7 @@ const createDependencies = () => {
     queueStore,
     resultsStore,
     connectionStore,
-    formStore,
+    uiStore,
     settingsStore,
     dependencies: {
       useGenerationOrchestratorManagerStore: () =>
@@ -149,7 +149,7 @@ const createDependencies = () => {
       useGenerationResultsStore: () => resultsStore as GenerationResultsStore,
       useGenerationConnectionStore: () =>
         connectionStore as GenerationConnectionStore,
-      useGenerationFormStore: () => formStore as GenerationFormStore,
+      useGenerationStudioUiStore: () => uiStore as GenerationStudioUiStore,
       useSettingsStore: () => settingsStore as SettingsStore,
     },
   };

--- a/tests/vue/stores/generationStudioUiStore.spec.ts
+++ b/tests/vue/stores/generationStudioUiStore.spec.ts
@@ -1,0 +1,42 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import { createPinia, setActivePinia } from 'pinia'
+
+import { useGenerationStudioUiStore } from '@/stores/generation'
+import type { GenerationResult } from '@/types'
+
+describe('generation studio ui store', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  it('tracks modal visibility alongside the selected result', () => {
+    const store = useGenerationStudioUiStore()
+    const result = { id: '1' } as unknown as GenerationResult
+
+    expect(store.showModal).toBe(false)
+    expect(store.selectedResult).toBeNull()
+
+    store.selectResult(result)
+
+    expect(store.showModal).toBe(true)
+    expect(store.selectedResult).toBe(result)
+
+    store.setShowModal(false)
+
+    expect(store.showModal).toBe(false)
+    expect(store.selectedResult).toBeNull()
+  })
+
+  it('resets ui state independently from form data', () => {
+    const store = useGenerationStudioUiStore()
+
+    store.setShowHistory(true)
+    store.selectResult({ id: '2' } as unknown as GenerationResult)
+
+    store.reset()
+
+    expect(store.showHistory).toBe(false)
+    expect(store.showModal).toBe(false)
+    expect(store.selectedResult).toBeNull()
+  })
+})

--- a/tests/vue/useGenerationUI.spec.ts
+++ b/tests/vue/useGenerationUI.spec.ts
@@ -2,13 +2,18 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createPinia, setActivePinia, storeToRefs } from 'pinia'
 
 import { useGenerationUI } from '@/composables/generation/useGenerationUI'
-import { useGenerationFormStore, useGenerationResultsStore } from '@/stores/generation'
+import {
+  useGenerationFormStore,
+  useGenerationResultsStore,
+  useGenerationStudioUiStore,
+} from '@/stores/generation'
 import type { GenerationResult } from '@/types'
 
 describe('useGenerationUI', () => {
   beforeEach(() => {
     setActivePinia(createPinia())
     useGenerationFormStore().reset()
+    useGenerationStudioUiStore().reset()
     useGenerationResultsStore().reset()
   })
 
@@ -31,8 +36,8 @@ describe('useGenerationUI', () => {
 
   it('clears the modal when hiding image modal', () => {
     const notify = vi.fn()
-    const formStore = useGenerationFormStore()
-    const { showModal, selectedResult } = storeToRefs(formStore)
+    const uiStore = useGenerationStudioUiStore()
+    const { showModal, selectedResult } = storeToRefs(uiStore)
     const ui = useGenerationUI({ notify })
 
     const result = {


### PR DESCRIPTION
## Summary
- add a dedicated generation studio UI store to track modal and history state independently from form parameters
- update generation UI/studio composables and orchestrator manager to use the new UI store while keeping form updates in the form store
- adjust unit tests and add coverage for the new UI store behaviour

## Testing
- npm run test:unit *(fails: existing vitest suite has numerous unresolved import aliases outside the touched files)*

------
https://chatgpt.com/codex/tasks/task_e_68dbdf4035488329889b8695fcbb3c94