### PR TITLE
Refactor backend environment subscriptions and deduplicate generation routes

### DIFF
--- a/app/frontend/src/features/recommendations/composables/useRecommendations.ts
+++ b/app/frontend/src/features/recommendations/composables/useRecommendations.ts
@@ -1,8 +1,9 @@
-import { computed, onScopeDispose, ref, watch, type Ref } from 'vue';
+import { computed, ref, watch, type Ref } from 'vue';
 import { storeToRefs } from 'pinia';
 
 import { useRecommendationApi } from '@/composables/shared';
 import { useAdapterCatalogStore } from '@/features/lora';
+import { useBackendEnvironmentSubscription } from '@/services';
 import { useBackendEnvironment, useSettingsStore } from '@/stores';
 import type { AdapterSummary, RecommendationItem, RecommendationResponse } from '@/types';
 
@@ -182,14 +183,10 @@ export const useRecommendations = (options: UseRecommendationsOptions = {}) => {
     }
   });
 
-  const stopBackendSubscription = backendEnvironment.onBackendUrlChange(() => {
+  useBackendEnvironmentSubscription(() => {
     if (selectedLora.value) {
       void fetchRecommendations();
     }
-  });
-
-  onScopeDispose(() => {
-    stopBackendSubscription();
   });
 
   void adapterCatalog.ensureLoaded({ perPage: 200 });

--- a/app/frontend/src/services/system/backendEnvironmentBus.ts
+++ b/app/frontend/src/services/system/backendEnvironmentBus.ts
@@ -1,0 +1,59 @@
+import { onScopeDispose } from 'vue';
+
+// Access settings store directly to avoid circular dependencies when importing from the stores barrel.
+// eslint-disable-next-line no-restricted-imports
+import { useBackendEnvironment, type BackendUrlChangeHandler } from '@/stores/settings';
+
+export interface BackendEnvironmentSubscription {
+  start(): void;
+  stop(): void;
+  restart(): void;
+  isActive(): boolean;
+}
+
+export const createBackendEnvironmentSubscription = (
+  handler: BackendUrlChangeHandler,
+): BackendEnvironmentSubscription => {
+  const backendEnvironment = useBackendEnvironment();
+  let stop: (() => void) | null = null;
+
+  const start = () => {
+    if (stop) {
+      return;
+    }
+    stop = backendEnvironment.onBackendUrlChange((next, previous) => {
+      void handler(next, previous);
+    });
+  };
+
+  const stopSubscription = () => {
+    if (!stop) {
+      return;
+    }
+    stop();
+    stop = null;
+  };
+
+  const restart = () => {
+    stopSubscription();
+    start();
+  };
+
+  const isActive = () => stop != null;
+
+  return {
+    start,
+    stop: stopSubscription,
+    restart,
+    isActive,
+  };
+};
+
+export const useBackendEnvironmentSubscription = (
+  handler: BackendUrlChangeHandler,
+): BackendEnvironmentSubscription => {
+  const subscription = createBackendEnvironmentSubscription(handler);
+  subscription.start();
+  onScopeDispose(subscription.stop);
+  return subscription;
+};

--- a/app/frontend/src/services/system/index.ts
+++ b/app/frontend/src/services/system/index.ts
@@ -1,1 +1,2 @@
 export * from './systemService';
+export * from './backendEnvironmentBus';

--- a/app/frontend/src/utils/backend.ts
+++ b/app/frontend/src/utils/backend.ts
@@ -16,7 +16,6 @@ import {
   sanitizeBackendBaseUrl,
   trimLeadingSlash,
   trimTrailingSlash,
-  resolveGenerationRoute,
   withSameOrigin,
   type BackendPathBuilder,
 } from './backend/helpers';
@@ -27,7 +26,6 @@ export {
   joinBackendPath,
   joinBackendSegments,
   normaliseBackendBase,
-  resolveGenerationRoute,
   sanitizeBackendBaseUrl,
   trimLeadingSlash,
   trimTrailingSlash,
@@ -160,7 +158,6 @@ export const backendUtils = {
   joinBackendPath,
   joinBackendSegments,
   normaliseBackendBase,
-  resolveGenerationRoute,
   trimLeadingSlash,
   trimTrailingSlash,
   sanitizeBackendBaseUrl,

--- a/app/frontend/src/utils/backend/helpers.ts
+++ b/app/frontend/src/utils/backend/helpers.ts
@@ -126,7 +126,3 @@ export const joinBackendPath = (base: string, path: string): string => {
   return `${combined}${suffix}`;
 };
 
-export const resolveGenerationRoute = (path = ''): string => {
-  const trimmed = trimLeadingSlash(path);
-  return `/generation${trimmed ? `/${trimmed}` : ''}`;
-};


### PR DESCRIPTION
## Summary
- remove the duplicate `resolveGenerationRoute` helper from the shared backend utilities so the generation service remains the single source of truth
- add a backend environment subscription helper and export it from the system services module
- update analytics, admin metrics, LoRA catalog, and recommendation flows to use the shared backend environment subscription logic

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dc1d6770b88329a5629c3852f28ae5