### PR TITLE
Refactor recommendations LoRA fetching

### DIFF
--- a/app/frontend/src/features/recommendations/composables/index.ts
+++ b/app/frontend/src/features/recommendations/composables/index.ts
@@ -1,1 +1,2 @@
+export * from './useLoraSummaries';
 export * from './useRecommendations';

--- a/app/frontend/src/features/recommendations/composables/useLoraSummaries.ts
+++ b/app/frontend/src/features/recommendations/composables/useLoraSummaries.ts
@@ -1,0 +1,119 @@
+import { computed, ref } from 'vue';
+
+import { fetchAdapterList } from '@/features/lora/services/lora/loraService';
+import { useBackendClient, useBackendEnvironmentSubscription } from '@/services';
+import type { AdapterListQuery, AdapterListResponse, AdapterSummary } from '@/types';
+
+export interface UseLoraSummariesOptions {
+  /**
+   * Query parameters applied when fetching adapter summaries.
+   * Defaults to a single page of results sized for recommendation usage.
+   */
+  initialQuery?: AdapterListQuery;
+  /**
+   * When false, the helper will not load data automatically on creation.
+   */
+  autoLoad?: boolean;
+}
+
+const SUMMARY_QUERY_DEFAULTS: AdapterListQuery = {
+  page: 1,
+  perPage: 200,
+};
+
+const mergeQuery = (base: AdapterListQuery, overrides: AdapterListQuery = {}): AdapterListQuery => ({
+  ...base,
+  ...overrides,
+});
+
+const mapToSummaries = (payload: AdapterListResponse | null | undefined): AdapterSummary[] => {
+  if (!payload || !Array.isArray(payload.items)) {
+    return [];
+  }
+
+  return payload.items.map((item) => ({
+    id: item.id,
+    name: item.name,
+    description: item.description ?? undefined,
+    active: item.active ?? true,
+  }));
+};
+
+export const useLoraSummaries = (options: UseLoraSummariesOptions = {}) => {
+  const backendClient = useBackendClient();
+
+  const items = ref<AdapterSummary[]>([]);
+  const error = ref<unknown>(null);
+  const isLoading = ref(false);
+  const hasLoaded = ref(false);
+  const pending = ref<Promise<AdapterSummary[]> | null>(null);
+
+  const baseQuery: AdapterListQuery = { ...SUMMARY_QUERY_DEFAULTS, ...(options.initialQuery ?? {}) };
+  const lastQuery = ref<AdapterListQuery>({ ...baseQuery });
+
+  const runFetch = async (query: AdapterListQuery): Promise<AdapterSummary[]> => {
+    if (pending.value) {
+      return pending.value;
+    }
+
+    const request = (async () => {
+      isLoading.value = true;
+      error.value = null;
+
+      try {
+        const payload = await fetchAdapterList(query, backendClient);
+        items.value = mapToSummaries(payload);
+        lastQuery.value = { ...query };
+        hasLoaded.value = true;
+        return items.value;
+      } catch (err) {
+        error.value = err;
+        items.value = [];
+        throw err;
+      } finally {
+        isLoading.value = false;
+        pending.value = null;
+      }
+    })();
+
+    pending.value = request;
+    return request;
+  };
+
+  const load = async (overrides: AdapterListQuery = {}): Promise<AdapterSummary[]> =>
+    runFetch(mergeQuery(baseQuery, overrides));
+
+  const ensureLoaded = async (overrides: AdapterListQuery = {}): Promise<AdapterSummary[]> => {
+    if (!hasLoaded.value || Object.keys(overrides).length > 0) {
+      return load(overrides);
+    }
+    return items.value;
+  };
+
+  const refresh = async (overrides: AdapterListQuery = {}): Promise<AdapterSummary[]> =>
+    runFetch(mergeQuery(lastQuery.value, overrides));
+
+  useBackendEnvironmentSubscription(() => {
+    hasLoaded.value = false;
+    items.value = [];
+    error.value = null;
+    pending.value = null;
+
+    if (options.autoLoad !== false) {
+      void refresh();
+    }
+  });
+
+  if (options.autoLoad !== false) {
+    void load();
+  }
+
+  return {
+    loras: computed(() => items.value),
+    error: computed(() => error.value),
+    isLoading: computed(() => isLoading.value),
+    load,
+    ensureLoaded,
+    refresh,
+  };
+};

--- a/tests/vue/useRecommendations.spec.ts
+++ b/tests/vue/useRecommendations.spec.ts
@@ -5,7 +5,7 @@ import { createPinia, setActivePinia } from 'pinia';
 
 import type { RecommendationItem, RecommendationResponse } from '@/types';
 
-type UseRecommendations = typeof import('@/composables/recommendations/useRecommendations').useRecommendations;
+type UseRecommendations = typeof import('@/features/recommendations/composables/useRecommendations').useRecommendations;
 type UseSettingsStore = typeof import('@/stores/settings').useSettingsStore;
 
 const flush = async () => {
@@ -168,10 +168,17 @@ describe('useRecommendations', () => {
       const actual = await vi.importActual<typeof import('@/services')>('@/services');
       return {
         ...actual,
-        fetchAdapterList: serviceMocks.fetchAdapterList,
-        fetchAdapterTags: serviceMocks.fetchAdapterTags,
-        performBulkLoraAction: serviceMocks.performBulkLoraAction,
         useBackendClient: serviceMocks.useBackendClient,
+      };
+    });
+
+    vi.doMock('@/features/lora/services/lora/loraService', async () => {
+      const actual = await vi.importActual<typeof import('@/features/lora/services/lora/loraService')>(
+        '@/features/lora/services/lora/loraService',
+      );
+      return {
+        ...actual,
+        fetchAdapterList: serviceMocks.fetchAdapterList,
       };
     });
 
@@ -191,7 +198,7 @@ describe('useRecommendations', () => {
       };
     });
 
-    const module = await import('@/composables/recommendations/useRecommendations');
+    const module = await import('@/features/recommendations/composables/useRecommendations');
     useRecommendations = module.useRecommendations;
 
     const settingsModule = await import('@/stores/settings');


### PR DESCRIPTION
## Summary
- add a lightweight `useLoraSummaries` composable to load LoRA adapter summaries without the gallery store
- refactor `useRecommendations` to consume the new helper, keep selections in sync, and drop the gallery dependency
- update the recommendations barrel export and unit test mocks to exercise the slimmer data dependency

## Testing
- npm run test -- useRecommendations

------
https://chatgpt.com/codex/tasks/task_e_68dc2f0fd96c8329965634463669bbaa