### PR TITLE
Refactor services and stores barrels to use feature imports

### DIFF
--- a/app/frontend/src/components/dashboard/DashboardGenerationSummary.vue
+++ b/app/frontend/src/components/dashboard/DashboardGenerationSummary.vue
@@ -97,7 +97,8 @@ import { computed, onMounted, ref, watch } from 'vue';
 import { storeToRefs } from 'pinia';
 import { RouterLink } from 'vue-router';
 
-import { listResults as listHistoryResults, useBackendClient } from '@/services';
+import { useBackendClient } from '@/services';
+import { listResults as listHistoryResults } from '@/features/history/services';
 import { useGenerationResultsStore } from '@/features/generation';
 import { formatFileSize, formatRelativeTime } from '@/utils/format';
 import { mapGenerationResultsToHistory, mapHistoryResultsToGeneration } from '@/utils/generationHistory';

--- a/app/frontend/src/features/analytics/stores/performanceAnalytics.ts
+++ b/app/frontend/src/features/analytics/stores/performanceAnalytics.ts
@@ -1,12 +1,8 @@
 import { computed, onScopeDispose, ref } from 'vue';
 import { defineStore } from 'pinia';
 
-import {
-  exportAnalyticsReport,
-  fetchPerformanceAnalytics,
-  fetchTopAdapters,
-  useBackendClient,
-} from '@/services';
+import { fetchTopAdapters, useBackendClient } from '@/services';
+import { exportAnalyticsReport, fetchPerformanceAnalytics } from '@/features/analytics/services';
 import { formatDuration as formatDurationLabel } from '@/utils/format';
 import { useBackendEnvironment } from '@/stores';
 

--- a/app/frontend/src/features/generation/composables/createGenerationOrchestrator.ts
+++ b/app/frontend/src/features/generation/composables/createGenerationOrchestrator.ts
@@ -8,7 +8,7 @@ import {
 import type {
   GenerationQueueClient,
   GenerationWebSocketManager,
-} from '@/services';
+} from '@/features/generation/services';
 import { acquireSystemStatusController, DEFAULT_HISTORY_LIMIT } from '@/features/generation';
 import type {
   GenerationConnectionStore,

--- a/app/frontend/src/features/generation/composables/useGenerationOrchestrator.ts
+++ b/app/frontend/src/features/generation/composables/useGenerationOrchestrator.ts
@@ -1,7 +1,7 @@
 import type {
   GenerationQueueClient,
   GenerationWebSocketManager,
-} from '@/services';
+} from '@/features/generation/services';
 
 import type { GenerationNotificationAdapter } from './useGenerationTransport';
 import {

--- a/app/frontend/src/features/generation/composables/useGenerationOrchestratorManager.ts
+++ b/app/frontend/src/features/generation/composables/useGenerationOrchestratorManager.ts
@@ -9,7 +9,7 @@ import type { GenerationNotificationAdapter } from './useGenerationTransport';
 import type {
   GenerationQueueClient,
   GenerationWebSocketManager,
-} from '@/services';
+} from '@/features/generation/services';
 import {
   useGenerationConnectionStore,
   useGenerationQueueStore,

--- a/app/frontend/src/features/generation/composables/useGenerationQueueClient.ts
+++ b/app/frontend/src/features/generation/composables/useGenerationQueueClient.ts
@@ -6,7 +6,7 @@ import {
   parseGenerationJobStatuses,
   parseGenerationResults,
   type GenerationQueueClient,
-} from '@/services';
+} from '@/features/generation/services';
 import type {
   GenerationJobStatus,
   GenerationRequestPayload,

--- a/app/frontend/src/features/generation/composables/useGenerationSocketBridge.ts
+++ b/app/frontend/src/features/generation/composables/useGenerationSocketBridge.ts
@@ -4,7 +4,7 @@ import {
   createGenerationWebSocketManager,
   ensureArray,
   type GenerationWebSocketManager,
-} from '@/services';
+} from '@/features/generation/services';
 import type {
   GenerationCompleteMessage,
   GenerationErrorMessage,

--- a/app/frontend/src/features/generation/composables/useGenerationStudioController.ts
+++ b/app/frontend/src/features/generation/composables/useGenerationStudioController.ts
@@ -1,6 +1,6 @@
 import { onMounted, onUnmounted, shallowRef, type Ref } from 'vue'
 
-import { toGenerationRequestPayload } from '@/services'
+import { toGenerationRequestPayload } from '@/features/generation/services'
 import {
   useGenerationOrchestratorManager,
   type GenerationOrchestratorBinding,

--- a/app/frontend/src/features/generation/composables/useGenerationTransport.ts
+++ b/app/frontend/src/features/generation/composables/useGenerationTransport.ts
@@ -2,7 +2,7 @@ import {
   extractGenerationErrorMessage,
   type GenerationQueueClient,
   type GenerationWebSocketManager,
-} from '@/services';
+} from '@/features/generation/services';
 import type {
   GenerationCompleteMessage,
   GenerationErrorMessage,

--- a/app/frontend/src/features/generation/composables/useGenerationUpdates.ts
+++ b/app/frontend/src/features/generation/composables/useGenerationUpdates.ts
@@ -8,7 +8,7 @@ import {
 import type {
   GenerationQueueClient,
   GenerationWebSocketManager,
-} from '@/services';
+} from '@/features/generation/services';
 import type {
   GenerationJob,
   GenerationRequestPayload,

--- a/app/frontend/src/features/generation/composables/useJobQueueActions.ts
+++ b/app/frontend/src/features/generation/composables/useJobQueueActions.ts
@@ -1,7 +1,7 @@
 import { ref, unref, type MaybeRefOrGetter } from 'vue';
 import { storeToRefs } from 'pinia';
 
-import { cancelGenerationJob } from '@/services';
+import { cancelGenerationJob } from '@/features/generation/services';
 import { useGenerationQueueStore } from '@/features/generation';
 import { useNotifications } from '@/composables/shared';
 import { useBackendBase } from '@/utils/backend';

--- a/app/frontend/src/features/generation/composables/useJobQueueTransport.ts
+++ b/app/frontend/src/features/generation/composables/useJobQueueTransport.ts
@@ -1,6 +1,6 @@
 import { ref, unref, type MaybeRefOrGetter, type Ref } from 'vue';
 
-import { fetchActiveGenerationJobs } from '@/services';
+import { fetchActiveGenerationJobs } from '@/features/generation/services';
 import { DEFAULT_BACKEND_BASE } from '@/utils/backend';
 import type { GenerationJobStatus } from '@/types';
 

--- a/app/frontend/src/features/generation/stores/connection.ts
+++ b/app/frontend/src/features/generation/stores/connection.ts
@@ -1,7 +1,7 @@
 import { reactive, ref } from 'vue';
 import { defineStore } from 'pinia';
 
-import { DEFAULT_POLL_INTERVAL } from '@/services';
+import { DEFAULT_POLL_INTERVAL } from '@/features/generation/services';
 import type { SystemStatusPayload, SystemStatusState } from '@/types';
 
 export const DEFAULT_SYSTEM_STATUS: SystemStatusState = {

--- a/app/frontend/src/features/history/composables/useGenerationHistory.ts
+++ b/app/frontend/src/features/history/composables/useGenerationHistory.ts
@@ -2,7 +2,8 @@ import { computed, ref, type ComputedRef } from 'vue';
 import type { MaybeRefOrGetter } from 'vue';
 
 import { debounce, type DebouncedFunction } from '@/utils/async';
-import { listResults as listHistoryResults, useBackendClient } from '@/services';
+import { useBackendClient } from '@/services';
+import { listResults as listHistoryResults } from '@/features/history/services';
 import type {
   GenerationHistoryQuery,
   GenerationHistoryResult,

--- a/app/frontend/src/features/history/composables/useHistoryActions.ts
+++ b/app/frontend/src/features/history/composables/useHistoryActions.ts
@@ -3,6 +3,7 @@ import type { Router } from 'vue-router';
 
 import { PERSISTENCE_KEYS, usePersistence } from '@/composables/shared';
 import { downloadFile } from '@/utils/browser';
+import { useBackendClient } from '@/services';
 import {
   deleteResult as deleteHistoryResult,
   deleteResults as deleteHistoryResults,
@@ -11,8 +12,7 @@ import {
   favoriteResult as favoriteHistoryResult,
   favoriteResults as favoriteHistoryResults,
   rateResult as rateHistoryResult,
-  useBackendClient,
-} from '@/services';
+} from '@/features/history/services';
 import type { GenerationHistoryResult, NotificationType } from '@/types';
 
 export interface UseHistoryActionsOptions {

--- a/app/frontend/src/services/index.ts
+++ b/app/frontend/src/services/index.ts
@@ -1,7 +1,4 @@
 export * from './apiClient';
 export * from './backendClient';
-export * from '../features/generation/services';
 export * from './system';
 export * from './lora';
-export * from '../features/history/services';
-export * from '../features/analytics/services';

--- a/app/frontend/src/stores/index.ts
+++ b/app/frontend/src/stores/index.ts
@@ -1,7 +1,5 @@
 export * from './settings';
 export * from './app';
 export * from './adminMetrics';
-export * from '../features/generation/stores';
 export * from './adapterCatalog';
-export * from '../features/analytics/stores';
 

--- a/app/frontend/src/utils/promptGeneration.ts
+++ b/app/frontend/src/utils/promptGeneration.ts
@@ -1,4 +1,4 @@
-import { createGenerationParams, requestGeneration } from '@/services';
+import { createGenerationParams, requestGeneration } from '@/features/generation/services';
 
 import type { CompositionEntry } from '@/types';
 


### PR DESCRIPTION
## Summary
- stop re-exporting feature-specific services and stores from the shared barrels
- update generation, history, and analytics code to import from their feature-scoped entry points
- ensure shared utilities reference the new feature-level service exports

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dc1388a8cc8329ae0dccdc77498d9c