### PR TITLE
Refactor feature exports to curated public entry points

### DIFF
--- a/app/frontend/src/components/dashboard/DashboardGenerationSummary.vue
+++ b/app/frontend/src/components/dashboard/DashboardGenerationSummary.vue
@@ -99,7 +99,7 @@ import { RouterLink } from 'vue-router';
 
 import { useBackendClient } from '@/services';
 import { listResults as listHistoryResults } from '@/features/history/services';
-import { useGenerationResultsStore } from '@/features/generation';
+import { useGenerationResultsStore } from '@/features/generation/public';
 import { formatFileSize, formatRelativeTime } from '@/utils/format';
 import { mapGenerationResultsToHistory, mapHistoryResultsToGeneration } from '@/utils/generationHistory';
 import type {

--- a/app/frontend/src/components/dashboard/DashboardLoraSummary.vue
+++ b/app/frontend/src/components/dashboard/DashboardLoraSummary.vue
@@ -82,7 +82,7 @@ import { computed, onMounted } from 'vue';
 import { storeToRefs } from 'pinia';
 import { RouterLink } from 'vue-router';
 
-import { useAdapterCatalogStore } from '@/features/lora';
+import { useAdapterCatalogStore } from '@/features/lora/public';
 import { formatRelativeTime } from '@/utils/format';
 
 const SUMMARY_QUERY = Object.freeze({ perPage: 12, sort: 'last_updated_desc' as const });

--- a/app/frontend/src/composables/compose/useAdapterCatalog.ts
+++ b/app/frontend/src/composables/compose/useAdapterCatalog.ts
@@ -1,7 +1,7 @@
 import { computed, ref, type ComputedRef, type Ref } from 'vue';
 import { storeToRefs } from 'pinia';
 
-import { useAdapterCatalogStore } from '@/features/lora';
+import { useAdapterCatalogStore } from '@/features/lora/public';
 
 import type { AdapterSummary } from '@/types';
 

--- a/app/frontend/src/features/analytics/components/PerformanceAnalyticsChartGrid.vue
+++ b/app/frontend/src/features/analytics/components/PerformanceAnalyticsChartGrid.vue
@@ -51,12 +51,10 @@
 </template>
 
 <script setup lang="ts">
-import {
-  GenerationVolumeChart,
-  LoraUsageChart,
-  PerformanceTrendChart,
-  ResourceUsageChart,
-} from '@/features/analytics';
+import GenerationVolumeChart from './GenerationVolumeChart.vue';
+import LoraUsageChart from './LoraUsageChart.vue';
+import PerformanceTrendChart from './PerformanceTrendChart.vue';
+import ResourceUsageChart from './ResourceUsageChart.vue';
 import type { PerformanceAnalyticsCharts } from '@/types';
 
 defineProps<{

--- a/app/frontend/src/features/analytics/composables/usePerformanceAnalytics.ts
+++ b/app/frontend/src/features/analytics/composables/usePerformanceAnalytics.ts
@@ -1,6 +1,6 @@
 import { storeToRefs } from 'pinia';
 
-import { usePerformanceAnalyticsStore } from '@/features/analytics';
+import { usePerformanceAnalyticsStore } from '../stores/performanceAnalytics';
 
 export function usePerformanceAnalytics() {
   const store = usePerformanceAnalyticsStore();

--- a/app/frontend/src/features/analytics/index.ts
+++ b/app/frontend/src/features/analytics/index.ts
@@ -1,4 +1,9 @@
-export * from './components';
-export * from './composables';
-export * from './services';
-export * from './stores';
+export {
+  PerformanceAnalyticsChartGrid,
+  PerformanceAnalyticsExportToolbar,
+  PerformanceAnalyticsInsights,
+  PerformanceAnalyticsKpiGrid,
+  usePerformanceAnalytics,
+  usePerformanceAnalyticsStore,
+} from './public';
+export type { PerformanceAnalyticsStore } from './public';

--- a/app/frontend/src/features/analytics/public.ts
+++ b/app/frontend/src/features/analytics/public.ts
@@ -1,0 +1,9 @@
+export { default as PerformanceAnalyticsChartGrid } from './components/PerformanceAnalyticsChartGrid.vue';
+export { default as PerformanceAnalyticsExportToolbar } from './components/PerformanceAnalyticsExportToolbar.vue';
+export { default as PerformanceAnalyticsInsights } from './components/PerformanceAnalyticsInsights.vue';
+export { default as PerformanceAnalyticsKpiGrid } from './components/PerformanceAnalyticsKpiGrid.vue';
+
+export { usePerformanceAnalytics } from './composables/usePerformanceAnalytics';
+
+export { usePerformanceAnalyticsStore } from './stores/performanceAnalytics';
+export type { PerformanceAnalyticsStore } from './stores/performanceAnalytics';

--- a/app/frontend/src/features/analytics/stores/performanceAnalytics.ts
+++ b/app/frontend/src/features/analytics/stores/performanceAnalytics.ts
@@ -1,8 +1,9 @@
 import { computed, ref } from 'vue';
 import { defineStore } from 'pinia';
 
-import { fetchTopAdapters, useBackendClient, useBackendEnvironmentSubscription } from '@/services';
-import { exportAnalyticsReport, fetchPerformanceAnalytics } from '@/features/analytics/services';
+import { useBackendClient, useBackendEnvironmentSubscription } from '@/services';
+import { fetchTopAdapters } from '@/features/lora/public';
+import { exportAnalyticsReport, fetchPerformanceAnalytics } from '../services/analyticsService';
 import { formatDuration as formatDurationLabel } from '@/utils/format';
 
 import type {

--- a/app/frontend/src/features/generation/components/GenerationActiveJobsList.vue
+++ b/app/frontend/src/features/generation/components/GenerationActiveJobsList.vue
@@ -69,7 +69,7 @@
 <script setup lang="ts">
 import { toRefs } from 'vue'
 
-import type { UseGenerationStudioReturn } from '@/features/generation'
+import type { UseGenerationStudioReturn } from '../composables/useGenerationStudio'
 import type { GenerationJob } from '@/types'
 
 const props = defineProps<{

--- a/app/frontend/src/features/generation/components/GenerationResultsGallery.vue
+++ b/app/frontend/src/features/generation/components/GenerationResultsGallery.vue
@@ -75,7 +75,7 @@
 <script setup lang="ts">
 import { toRefs } from 'vue'
 
-import type { UseGenerationStudioReturn } from '@/features/generation'
+import type { UseGenerationStudioReturn } from '../composables/useGenerationStudio'
 import type { GenerationResult } from '@/types'
 
 const props = defineProps<{

--- a/app/frontend/src/features/generation/components/GenerationStudio.vue
+++ b/app/frontend/src/features/generation/components/GenerationStudio.vue
@@ -126,13 +126,11 @@
 </template>
 
 <script setup lang="ts">
-import {
-  GenerationActiveJobsList,
-  GenerationParameterForm,
-  GenerationResultsGallery,
-  GenerationSystemStatusCard,
-  useGenerationStudio,
-} from '@/features/generation'
+import GenerationActiveJobsList from './GenerationActiveJobsList.vue';
+import GenerationParameterForm from './GenerationParameterForm.vue';
+import GenerationResultsGallery from './GenerationResultsGallery.vue';
+import GenerationSystemStatusCard from './GenerationSystemStatusCard.vue';
+import { useGenerationStudio } from '../composables/useGenerationStudio';
 
 const generationStudio = useGenerationStudio()
 

--- a/app/frontend/src/features/generation/components/GenerationSystemStatusCard.vue
+++ b/app/frontend/src/features/generation/components/GenerationSystemStatusCard.vue
@@ -34,7 +34,7 @@
 <script setup lang="ts">
 import { toRefs } from 'vue'
 
-import type { UseGenerationStudioReturn } from '@/features/generation'
+import type { UseGenerationStudioReturn } from '../composables/useGenerationStudio'
 import type { SystemStatusState } from '@/types'
 
 const props = defineProps<{

--- a/app/frontend/src/features/generation/components/JobQueue.vue
+++ b/app/frontend/src/features/generation/components/JobQueue.vue
@@ -78,11 +78,9 @@
 import { computed } from 'vue';
 import { storeToRefs } from 'pinia';
 
-import {
-  useGenerationConnectionStore,
-  useJobQueue,
-  useJobQueueActions,
-} from '@/features/generation';
+import { useGenerationConnectionStore } from '../stores/connection';
+import { useJobQueue } from '../composables/useJobQueue';
+import { useJobQueueActions } from '../composables/useJobQueueActions';
 import { formatElapsedTime } from '@/utils/format';
 
 import type { GenerationJob } from '@/types';

--- a/app/frontend/src/features/generation/composables/createGenerationOrchestrator.ts
+++ b/app/frontend/src/features/generation/composables/createGenerationOrchestrator.ts
@@ -5,16 +5,13 @@ import {
   useGenerationTransport,
   type GenerationNotificationAdapter,
 } from './useGenerationTransport';
-import type {
-  GenerationQueueClient,
-  GenerationWebSocketManager,
-} from '@/features/generation/services';
-import { acquireSystemStatusController, DEFAULT_HISTORY_LIMIT } from '@/features/generation';
-import type {
-  GenerationConnectionStore,
-  GenerationQueueStore,
-  GenerationResultsStore,
-} from '@/features/generation';
+import type { GenerationQueueClient } from '../services/queueClient';
+import type { GenerationWebSocketManager } from '../services/websocketManager';
+import { acquireSystemStatusController } from '../stores/systemStatusController';
+import { DEFAULT_HISTORY_LIMIT } from '../stores/results';
+import type { GenerationConnectionStore } from '../stores/connection';
+import type { GenerationQueueStore } from '../stores/queue';
+import type { GenerationResultsStore } from '../stores/results';
 import type {
   GenerationJob,
   GenerationRequestPayload,

--- a/app/frontend/src/features/generation/composables/useGenerationOrchestrator.ts
+++ b/app/frontend/src/features/generation/composables/useGenerationOrchestrator.ts
@@ -1,7 +1,5 @@
-import type {
-  GenerationQueueClient,
-  GenerationWebSocketManager,
-} from '@/features/generation/services';
+import type { GenerationQueueClient } from '../services/queueClient';
+import type { GenerationWebSocketManager } from '../services/websocketManager';
 
 import type { GenerationNotificationAdapter } from './useGenerationTransport';
 import {

--- a/app/frontend/src/features/generation/composables/useGenerationOrchestratorManager.ts
+++ b/app/frontend/src/features/generation/composables/useGenerationOrchestratorManager.ts
@@ -6,18 +6,16 @@ import {
   type GenerationOrchestrator,
 } from './createGenerationOrchestrator';
 import type { GenerationNotificationAdapter } from './useGenerationTransport';
-import type {
-  GenerationQueueClient,
-  GenerationWebSocketManager,
-} from '@/features/generation/services';
+import type { GenerationQueueClient } from '../services/queueClient';
+import type { GenerationWebSocketManager } from '../services/websocketManager';
+import { useGenerationConnectionStore } from '../stores/connection';
+import { useGenerationQueueStore } from '../stores/queue';
+import { useGenerationResultsStore } from '../stores/results';
 import {
-  useGenerationConnectionStore,
-  useGenerationQueueStore,
-  useGenerationResultsStore,
   useGenerationOrchestratorManagerStore,
-  useGenerationStudioUiStore,
   type GenerationOrchestratorConsumer,
-} from '@/features/generation';
+} from '../stores/orchestratorManagerStore';
+import { useGenerationStudioUiStore } from '../stores/ui';
 import { useSettingsStore } from '@/stores';
 import type {
   GenerationJob,

--- a/app/frontend/src/features/generation/composables/useGenerationPersistence.ts
+++ b/app/frontend/src/features/generation/composables/useGenerationPersistence.ts
@@ -1,7 +1,7 @@
 import { onUnmounted, watch, type Ref } from 'vue'
 
 import { PERSISTENCE_KEYS, usePersistence } from '@/composables/shared'
-import { useGenerationFormStore } from '@/features/generation'
+import { useGenerationFormStore } from '../stores/form'
 import type { UseDialogServiceReturn } from '@/composables/shared'
 import type { GenerationFormState, NotificationType } from '@/types'
 

--- a/app/frontend/src/features/generation/composables/useGenerationQueueClient.ts
+++ b/app/frontend/src/features/generation/composables/useGenerationQueueClient.ts
@@ -1,12 +1,9 @@
 import { ref, shallowRef } from 'vue';
 
-import {
-  DEFAULT_POLL_INTERVAL,
-  createGenerationQueueClient,
-  parseGenerationJobStatuses,
-  parseGenerationResults,
-  type GenerationQueueClient,
-} from '@/features/generation/services';
+import { createGenerationQueueClient, type GenerationQueueClient } from '../services/queueClient';
+import { DEFAULT_POLL_INTERVAL } from '../services/updates';
+import { parseGenerationJobStatuses, parseGenerationResults } from '../services/validation';
+import type { GenerationJobInput } from '../stores/queue';
 import type {
   GenerationJobStatus,
   GenerationRequestPayload,
@@ -16,7 +13,6 @@ import type {
   SystemStatusPayload,
   SystemStatusState,
 } from '@/types';
-import type { GenerationJobInput } from '@/features/generation';
 import { SystemStatusPayloadSchema } from '@/schemas';
 import { normalizeJobStatus } from '@/utils/status';
 

--- a/app/frontend/src/features/generation/composables/useGenerationSocketBridge.ts
+++ b/app/frontend/src/features/generation/composables/useGenerationSocketBridge.ts
@@ -1,10 +1,8 @@
 import { shallowRef } from 'vue';
 
-import {
-  createGenerationWebSocketManager,
-  ensureArray,
-  type GenerationWebSocketManager,
-} from '@/features/generation/services';
+import { createGenerationWebSocketManager, type GenerationWebSocketManager } from '../services/websocketManager';
+import { ensureArray } from '../services/validation';
+import type { GenerationJobInput } from '../stores/queue';
 import type {
   GenerationCompleteMessage,
   GenerationErrorMessage,
@@ -12,7 +10,6 @@ import type {
   SystemStatusPayload,
   SystemStatusState,
 } from '@/types';
-import type { GenerationJobInput } from '@/features/generation';
 
 interface SocketBridgeOptions {
   getBackendUrl: () => string | null | undefined;

--- a/app/frontend/src/features/generation/composables/useGenerationStudio.ts
+++ b/app/frontend/src/features/generation/composables/useGenerationStudio.ts
@@ -4,7 +4,7 @@ import { useGenerationPersistence } from './useGenerationPersistence'
 import { useGenerationUI } from './useGenerationUI'
 import { useGenerationStudioController } from './useGenerationStudioController'
 import { useGenerationStudioNotifications } from './useGenerationStudioNotifications'
-import { useGenerationFormStore } from '@/features/generation'
+import { useGenerationFormStore } from '../stores/form'
 import type { GenerationFormState } from '@/types'
 
 export const useGenerationStudio = () => {

--- a/app/frontend/src/features/generation/composables/useGenerationStudioController.ts
+++ b/app/frontend/src/features/generation/composables/useGenerationStudioController.ts
@@ -1,11 +1,11 @@
 import { onMounted, onUnmounted, shallowRef, type Ref } from 'vue'
 
-import { toGenerationRequestPayload } from '@/features/generation/services'
+import { toGenerationRequestPayload } from '../services/generationService'
 import {
   useGenerationOrchestratorManager,
   type GenerationOrchestratorBinding,
 } from './useGenerationOrchestratorManager'
-import { useGenerationFormStore } from '@/features/generation'
+import { useGenerationFormStore } from '../stores/form'
 import type { GenerationFormState, NotificationType, GenerationJob } from '@/types'
 
 export interface UseGenerationStudioControllerOptions {

--- a/app/frontend/src/features/generation/composables/useGenerationTransport.ts
+++ b/app/frontend/src/features/generation/composables/useGenerationTransport.ts
@@ -1,8 +1,7 @@
-import {
-  extractGenerationErrorMessage,
-  type GenerationQueueClient,
-  type GenerationWebSocketManager,
-} from '@/features/generation/services';
+import { extractGenerationErrorMessage } from '../services/updates';
+import type { GenerationQueueClient } from '../services/queueClient';
+import type { GenerationWebSocketManager } from '../services/websocketManager';
+import type { GenerationJobInput } from '../stores/queue';
 import type {
   GenerationCompleteMessage,
   GenerationErrorMessage,
@@ -13,7 +12,6 @@ import type {
   SystemStatusState,
   NotificationType,
 } from '@/types';
-import type { GenerationJobInput } from '@/features/generation';
 
 import { useGenerationQueueClient } from './useGenerationQueueClient';
 import { useGenerationSocketBridge } from './useGenerationSocketBridge';

--- a/app/frontend/src/features/generation/composables/useGenerationUI.ts
+++ b/app/frontend/src/features/generation/composables/useGenerationUI.ts
@@ -1,10 +1,8 @@
 import { storeToRefs } from 'pinia'
 
-import {
-  useGenerationFormStore,
-  useGenerationResultsStore,
-  useGenerationStudioUiStore,
-} from '@/features/generation'
+import { useGenerationFormStore } from '../stores/form'
+import { useGenerationResultsStore } from '../stores/results'
+import { useGenerationStudioUiStore } from '../stores/ui'
 import type { GenerationResult, NotificationType } from '@/types'
 
 const STATUS_CLASS_MAP = {

--- a/app/frontend/src/features/generation/composables/useGenerationUpdates.ts
+++ b/app/frontend/src/features/generation/composables/useGenerationUpdates.ts
@@ -5,10 +5,8 @@ import {
   useGenerationOrchestratorManager,
   type GenerationOrchestratorBinding,
 } from './useGenerationOrchestratorManager';
-import type {
-  GenerationQueueClient,
-  GenerationWebSocketManager,
-} from '@/features/generation/services';
+import type { GenerationQueueClient } from '../services/queueClient';
+import type { GenerationWebSocketManager } from '../services/websocketManager';
 import type {
   GenerationJob,
   GenerationRequestPayload,

--- a/app/frontend/src/features/generation/composables/useJobQueue.ts
+++ b/app/frontend/src/features/generation/composables/useJobQueue.ts
@@ -1,11 +1,9 @@
 import { computed, unref, type MaybeRefOrGetter } from 'vue';
 import { storeToRefs } from 'pinia';
 
-import {
-  useGenerationConnectionStore,
-  useGenerationQueueStore,
-  useGenerationResultsStore,
-} from '@/features/generation';
+import { useGenerationConnectionStore } from '../stores/connection';
+import { useGenerationQueueStore } from '../stores/queue';
+import { useGenerationResultsStore } from '../stores/results';
 import { useBackendBase } from '@/utils/backend';
 import type { GenerationJob, GenerationJobStatus, GenerationResult } from '@/types';
 import { normalizeJobStatus } from '@/utils/status';

--- a/app/frontend/src/features/generation/composables/useJobQueueActions.ts
+++ b/app/frontend/src/features/generation/composables/useJobQueueActions.ts
@@ -1,8 +1,8 @@
 import { ref, unref, type MaybeRefOrGetter } from 'vue';
 import { storeToRefs } from 'pinia';
 
-import { cancelGenerationJob } from '@/features/generation/services';
-import { useGenerationQueueStore } from '@/features/generation';
+import { cancelGenerationJob } from '../services/generationService';
+import { useGenerationQueueStore } from '../stores/queue';
 import { useNotifications } from '@/composables/shared';
 import { useBackendBase } from '@/utils/backend';
 

--- a/app/frontend/src/features/generation/composables/useJobQueueTransport.ts
+++ b/app/frontend/src/features/generation/composables/useJobQueueTransport.ts
@@ -1,6 +1,6 @@
 import { ref, unref, type MaybeRefOrGetter, type Ref } from 'vue';
 
-import { fetchActiveGenerationJobs } from '@/features/generation/services';
+import { fetchActiveGenerationJobs } from '../services/generationService';
 import { DEFAULT_BACKEND_BASE } from '@/utils/backend';
 import type { GenerationJobStatus } from '@/types';
 

--- a/app/frontend/src/features/generation/index.ts
+++ b/app/frontend/src/features/generation/index.ts
@@ -1,4 +1,9 @@
-export * from './components';
-export * from './composables';
-export * from './services';
-export * from './stores';
+export {
+  GenerationStudio,
+  JobQueue,
+  SystemAdminStatusCard,
+  SystemStatusCard,
+  SystemStatusPanel,
+  useGenerationResultsStore,
+} from './public';
+export type { GenerationResultsStore } from './public';

--- a/app/frontend/src/features/generation/public.ts
+++ b/app/frontend/src/features/generation/public.ts
@@ -1,0 +1,8 @@
+export { default as GenerationStudio } from './components/GenerationStudio.vue';
+export { default as JobQueue } from './components/JobQueue.vue';
+export { default as SystemAdminStatusCard } from './components/system/SystemAdminStatusCard.vue';
+export { default as SystemStatusCard } from './components/system/SystemStatusCard.vue';
+export { default as SystemStatusPanel } from './components/system/SystemStatusPanel.vue';
+
+export { useGenerationResultsStore } from './stores/results';
+export type { GenerationResultsStore } from './stores/results';

--- a/app/frontend/src/features/generation/stores/connection.ts
+++ b/app/frontend/src/features/generation/stores/connection.ts
@@ -1,7 +1,7 @@
 import { reactive, ref } from 'vue';
 import { defineStore } from 'pinia';
 
-import { DEFAULT_POLL_INTERVAL } from '@/features/generation/services';
+import { DEFAULT_POLL_INTERVAL } from '../services/updates';
 import type { SystemStatusPayload, SystemStatusState } from '@/types';
 
 export const DEFAULT_SYSTEM_STATUS: SystemStatusState = {

--- a/app/frontend/src/features/generation/stores/orchestratorManagerStore.ts
+++ b/app/frontend/src/features/generation/stores/orchestratorManagerStore.ts
@@ -1,7 +1,8 @@
 import { defineStore } from 'pinia';
 import { effectScope, markRaw, ref, shallowRef, type EffectScope } from 'vue';
 
-import type { GenerationNotificationAdapter, GenerationOrchestrator } from '@/features/generation';
+import type { GenerationOrchestrator } from '../composables/createGenerationOrchestrator';
+import type { GenerationNotificationAdapter } from '../composables/useGenerationTransport';
 import type { SystemStatusController, SystemStatusControllerHandle } from './systemStatusController';
 
 export interface GenerationOrchestratorConsumer {

--- a/app/frontend/src/features/generation/stores/systemStatusController.ts
+++ b/app/frontend/src/features/generation/stores/systemStatusController.ts
@@ -4,7 +4,7 @@ import { storeToRefs } from 'pinia';
 import { ApiError } from '@/composables/shared';
 import { fetchSystemStatus, useBackendClient, type BackendClient } from '@/services';
 import { resolveBackendBaseUrl } from '@/utils/backend';
-import { useGenerationConnectionStore } from '@/features/generation';
+import { useGenerationConnectionStore } from './connection';
 import { useGenerationOrchestratorManagerStore } from './orchestratorManagerStore';
 
 const DEFAULT_POLL_INTERVAL = 10_000;

--- a/app/frontend/src/features/lora/components/lora-gallery/LoraCard.vue
+++ b/app/frontend/src/features/lora/components/lora-gallery/LoraCard.vue
@@ -32,7 +32,7 @@
 import { computed, toRef } from 'vue';
 import LoraCardGrid from './LoraCardGrid.vue';
 import LoraCardList from './LoraCardList.vue';
-import { useLoraCardActions } from '@/features/lora/composables';
+import { useLoraCardActions } from '../../composables/lora-gallery/useLoraCardActions';
 import type { LoraGallerySelectionState, LoraListItem, LoraUpdatePayload } from '@/types';
 
 type LoraCardViewModel = {

--- a/app/frontend/src/features/lora/components/lora-gallery/LoraGallery.vue
+++ b/app/frontend/src/features/lora/components/lora-gallery/LoraGallery.vue
@@ -69,9 +69,9 @@ import LoraGalleryFilters from './LoraGalleryFilters.vue';
 import LoraGalleryGrid from './LoraGalleryGrid.vue';
 import LoraGalleryHeader from './LoraGalleryHeader.vue';
 import LoraGalleryTagModal from './LoraGalleryTagModal.vue';
-import { useLoraGalleryData } from '@/features/lora/composables';
-import { useLoraGalleryFilters } from '@/features/lora/composables';
-import { useLoraGallerySelection } from '@/features/lora/composables';
+import { useLoraGalleryData } from '../../composables/lora-gallery/useLoraGalleryData';
+import { useLoraGalleryFilters } from '../../composables/lora-gallery/useLoraGalleryFilters';
+import { useLoraGallerySelection } from '../../composables/lora-gallery/useLoraGallerySelection';
 import { useDialogService, useNotifications, useSyncedQueryParam } from '@/composables/shared';
 import type {
   LoraBulkAction,

--- a/app/frontend/src/features/lora/composables/lora-gallery/useLoraCardActions.ts
+++ b/app/frontend/src/features/lora/composables/lora-gallery/useLoraCardActions.ts
@@ -9,7 +9,7 @@ import {
   toggleLoraActiveState,
   triggerPreviewGeneration,
   updateLoraWeight,
-} from '@/features/lora/services';
+} from '../../services/lora/loraService';
 import type { LoraListItem, LoraUpdatePayload } from '@/types';
 
 type UseLoraCardActionsOptions = {

--- a/app/frontend/src/features/lora/composables/lora-gallery/useLoraGalleryData.ts
+++ b/app/frontend/src/features/lora/composables/lora-gallery/useLoraGalleryData.ts
@@ -1,6 +1,6 @@
 import { storeToRefs } from 'pinia';
 
-import { useAdapterCatalogStore } from '@/features/lora';
+import { useAdapterCatalogStore } from '../../stores/adapterCatalog';
 import type { AdapterListQuery, LoraBulkAction, LoraUpdatePayload } from '@/types';
 
 export function useLoraGalleryData() {

--- a/app/frontend/src/features/lora/index.ts
+++ b/app/frontend/src/features/lora/index.ts
@@ -1,4 +1,2 @@
-export * from './components';
-export * from './composables';
-export * from './services';
-export * from './stores';
+export { LoraGallery, useAdapterCatalogStore, fetchTopAdapters } from './public';
+export type { AdapterCatalogStore } from './public';

--- a/app/frontend/src/features/lora/public.ts
+++ b/app/frontend/src/features/lora/public.ts
@@ -1,0 +1,6 @@
+export { default as LoraGallery } from './components/lora-gallery/LoraGallery.vue';
+
+export { useAdapterCatalogStore } from './stores/adapterCatalog';
+export type { AdapterCatalogStore } from './stores/adapterCatalog';
+
+export { fetchTopAdapters } from './services/lora/loraService';

--- a/app/frontend/src/features/lora/stores/adapterCatalog.ts
+++ b/app/frontend/src/features/lora/stores/adapterCatalog.ts
@@ -2,7 +2,7 @@ import { computed, reactive, ref } from 'vue';
 import { defineStore } from 'pinia';
 
 import { ApiError } from '@/composables/shared';
-import { fetchAdapterList, fetchAdapterTags, performBulkLoraAction } from '@/features/lora/services';
+import { fetchAdapterList, fetchAdapterTags, performBulkLoraAction } from '../services/lora/loraService';
 import { useBackendClient, useBackendEnvironmentSubscription } from '@/services';
 
 import type {

--- a/app/frontend/src/features/recommendations/composables/useRecommendations.ts
+++ b/app/frontend/src/features/recommendations/composables/useRecommendations.ts
@@ -2,7 +2,7 @@ import { computed, ref, watch, type Ref } from 'vue';
 import { storeToRefs } from 'pinia';
 
 import { useRecommendationApi } from '@/composables/shared';
-import { useAdapterCatalogStore } from '@/features/lora';
+import { useAdapterCatalogStore } from '@/features/lora/public';
 import { useBackendEnvironmentSubscription } from '@/services';
 import { useBackendEnvironment, useSettingsStore } from '@/stores';
 import type { AdapterSummary, RecommendationItem, RecommendationResponse } from '@/types';

--- a/app/frontend/src/views/AdminView.vue
+++ b/app/frontend/src/views/AdminView.vue
@@ -31,7 +31,7 @@ import { RouterLink } from 'vue-router';
 import { defineAsyncComponent } from 'vue';
 
 import ImportExportContainer from '@/components/import-export/ImportExportContainer.vue';
-import { JobQueue, SystemAdminStatusCard, SystemStatusPanel } from '@/features/generation';
+import { JobQueue, SystemAdminStatusCard, SystemStatusPanel } from '@/features/generation/public';
 import PageHeader from '@/components/layout/PageHeader.vue';
 import { RecommendationsPanel } from '@/features/recommendations';
 

--- a/app/frontend/src/views/DashboardView.vue
+++ b/app/frontend/src/views/DashboardView.vue
@@ -74,10 +74,15 @@ import { RouterLink } from 'vue-router';
 import DashboardGenerationSummary from '@/components/dashboard/DashboardGenerationSummary.vue';
 import DashboardLazyModuleCard from '@/components/dashboard/DashboardLazyModuleCard.vue';
 import DashboardLoraSummary from '@/components/dashboard/DashboardLoraSummary.vue';
-import { JobQueue, SystemAdminStatusCard, SystemStatusCard, SystemStatusPanel } from '@/features/generation';
+import {
+  JobQueue,
+  SystemAdminStatusCard,
+  SystemStatusCard,
+  SystemStatusPanel,
+} from '@/features/generation/public';
 import PageHeader from '@/components/layout/PageHeader.vue';
 import { RecommendationsPanel } from '@/features/recommendations';
-import { usePerformanceAnalyticsStore } from '@/features/analytics';
+import { usePerformanceAnalyticsStore } from '@/features/analytics/public';
 
 type PanelKey = 'analytics' | 'composer' | 'studio' | 'gallery' | 'history' | 'importExport';
 

--- a/app/frontend/src/views/GenerateCompositionExampleView.vue
+++ b/app/frontend/src/views/GenerateCompositionExampleView.vue
@@ -25,5 +25,5 @@ import { RouterLink } from 'vue-router';
 
 import PageHeader from '@/components/layout/PageHeader.vue';
 import PromptComposer from '@/components/compose/PromptComposer.vue';
-import { SystemStatusCard, SystemStatusPanel } from '@/features/generation';
+import { SystemStatusCard, SystemStatusPanel } from '@/features/generation/public';
 </script>

--- a/app/frontend/src/views/GenerateView.vue
+++ b/app/frontend/src/views/GenerateView.vue
@@ -24,7 +24,7 @@
 <script setup lang="ts">
 import { RouterLink } from 'vue-router';
 
-import { GenerationStudio, JobQueue, SystemStatusCard } from '@/features/generation';
+import { GenerationStudio, JobQueue, SystemStatusCard } from '@/features/generation/public';
 import PageHeader from '@/components/layout/PageHeader.vue';
 import { RecommendationsPanel } from '@/features/recommendations';
 </script>

--- a/app/frontend/src/views/HistoryView.vue
+++ b/app/frontend/src/views/HistoryView.vue
@@ -24,6 +24,6 @@
 import { RouterLink } from 'vue-router';
 
 import { GenerationHistory } from '@/features/history';
-import { JobQueue, SystemStatusCard } from '@/features/generation';
+import { JobQueue, SystemStatusCard } from '@/features/generation/public';
 import PageHeader from '@/components/layout/PageHeader.vue';
 </script>

--- a/app/frontend/src/views/ImportExportView.vue
+++ b/app/frontend/src/views/ImportExportView.vue
@@ -22,7 +22,7 @@
 import { defineAsyncComponent, ref } from 'vue';
 import { RouterLink } from 'vue-router';
 
-import { JobQueue, SystemStatusPanel } from '@/features/generation';
+import { JobQueue, SystemStatusPanel } from '@/features/generation/public';
 import PageHeader from '@/components/layout/PageHeader.vue';
 import ImportExportSkeleton from '@/components/import-export/ImportExportSkeleton.vue';
 

--- a/app/frontend/src/views/LorasView.vue
+++ b/app/frontend/src/views/LorasView.vue
@@ -17,6 +17,6 @@
 <script setup lang="ts">
 import { RouterLink } from 'vue-router';
 
-import { LoraGallery } from '@/features/lora';
+import { LoraGallery } from '@/features/lora/public';
 import PageHeader from '@/components/layout/PageHeader.vue';
 </script>

--- a/app/frontend/src/views/RecommendationsView.vue
+++ b/app/frontend/src/views/RecommendationsView.vue
@@ -26,5 +26,5 @@ import { RouterLink } from 'vue-router';
 import { GenerationHistory } from '@/features/history';
 import PageHeader from '@/components/layout/PageHeader.vue';
 import { RecommendationsPanel } from '@/features/recommendations';
-import { SystemStatusCard } from '@/features/generation';
+import { SystemStatusCard } from '@/features/generation/public';
 </script>

--- a/app/frontend/src/views/analytics/PerformanceAnalyticsPage.vue
+++ b/app/frontend/src/views/analytics/PerformanceAnalyticsPage.vue
@@ -166,14 +166,14 @@
 import { computed, onMounted, onUnmounted } from 'vue';
 
 import PageHeader from '@/components/layout/PageHeader.vue';
-import { SystemStatusCard, SystemStatusPanel } from '@/features/generation';
+import { SystemStatusCard, SystemStatusPanel } from '@/features/generation/public';
 import {
   PerformanceAnalyticsChartGrid,
   PerformanceAnalyticsExportToolbar,
   PerformanceAnalyticsInsights,
   PerformanceAnalyticsKpiGrid,
   usePerformanceAnalytics,
-} from '@/features/analytics';
+} from '@/features/analytics/public';
 import { useNotifications } from '@/composables/shared';
 import { downloadFile } from '@/utils/browser';
 import { successRateClass } from '@/utils/analyticsFormatting';


### PR DESCRIPTION
## Summary
- add curated `public.ts` entry points for generation, LoRA, and analytics features and limit their `index.ts` barrels to the supported surface
- adjust feature internals to import stores, composables, and services directly instead of routing through the global barrels
- update cross-feature consumers (dashboards, views, analytics) to import from the new public entry points and align analytics with LoRA service helpers

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dc28ff3f608329b1ae47180ab4bc73