### PR TITLE
refactor: add recommendations composable

### DIFF
--- a/app/frontend/src/components/recommendations/RecommendationsPanel.vue
+++ b/app/frontend/src/components/recommendations/RecommendationsPanel.vue
@@ -32,7 +32,7 @@
           <div class="flex items-center gap-3">
             <div class="lora-preview-icon-container">
               <svg class="w-6 h-6 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"/>
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" />
               </svg>
             </div>
             <div class="flex-1">
@@ -89,13 +89,13 @@
       <div v-if="selectedLoraId">
         <div class="flex items-center justify-between mb-2">
           <h4 class="font-medium">Results</h4>
-          <button class="btn btn-primary btn-sm" :disabled="isLoadingRecs" @click="fetchRecommendations">
-            <span v-if="isLoadingRecs">Loading...</span>
+          <button class="btn btn-primary btn-sm" :disabled="isLoading" @click="fetchRecommendations">
+            <span v-if="isLoading">Loading...</span>
             <span v-else>Refresh</span>
           </button>
         </div>
-        <div v-if="recsError" class="text-sm text-red-600 mb-2">{{ recsError }}</div>
-        <div v-if="isLoadingRecs" class="text-gray-500">Fetching recommendations…</div>
+        <div v-if="error" class="text-sm text-red-600 mb-2">{{ error }}</div>
+        <div v-if="isLoading" class="text-gray-500">Fetching recommendations…</div>
         <div v-else-if="recommendations.length === 0" class="text-gray-500">No recommendations yet.</div>
         <div v-else class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4">
           <div v-for="r in recommendations" :key="r.lora_id" class="border rounded-lg p-3 hover:shadow-sm">
@@ -113,147 +113,25 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted, ref, watch } from 'vue';
-import { storeToRefs } from 'pinia';
-
-import { useRecommendationApi } from '@/composables/shared';
-import { useAdapterCatalogStore } from '@/stores';
-import type { AdapterSummary, RecommendationItem, RecommendationResponse } from '@/types';
-import { useBackendUrl } from '@/utils/backend';
-
-const WEIGHT_KEYS = ['semantic', 'artistic', 'technical'] as const;
-type WeightKey = (typeof WEIGHT_KEYS)[number];
-type WeightState = Record<WeightKey, number>;
-
-const DEFAULT_WEIGHTS: Readonly<WeightState> = {
-  semantic: 0.6,
-  artistic: 0.3,
-  technical: 0.1,
-} as const satisfies WeightState;
-
-const toErrorMessage = (error: unknown, fallback: string): string => {
-  if (error instanceof Error && error.message) {
-    return error.message;
-  }
-  if (typeof error === 'string' && error) {
-    return error;
-  }
-  return fallback;
-};
-
-const adapterCatalog = useAdapterCatalogStore();
-const { adapters: catalogAdapters, error: lorasErr, isLoading: lorasLoading } = storeToRefs(adapterCatalog);
-
-void adapterCatalog.ensureLoaded({ perPage: 200 });
-
-const loras = computed<AdapterSummary[]>(() => catalogAdapters.value);
-const lorasError = computed<string>(() =>
-  lorasErr.value ? toErrorMessage(lorasErr.value, 'Unable to load available LoRAs') : '',
-);
-
-const selectedLoraId = ref<AdapterSummary['id'] | ''>('');
-const selectedLora = computed<AdapterSummary | null>(() => {
-  if (!selectedLoraId.value) {
-    return null;
-  }
-  return loras.value.find((lora) => lora.id === selectedLoraId.value) ?? null;
-});
-
-const limit = ref<number>(10);
-const similarityThreshold = ref<number>(0.1);
-const weights = ref<WeightState>({ ...DEFAULT_WEIGHTS });
-
-const recommendations = ref<RecommendationItem[]>([]);
-const recsError = ref<string>('');
-
-const fmtScore = (value: number | null | undefined): string =>
-  value == null ? '-' : Number(value).toFixed(3);
-
-const recommendationPath = computed<string>(() => {
-  if (!selectedLoraId.value) {
-    return '';
-  }
-  const base = `recommendations/similar/${encodeURIComponent(selectedLoraId.value)}`;
-  const params = new URLSearchParams();
-  params.set('limit', String(limit.value));
-  params.set('similarity_threshold', String(similarityThreshold.value));
-  WEIGHT_KEYS.forEach((key) => {
-    params.set(`weight_${key}`, weights.value[key].toString());
-  });
-  return `${base}?${params.toString()}`;
-});
-
-const recommendationUrl = useBackendUrl(recommendationPath);
+import { useRecommendations } from '@/composables/recommendations/useRecommendations';
+import type { RecommendationItem } from '@/types';
 
 const {
-  data: recsData,
-  error: recsErrObj,
-  isLoading: recsLoading,
-  fetchData: loadRecs,
-} = useRecommendationApi(recommendationPath);
+  loras,
+  lorasError,
+  isLoadingLoras,
+  selectedLoraId,
+  selectedLora,
+  limit,
+  similarityThreshold,
+  weights,
+  recommendations,
+  error,
+  isLoading,
+  fetchRecommendations,
+  resetSettings,
+} = useRecommendations();
 
-const isLoadingLoras = computed<boolean>(() => lorasLoading.value);
-const isLoadingRecs = computed<boolean>(() => recsLoading.value);
-
-const isRecommendationResponse = (payload: unknown): payload is RecommendationResponse =>
-  Boolean(
-    payload &&
-      typeof payload === 'object' &&
-      Array.isArray((payload as RecommendationResponse).recommendations),
-  );
-
-const resetSettings = (): void => {
-  limit.value = 10;
-  similarityThreshold.value = 0.1;
-  weights.value = { ...DEFAULT_WEIGHTS };
-};
-
-const fetchRecommendations = async (): Promise<void> => {
-  recsError.value = '';
-  recommendations.value = [];
-
-  if (!selectedLora.value) {
-    return;
-  }
-
-  if (!recommendationUrl.value) {
-    recsError.value = 'Unable to resolve recommendation endpoint.';
-    return;
-  }
-
-  try {
-    const payload = (await loadRecs()) ?? recsData.value;
-    if (isRecommendationResponse(payload)) {
-      recommendations.value = payload.recommendations;
-    } else if (Array.isArray(payload)) {
-      recommendations.value = payload;
-    }
-  } catch (error) {
-    recsError.value = toErrorMessage(error, 'Failed to fetch recommendations');
-  }
-};
-
-watch(recsErrObj, (error) => {
-  if (error) {
-    recsError.value = toErrorMessage(error, 'Failed to fetch recommendations');
-  }
-});
-
-watch(selectedLoraId, (nextId) => {
-  if (!nextId) {
-    recommendations.value = [];
-    recsError.value = '';
-  }
-});
-
-onMounted(async () => {
-  await adapterCatalog.ensureLoaded({ perPage: 200 });
-});
-
-watch([selectedLoraId, limit, similarityThreshold], () => {
-  if (selectedLora.value) {
-    void fetchRecommendations();
-  }
-});
-
+const fmtScore = (value: RecommendationItem['similarity_score']): string =>
+  value == null ? '-' : Number(value).toFixed(3);
 </script>

--- a/app/frontend/src/composables/recommendations/useRecommendations.ts
+++ b/app/frontend/src/composables/recommendations/useRecommendations.ts
@@ -1,0 +1,217 @@
+import { computed, onScopeDispose, ref, watch, type Ref } from 'vue';
+import { storeToRefs } from 'pinia';
+
+import { useRecommendationApi } from '@/composables/shared';
+import { useAdapterCatalogStore, useSettingsStore } from '@/stores';
+import { useBackendEnvironment } from '@/stores/settings';
+import type { AdapterSummary, RecommendationItem, RecommendationResponse } from '@/types';
+
+const WEIGHT_KEYS = ['semantic', 'artistic', 'technical'] as const;
+type WeightKey = (typeof WEIGHT_KEYS)[number];
+export type WeightState = Record<WeightKey, number>;
+
+const DEFAULT_WEIGHTS: Readonly<WeightState> = {
+  semantic: 0.6,
+  artistic: 0.3,
+  technical: 0.1,
+} as const satisfies WeightState;
+
+export interface UseRecommendationsOptions {
+  initialLimit?: number;
+  initialThreshold?: number;
+  initialWeights?: Partial<WeightState>;
+  initialLoraId?: AdapterSummary['id'];
+}
+
+const toErrorMessage = (error: unknown, fallback: string): string => {
+  if (error instanceof Error && error.message) {
+    return error.message;
+  }
+  if (typeof error === 'string' && error) {
+    return error;
+  }
+  return fallback;
+};
+
+const isRecommendationResponse = (
+  payload: unknown,
+): payload is RecommendationResponse =>
+  Boolean(
+    payload &&
+      typeof payload === 'object' &&
+      Array.isArray((payload as RecommendationResponse).recommendations),
+  );
+
+export const useRecommendations = (options: UseRecommendationsOptions = {}) => {
+  const adapterCatalog = useAdapterCatalogStore();
+  const settingsStore = useSettingsStore();
+  const backendEnvironment = useBackendEnvironment();
+
+  const { adapters: catalogAdapters, error: lorasErr, isLoading: lorasLoading } = storeToRefs(adapterCatalog);
+  const { isLoaded: settingsLoaded } = storeToRefs(settingsStore);
+
+  const loras = computed<AdapterSummary[]>(() => catalogAdapters.value);
+  const lorasError = computed<string>(() =>
+    lorasErr.value ? toErrorMessage(lorasErr.value, 'Unable to load available LoRAs') : '',
+  );
+
+  const selectedLoraId = ref<AdapterSummary['id'] | ''>(options.initialLoraId ?? '');
+  const selectedLora = computed<AdapterSummary | null>(() => {
+    if (!selectedLoraId.value) {
+      return null;
+    }
+    return loras.value.find((lora) => lora.id === selectedLoraId.value) ?? null;
+  });
+
+  const limit = ref<number>(options.initialLimit ?? 10);
+  const similarityThreshold = ref<number>(options.initialThreshold ?? 0.1);
+  const weights = ref<WeightState>({ ...DEFAULT_WEIGHTS, ...(options.initialWeights ?? {}) });
+
+  const recommendations = ref<RecommendationItem[]>([]);
+  const error = ref<string>('');
+
+  const hydrationReady = ref(false);
+  void backendEnvironment.readyPromise.then(() => {
+    hydrationReady.value = true;
+  });
+
+  const isHydrated = computed<boolean>(() => hydrationReady.value && settingsLoaded.value);
+
+  const recommendationPath = computed<string>(() => {
+    if (!selectedLoraId.value) {
+      return '';
+    }
+    const base = `recommendations/similar/${encodeURIComponent(selectedLoraId.value)}`;
+    const params = new URLSearchParams();
+    params.set('limit', String(limit.value));
+    params.set('similarity_threshold', String(similarityThreshold.value));
+    WEIGHT_KEYS.forEach((key) => {
+      params.set(`weight_${key}`, weights.value[key].toString());
+    });
+    return `${base}?${params.toString()}`;
+  });
+
+  const {
+    data: recsData,
+    error: recsErrObj,
+    isLoading: recsLoading,
+    fetchData: loadRecs,
+  } = useRecommendationApi(recommendationPath);
+
+  const isLoading = computed<boolean>(() => recsLoading.value);
+
+  const applyRecommendations = (payload: RecommendationResponse | RecommendationItem[] | null | undefined) => {
+    if (!payload) {
+      recommendations.value = [];
+      return;
+    }
+
+    if (isRecommendationResponse(payload)) {
+      recommendations.value = payload.recommendations;
+      return;
+    }
+
+    if (Array.isArray(payload)) {
+      recommendations.value = payload;
+      return;
+    }
+
+    recommendations.value = [];
+  };
+
+  const fetchRecommendations = async (): Promise<RecommendationItem[]> => {
+    error.value = '';
+    recommendations.value = [];
+
+    if (!selectedLora.value) {
+      return recommendations.value;
+    }
+
+    if (!isHydrated.value) {
+      return recommendations.value;
+    }
+
+    try {
+      const payload = (await loadRecs()) ?? recsData.value;
+      applyRecommendations(payload);
+    } catch (err) {
+      error.value = toErrorMessage(err, 'Failed to fetch recommendations');
+    }
+
+    return recommendations.value;
+  };
+
+  const resetSettings = () => {
+    limit.value = options.initialLimit ?? 10;
+    similarityThreshold.value = options.initialThreshold ?? 0.1;
+    weights.value = { ...DEFAULT_WEIGHTS, ...(options.initialWeights ?? {}) };
+  };
+
+  watch(recsErrObj, (err) => {
+    if (err) {
+      error.value = toErrorMessage(err, 'Failed to fetch recommendations');
+    }
+  });
+
+  watch(selectedLoraId, (next) => {
+    if (!next) {
+      recommendations.value = [];
+      error.value = '';
+      return;
+    }
+
+    if (isHydrated.value) {
+      void fetchRecommendations();
+    }
+  });
+
+  const triggerRefreshIfReady = () => {
+    if (!selectedLora.value || !isHydrated.value) {
+      return;
+    }
+    void fetchRecommendations();
+  };
+
+  watch([limit, similarityThreshold], triggerRefreshIfReady);
+
+  watch(weights as Ref<WeightState>, triggerRefreshIfReady, { deep: true });
+
+  watch(isHydrated, (ready) => {
+    if (ready && selectedLora.value) {
+      void fetchRecommendations();
+    }
+  });
+
+  const stopBackendSubscription = backendEnvironment.onBackendUrlChange(() => {
+    if (selectedLora.value) {
+      void fetchRecommendations();
+    }
+  });
+
+  onScopeDispose(() => {
+    stopBackendSubscription();
+  });
+
+  void adapterCatalog.ensureLoaded({ perPage: 200 });
+
+  return {
+    loras,
+    lorasError,
+    isLoadingLoras: computed<boolean>(() => lorasLoading.value),
+    selectedLoraId,
+    selectedLora,
+    limit,
+    similarityThreshold,
+    weights,
+    recommendations,
+    error,
+    isLoading,
+    fetchRecommendations,
+    resetSettings,
+    recommendationPath,
+  };
+};
+
+export type UseRecommendationsReturn = ReturnType<typeof useRecommendations>;
+
+export const defaultRecommendationWeights = (): WeightState => ({ ...DEFAULT_WEIGHTS });

--- a/tests/vue/useRecommendations.spec.ts
+++ b/tests/vue/useRecommendations.spec.ts
@@ -1,0 +1,314 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { computed, nextTick, ref, unref, watch } from 'vue';
+import { mount } from '@vue/test-utils';
+import { createPinia, setActivePinia } from 'pinia';
+
+import type { RecommendationItem, RecommendationResponse } from '@/types';
+
+type UseRecommendations = typeof import('@/composables/recommendations/useRecommendations').useRecommendations;
+type UseSettingsStore = typeof import('@/stores/settings').useSettingsStore;
+
+const flush = async () => {
+  await Promise.resolve();
+  await nextTick();
+  await Promise.resolve();
+  await nextTick();
+};
+
+const serviceMocks = {
+  fetchAdapterList: vi.fn(),
+  fetchAdapterTags: vi.fn(),
+  performBulkLoraAction: vi.fn(),
+  useBackendClient: vi.fn(() => ({ baseUrl: '/api' })),
+};
+
+const createBackendEnvironmentState = () => {
+  let resolveReady: (() => void) | null = null;
+  const handlers: ((next: string, previous: string | null) => void)[] = [];
+  const readyPromise = new Promise<void>((resolve) => {
+    resolveReady = resolve;
+  });
+
+  const onBackendUrlChange = (handler: (next: string, previous: string | null) => void) => {
+    handlers.push(handler);
+    return () => {
+      const index = handlers.indexOf(handler);
+      if (index !== -1) {
+        handlers.splice(index, 1);
+      }
+    };
+  };
+
+  return {
+    readyPromise,
+    onBackendUrlChange,
+    resolveReady: () => {
+      resolveReady?.();
+    },
+    triggerBackendChange: (next = '/api/new', previous: string | null = '/api/old') => {
+      handlers.forEach((handler) => handler(next, previous));
+    },
+    resetHandlers: () => {
+      handlers.splice(0, handlers.length);
+    },
+  };
+};
+
+const recommendationApiMock = (() => {
+  const data = ref<RecommendationResponse | RecommendationItem[] | null>(null);
+  const error = ref<unknown>(null);
+  const isLoading = ref(false);
+  const lastPath = ref('');
+  const fetchCalls: string[] = [];
+  let fetchImplementation: (() => Promise<RecommendationResponse | RecommendationItem[] | null>) | null = null;
+
+  const fetchDataMock = vi.fn(async () => {
+    fetchCalls.push(lastPath.value);
+    const payload = await (fetchImplementation?.() ?? Promise.resolve({ recommendations: [] }));
+    data.value = payload;
+    return payload;
+  });
+
+  const useMock = vi.fn((path) => {
+    const resolved = computed(() => (typeof path === 'function' ? path() : unref(path)));
+    watch(
+      resolved,
+      (value) => {
+        lastPath.value = value;
+      },
+      { immediate: true },
+    );
+
+    return {
+      data,
+      error,
+      isLoading,
+      fetchData: fetchDataMock,
+    };
+  });
+
+  const setFetchImplementation = (
+    impl: () => Promise<RecommendationResponse | RecommendationItem[] | null>,
+  ) => {
+    fetchImplementation = impl;
+  };
+
+  const reset = () => {
+    data.value = null;
+    error.value = null;
+    isLoading.value = false;
+    lastPath.value = '';
+    fetchCalls.splice(0, fetchCalls.length);
+    fetchDataMock.mockClear();
+    fetchImplementation = null;
+  };
+
+  return {
+    useMock,
+    fetchDataMock,
+    fetchCalls,
+    lastPath,
+    setFetchImplementation,
+    reset,
+    error,
+    data,
+    isLoading,
+  };
+})();
+
+describe('useRecommendations', () => {
+  let useRecommendations: UseRecommendations;
+  let useSettingsStore: UseSettingsStore;
+  let backendEnvironmentState = createBackendEnvironmentState();
+
+  const withRecommendations = async (
+    run: (state: ReturnType<UseRecommendations>) => Promise<void>,
+  ) => {
+    let state: ReturnType<UseRecommendations> | undefined;
+
+    const wrapper = mount({
+      setup() {
+        state = useRecommendations();
+        return () => null;
+      },
+    });
+
+    try {
+      await run(state!);
+    } finally {
+      wrapper.unmount();
+    }
+  };
+
+  beforeEach(async () => {
+    vi.resetModules();
+
+    backendEnvironmentState = createBackendEnvironmentState();
+    backendEnvironmentState.resetHandlers();
+
+    recommendationApiMock.reset();
+
+    serviceMocks.fetchAdapterList.mockReset();
+    serviceMocks.fetchAdapterList.mockImplementation(async () => ({
+      items: [
+        { id: 'alpha', name: 'Alpha', description: 'First', active: true },
+        { id: 'beta', name: 'Beta', description: 'Second', active: true },
+      ],
+      total: 2,
+      filtered: 2,
+      page: 1,
+      pages: 1,
+      per_page: 200,
+    }));
+    serviceMocks.fetchAdapterTags.mockReset();
+    serviceMocks.performBulkLoraAction.mockReset();
+    serviceMocks.useBackendClient.mockReturnValue({ baseUrl: '/api' });
+
+    vi.doMock('@/services', async () => {
+      const actual = await vi.importActual<typeof import('@/services')>('@/services');
+      return {
+        ...actual,
+        fetchAdapterList: serviceMocks.fetchAdapterList,
+        fetchAdapterTags: serviceMocks.fetchAdapterTags,
+        performBulkLoraAction: serviceMocks.performBulkLoraAction,
+        useBackendClient: serviceMocks.useBackendClient,
+      };
+    });
+
+    vi.doMock('@/stores/settings', async () => {
+      const actual = await vi.importActual<typeof import('@/stores/settings')>('@/stores/settings');
+      return {
+        ...actual,
+        useBackendEnvironment: () => backendEnvironmentState,
+      };
+    });
+
+    vi.doMock('@/composables/shared', async () => {
+      const actual = await vi.importActual<typeof import('@/composables/shared')>('@/composables/shared');
+      return {
+        ...actual,
+        useRecommendationApi: recommendationApiMock.useMock,
+      };
+    });
+
+    const module = await import('@/composables/recommendations/useRecommendations');
+    useRecommendations = module.useRecommendations;
+
+    const settingsModule = await import('@/stores/settings');
+    useSettingsStore = settingsModule.useSettingsStore;
+
+    const pinia = createPinia();
+    setActivePinia(pinia);
+
+    const settingsStore = useSettingsStore();
+    settingsStore.reset();
+    settingsStore.setSettings({ backendUrl: '/api' });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.resetModules();
+  });
+
+  it('builds the recommendation API path with selected parameters', async () => {
+    await withRecommendations(async (state) => {
+      backendEnvironmentState.resolveReady();
+      await flush();
+
+      state.selectedLoraId.value = 'alpha';
+      await flush();
+
+      expect(recommendationApiMock.fetchDataMock).toHaveBeenCalledTimes(1);
+      expect(recommendationApiMock.lastPath.value).toContain('recommendations/similar/alpha');
+      expect(recommendationApiMock.lastPath.value).toContain('limit=10');
+      expect(recommendationApiMock.lastPath.value).toContain('similarity_threshold=0.1');
+      expect(recommendationApiMock.lastPath.value).toContain('weight_semantic=0.6');
+      expect(recommendationApiMock.lastPath.value).toContain('weight_artistic=0.3');
+      expect(recommendationApiMock.lastPath.value).toContain('weight_technical=0.1');
+    });
+  });
+
+  it('does not fetch recommendations until the backend environment is hydrated', async () => {
+    await withRecommendations(async (state) => {
+      state.selectedLoraId.value = 'alpha';
+      await flush();
+
+      expect(recommendationApiMock.fetchDataMock).not.toHaveBeenCalled();
+
+      backendEnvironmentState.resolveReady();
+      await flush();
+
+      expect(recommendationApiMock.fetchDataMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('refreshes recommendations when query parameters change', async () => {
+    const responses: RecommendationResponse[] = [
+      {
+        recommendations: [
+          {
+            lora_id: 'beta',
+            lora_name: 'Beta',
+            lora_description: 'Second',
+            final_score: 0.9,
+            similarity_score: 0.8,
+          } as RecommendationItem,
+        ],
+        recommendation_config: {},
+      },
+      {
+        recommendations: [
+          {
+            lora_id: 'gamma',
+            lora_name: 'Gamma',
+            lora_description: 'Third',
+            final_score: 0.7,
+            similarity_score: 0.6,
+          } as RecommendationItem,
+        ],
+        recommendation_config: {},
+      },
+      {
+        recommendations: [
+          {
+            lora_id: 'delta',
+            lora_name: 'Delta',
+            lora_description: 'Fourth',
+            final_score: 0.5,
+            similarity_score: 0.4,
+          } as RecommendationItem,
+        ],
+        recommendation_config: {},
+      },
+    ];
+
+    let callIndex = 0;
+    recommendationApiMock.setFetchImplementation(async () => {
+      const payload = responses[Math.min(callIndex, responses.length - 1)];
+      callIndex += 1;
+      return payload;
+    });
+
+    await withRecommendations(async (state) => {
+      backendEnvironmentState.resolveReady();
+      await flush();
+
+      state.selectedLoraId.value = 'alpha';
+      await flush();
+
+      expect(state.recommendations.value[0]?.lora_id).toBe('beta');
+
+      state.limit.value = 20;
+      await flush();
+      expect(state.recommendations.value[0]?.lora_id).toBe('gamma');
+      expect(state.recommendationPath.value).toContain('limit=20');
+
+      state.weights.value.semantic = 0.4;
+      await flush();
+      expect(state.recommendations.value[0]?.lora_id).toBe('delta');
+      expect(state.recommendationPath.value).toContain('weight_semantic=0.4');
+
+      expect(recommendationApiMock.fetchDataMock).toHaveBeenCalledTimes(3);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- extract a dedicated `useRecommendations` composable that manages LoRA selection, query parameters, backend hydration, and API integration
- update `RecommendationsPanel.vue` to consume the composable so the component focuses on rendering controls and results
- add focused unit tests covering URL construction, hydration guarding, and reactive refresh behaviour for the new composable

## Testing
- npm run test -- useRecommendations

------
https://chatgpt.com/codex/tasks/task_e_68dbec43274883299d84030728632743