### PR TITLE
feat: centralize backend refresh handling

### DIFF
--- a/app/frontend/src/features/analytics/stores/performanceAnalytics.ts
+++ b/app/frontend/src/features/analytics/stores/performanceAnalytics.ts
@@ -1,7 +1,7 @@
 import { computed, ref } from 'vue';
 import { defineStore } from 'pinia';
 
-import { useBackendClient, useBackendEnvironmentSubscription } from '@/services';
+import { useBackendClient, useBackendRefresh } from '@/services';
 import { fetchTopAdapters } from '@/features/lora/public';
 import { exportAnalyticsReport, fetchPerformanceAnalytics } from '../services/analyticsService';
 import { formatDuration as formatDurationLabel } from '@/utils/format';
@@ -196,7 +196,7 @@ export const usePerformanceAnalyticsStore = defineStore('performanceAnalytics', 
     timeRange.value = range;
   };
 
-  useBackendEnvironmentSubscription(() => {
+  useBackendRefresh(() => {
     void loadAllData();
   });
 

--- a/app/frontend/src/features/lora/stores/adapterCatalog.ts
+++ b/app/frontend/src/features/lora/stores/adapterCatalog.ts
@@ -3,7 +3,7 @@ import { defineStore } from 'pinia';
 
 import { ApiError } from '@/composables/shared';
 import { fetchAdapterList, fetchAdapterTags, performBulkLoraAction } from '../services/lora/loraService';
-import { useBackendClient, useBackendEnvironmentSubscription } from '@/services';
+import { useBackendClient, useBackendRefresh } from '@/services';
 
 import type {
   AdapterRead,
@@ -224,13 +224,13 @@ export const useAdapterCatalogStore = defineStore('adapterCatalog', () => {
     await fetchTags();
   };
 
-  const backendSubscription = useBackendEnvironmentSubscription(() => {
+  const backendRefresh = useBackendRefresh(() => {
     void refresh();
     void fetchTags();
   });
 
   const reset = () => {
-    backendSubscription.stop();
+    backendRefresh.stop();
     pendingFetch.value = null;
     lastFetchedAt.value = null;
     pendingTagFetch.value = null;
@@ -241,7 +241,7 @@ export const useAdapterCatalogStore = defineStore('adapterCatalog', () => {
     availableTags.value = [];
     tagError.value = null;
     Object.assign(query, { ...DEFAULT_QUERY });
-    backendSubscription.start();
+    backendRefresh.start();
   };
 
   return {

--- a/app/frontend/src/features/recommendations/composables/useRecommendations.ts
+++ b/app/frontend/src/features/recommendations/composables/useRecommendations.ts
@@ -3,7 +3,7 @@ import { storeToRefs } from 'pinia';
 
 import { useRecommendationApi } from '@/composables/shared';
 import { useAdapterCatalogStore } from '@/features/lora/public';
-import { useBackendEnvironmentSubscription } from '@/services';
+import { useBackendRefresh } from '@/services';
 import { useBackendEnvironment, useSettingsStore } from '@/stores';
 import type { AdapterSummary, RecommendationItem, RecommendationResponse } from '@/types';
 
@@ -183,7 +183,7 @@ export const useRecommendations = (options: UseRecommendationsOptions = {}) => {
     }
   });
 
-  useBackendEnvironmentSubscription(() => {
+  useBackendRefresh(() => {
     if (selectedLora.value) {
       void fetchRecommendations();
     }

--- a/app/frontend/src/services/system/backendRefresh.ts
+++ b/app/frontend/src/services/system/backendRefresh.ts
@@ -1,0 +1,122 @@
+import { onScopeDispose } from 'vue';
+
+import {
+  type BackendEnvironmentSubscription,
+  useBackendEnvironmentSubscription,
+} from './backendEnvironmentBus';
+
+export interface BackendRefreshOptions {
+  /**
+   * Minimum amount of time (in milliseconds) between refresh executions.
+   * Defaults to `0`, meaning every backend change triggers an immediate refresh.
+   */
+  throttleMs?: number;
+  /**
+   * When `true`, the refresh callback will be scheduled immediately after the helper is created.
+   */
+  immediate?: boolean;
+}
+
+export interface BackendRefreshSubscription extends BackendEnvironmentSubscription {
+  /**
+   * Manually request a refresh using the configured throttling rules.
+   */
+  trigger(): void;
+}
+
+export const useBackendRefresh = (
+  refresh: () => void | Promise<void>,
+  options: BackendRefreshOptions = {},
+): BackendRefreshSubscription => {
+  const { throttleMs = 0, immediate = false } = options;
+
+  let lastRunAt = 0;
+  let pendingTimer: ReturnType<typeof setTimeout> | null = null;
+  let isSubscribed = true;
+
+  const clearPendingTimer = () => {
+    if (pendingTimer) {
+      clearTimeout(pendingTimer);
+      pendingTimer = null;
+    }
+  };
+
+  const runRefresh = () => {
+    clearPendingTimer();
+    lastRunAt = Date.now();
+    void refresh();
+  };
+
+  const scheduleRefresh = () => {
+    if (!isSubscribed || !subscription.isActive()) {
+      return;
+    }
+
+    if (throttleMs <= 0) {
+      runRefresh();
+      return;
+    }
+
+    const elapsed = Date.now() - lastRunAt;
+    if (elapsed >= throttleMs) {
+      runRefresh();
+      return;
+    }
+
+    clearPendingTimer();
+    pendingTimer = setTimeout(runRefresh, throttleMs - elapsed);
+  };
+
+  const subscription = useBackendEnvironmentSubscription(() => {
+    scheduleRefresh();
+  });
+
+  const stop = () => {
+    if (!isSubscribed) {
+      return;
+    }
+    isSubscribed = false;
+    clearPendingTimer();
+    subscription.stop();
+  };
+
+  const start = () => {
+    if (isSubscribed) {
+      return;
+    }
+    isSubscribed = true;
+    lastRunAt = 0;
+    subscription.start();
+    if (immediate) {
+      scheduleRefresh();
+    }
+  };
+
+  const restart = () => {
+    stop();
+    start();
+  };
+
+  const trigger = () => {
+    scheduleRefresh();
+  };
+
+  const isActive = () => isSubscribed && subscription.isActive();
+
+  onScopeDispose(() => {
+    clearPendingTimer();
+    isSubscribed = false;
+  });
+
+  if (immediate) {
+    scheduleRefresh();
+  }
+
+  return {
+    start,
+    stop,
+    restart,
+    isActive,
+    trigger,
+  } satisfies BackendRefreshSubscription;
+};

--- a/app/frontend/src/services/system/index.ts
+++ b/app/frontend/src/services/system/index.ts
@@ -1,2 +1,3 @@
 export * from './systemService';
 export * from './backendEnvironmentBus';
+export * from './backendRefresh';

--- a/app/frontend/src/stores/adminMetrics.ts
+++ b/app/frontend/src/stores/adminMetrics.ts
@@ -6,7 +6,7 @@ import {
   emptyMetricsSnapshot,
   fetchDashboardStats,
   useBackendClient,
-  useBackendEnvironmentSubscription,
+  useBackendRefresh,
 } from '@/services';
 import {
   buildResourceStats,
@@ -95,7 +95,7 @@ export const useAdminMetricsStore = defineStore('adminMetrics', () => {
     }
   };
 
-  useBackendEnvironmentSubscription(() => {
+  useBackendRefresh(() => {
     void refresh({ showLoader: false });
   });
 


### PR DESCRIPTION
## Summary
- add a reusable `useBackendRefresh` helper to manage backend environment subscriptions with optional throttling
- refactor the admin metrics store, analytics store, adapter catalog store, and recommendations composable to rely on the shared helper for consistent refresh handling

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dc2f1a04c88329aa744324199fc983