### PR TITLE
Guard orchestrator manager against failing factories

### DIFF
--- a/app/frontend/src/features/generation/composables/useGenerationOrchestratorManager.ts
+++ b/app/frontend/src/features/generation/composables/useGenerationOrchestratorManager.ts
@@ -217,9 +217,16 @@ export const createUseGenerationOrchestratorManager = (
       debug: options.debug,
     };
 
-    orchestratorManagerStore.registerConsumer(consumer);
-
-    const orchestrator = ensureOrchestrator(options);
+    const orchestrator = (() => {
+      try {
+        const created = ensureOrchestrator(options);
+        orchestratorManagerStore.registerConsumer(consumer);
+        return created;
+      } catch (error) {
+        orchestratorManagerStore.unregisterConsumer(consumer.id);
+        throw error;
+      }
+    })();
 
     const loadSystemStatusData = (): Promise<void> => orchestrator.loadSystemStatusData();
     const loadActiveJobsData = (): Promise<void> => orchestrator.loadActiveJobsData();

--- a/tests/vue/composables/useGenerationOrchestratorManager.spec.ts
+++ b/tests/vue/composables/useGenerationOrchestratorManager.spec.ts
@@ -4,9 +4,9 @@ import { ref, type Ref } from 'vue';
 import {
   createUseGenerationOrchestratorManager,
   type UseGenerationOrchestratorManagerDependencies,
-} from '@/composables/generation/useGenerationOrchestratorManager';
-import { createGenerationOrchestratorFactory } from '@/composables/generation/createGenerationOrchestrator';
-import type { GenerationNotificationAdapter } from '@/composables/generation/useGenerationTransport';
+} from '@/features/generation/composables/useGenerationOrchestratorManager';
+import { createGenerationOrchestratorFactory } from '@/features/generation/composables/createGenerationOrchestrator';
+import type { GenerationNotificationAdapter } from '@/features/generation/composables/useGenerationTransport';
 import type {
   GenerationConnectionStore,
   GenerationOrchestratorConsumer,
@@ -14,9 +14,9 @@ import type {
   GenerationQueueStore,
   GenerationResultsStore,
   GenerationStudioUiStore,
-} from '@/stores/generation';
+} from '@/features/generation/stores';
 import type { SettingsStore } from '@/stores';
-import type { GenerationOrchestrator } from '@/composables/generation/createGenerationOrchestrator';
+import type { GenerationOrchestrator } from '@/features/generation/composables/createGenerationOrchestrator';
 import type {
   GenerationJob,
   GenerationRequestPayload,
@@ -25,7 +25,7 @@ import type {
   SystemStatusState,
 } from '@/types';
 
-vi.mock('@/composables/generation/createGenerationOrchestrator', () => ({
+vi.mock('@/features/generation/composables/createGenerationOrchestrator', () => ({
   createGenerationOrchestratorFactory: vi.fn(),
 }));
 

--- a/tests/vue/composables/useGenerationOrchestratorManager.spec.ts
+++ b/tests/vue/composables/useGenerationOrchestratorManager.spec.ts
@@ -189,6 +189,25 @@ describe('createUseGenerationOrchestratorManager', () => {
     vi.clearAllMocks();
   });
 
+  it('rethrows factory errors without retaining consumers', () => {
+    const { dependencies, orchestratorManagerStore } = createDependencies();
+    const error = new Error('factory failed');
+
+    orchestratorManagerStore.ensureOrchestrator = vi
+      .fn((factory: () => GenerationOrchestrator) => {
+        factory();
+        throw error;
+      }) as GenerationOrchestratorManagerStore['ensureOrchestrator'];
+
+    const useManager = createUseGenerationOrchestratorManager(dependencies);
+    const manager = useManager();
+
+    expect(() => manager.acquire({ notify: vi.fn() })).toThrowError(error);
+    expect(orchestratorManagerStore.registerConsumer).not.toHaveBeenCalled();
+    expect(orchestratorManagerStore.unregisterConsumer).toHaveBeenCalledTimes(1);
+    expect(orchestratorManagerStore.consumers.value.size).toBe(0);
+  });
+
   it('initializes orchestrator once and updates manager state', async () => {
     const { binding, orchestrator, stores } = createBinding();
 


### PR DESCRIPTION
## Summary
- ensure generation orchestrator consumers are registered only after successful creation and are cleaned up if creation fails
- wrap orchestrator factory execution in a guarded scope so watcher scopes are not leaked on exceptions
- extend the orchestrator manager composable tests to cover failing factories and consumer cleanup

## Testing
- npm run test -- tests/vue/composables/useGenerationOrchestratorManager.spec.ts *(fails: module resolution error for "@/composables/generation/useGenerationOrchestratorManager")*

------
https://chatgpt.com/codex/tasks/task_e_68dc34304c6083299f84fa2f87ac7eaf