### PR TITLE
Refactor generation studio notifications handling

### DIFF
--- a/app/frontend/src/features/generation/composables/index.ts
+++ b/app/frontend/src/features/generation/composables/index.ts
@@ -1,5 +1,6 @@
 export * from './useGenerationStudio';
 export * from './useGenerationStudioController';
+export * from './useGenerationStudioNotifications';
 export * from './createGenerationOrchestrator';
 export * from './useGenerationTransport';
 export * from './useGenerationUI';

--- a/app/frontend/src/features/generation/composables/useGenerationPersistence.ts
+++ b/app/frontend/src/features/generation/composables/useGenerationPersistence.ts
@@ -1,7 +1,8 @@
 import { onUnmounted, watch, type Ref } from 'vue'
 
-import { PERSISTENCE_KEYS, useDialogService, usePersistence } from '@/composables/shared'
+import { PERSISTENCE_KEYS, usePersistence } from '@/composables/shared'
 import { useGenerationFormStore } from '@/features/generation'
+import type { UseDialogServiceReturn } from '@/composables/shared'
 import type { GenerationFormState, NotificationType } from '@/types'
 
 const RANDOM_PROMPTS: readonly string[] = [
@@ -18,6 +19,7 @@ const RANDOM_PROMPTS: readonly string[] = [
 interface UseGenerationPersistenceOptions {
   params: Ref<GenerationFormState>
   showToast: (message: string, type?: NotificationType) => void
+  requestPrompt: UseDialogServiceReturn['prompt']
 }
 
 export interface UseGenerationPersistenceReturn {
@@ -31,6 +33,7 @@ export interface UseGenerationPersistenceReturn {
 export const useGenerationPersistence = ({
   params,
   showToast,
+  requestPrompt,
 }: UseGenerationPersistenceOptions): UseGenerationPersistenceReturn => {
   const formStore = useGenerationFormStore()
   const persistence = usePersistence()
@@ -83,8 +86,6 @@ export const useGenerationPersistence = ({
 
     persistParams(value)
   }
-
-  const { prompt: requestPrompt } = useDialogService()
 
   const savePreset = async (): Promise<void> => {
     const presetName = await requestPrompt({

--- a/app/frontend/src/features/generation/composables/useGenerationStudio.ts
+++ b/app/frontend/src/features/generation/composables/useGenerationStudio.ts
@@ -3,26 +3,15 @@ import { computed, onMounted } from 'vue'
 import { useGenerationPersistence } from './useGenerationPersistence'
 import { useGenerationUI } from './useGenerationUI'
 import { useGenerationStudioController } from './useGenerationStudioController'
-import { useDialogService, useNotifications } from '@/composables/shared'
+import { useGenerationStudioNotifications } from './useGenerationStudioNotifications'
 import { useGenerationFormStore } from '@/features/generation'
-import type { GenerationFormState, NotificationType } from '@/types'
+import type { GenerationFormState } from '@/types'
 
 export const useGenerationStudio = () => {
   const formStore = useGenerationFormStore()
 
-  const { notify: pushNotification } = useNotifications()
-  const { confirm: requestConfirmation } = useDialogService()
-
-  const logDebug = (...args: unknown[]): void => {
-    if (import.meta.env.DEV) {
-      console.info('[GenerationStudio]', ...args)
-    }
-  }
-
-  const notify = (message: string, type: NotificationType = 'success') => {
-    logDebug(`[${type.toUpperCase()}] ${message}`)
-    pushNotification(message, type)
-  }
+  const { notify, confirm: requestConfirmation, prompt: requestPrompt, logDebug } =
+    useGenerationStudioNotifications()
 
   const {
     params: uiParams,
@@ -50,6 +39,7 @@ export const useGenerationStudio = () => {
   } = useGenerationPersistence({
     params: uiParams,
     showToast: notify,
+    requestPrompt,
   })
 
   const controller = useGenerationStudioController({

--- a/app/frontend/src/features/generation/composables/useGenerationStudioNotifications.ts
+++ b/app/frontend/src/features/generation/composables/useGenerationStudioNotifications.ts
@@ -1,0 +1,51 @@
+import { useDialogService, useNotifications } from '@/composables/shared'
+import type { UseDialogServiceReturn } from '@/composables/shared'
+import type { NotificationType } from '@/types'
+
+export interface UseGenerationStudioNotificationsOptions {
+  debugLabel?: string
+}
+
+export interface UseGenerationStudioNotificationsReturn {
+  notify: (message: string, type?: NotificationType) => void
+  confirm: UseDialogServiceReturn['confirm']
+  prompt: UseDialogServiceReturn['prompt']
+  logDebug: (...args: unknown[]) => void
+}
+
+export const useGenerationStudioNotifications = ({
+  debugLabel = '[GenerationStudio]',
+}: UseGenerationStudioNotificationsOptions = {}): UseGenerationStudioNotificationsReturn => {
+  const { notify: pushNotification } = useNotifications()
+  const dialogService = useDialogService()
+
+  const logDebug = (...args: unknown[]): void => {
+    if (import.meta.env.DEV) {
+      console.info(debugLabel, ...args)
+    }
+  }
+
+  const notify = (message: string, type: NotificationType = 'success'): void => {
+    logDebug(`notify:${type}`, message)
+    pushNotification(message, type)
+  }
+
+  const confirm: UseDialogServiceReturn['confirm'] = async (options) => {
+    logDebug('confirm', options.title ?? options.message)
+    return dialogService.confirm(options)
+  }
+
+  const prompt: UseDialogServiceReturn['prompt'] = async (options) => {
+    logDebug('prompt', options.title ?? options.message)
+    return dialogService.prompt(options)
+  }
+
+  return {
+    notify,
+    confirm,
+    prompt,
+    logDebug,
+  }
+}
+
+export type UseGenerationStudioNotifications = ReturnType<typeof useGenerationStudioNotifications>


### PR DESCRIPTION
## Summary
- extract a focused useGenerationStudioNotifications composable that wraps notifications, dialogs, and debugging
- update generation studio and persistence helpers to consume the new notification API and remove direct dialog wiring
- re-export the new composable for reuse within the generation feature

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dc1b15f3f88329a9dd24e3371ce843