### PR TITLE
feat: centralize async lifecycle error handling

### DIFF
--- a/app/frontend/src/components/import-export/ImportExportContainer.vue
+++ b/app/frontend/src/components/import-export/ImportExportContainer.vue
@@ -3,7 +3,7 @@
 </template>
 
 <script setup lang="ts">
-import { onMounted } from 'vue';
+import { useAsyncLifecycleTask, useNotifications } from '@/composables/shared';
 
 import ImportExport from './ImportExport.vue';
 
@@ -13,8 +13,22 @@ const emit = defineEmits<{ (event: 'initialized'): void }>();
 
 const { initialize } = provideImportExportContext();
 
-onMounted(async () => {
-  await initialize();
-  emit('initialized');
-});
+const { showError } = useNotifications();
+
+useAsyncLifecycleTask(
+  async () => {
+    await initialize();
+    emit('initialized');
+  },
+  {
+    errorMessage: (error) =>
+      error instanceof Error
+        ? `Failed to initialize the import/export interface: ${error.message}`
+        : 'Failed to initialize the import/export interface.',
+    notifyError: (message) => {
+      showError(message, 8000);
+    },
+    logLabel: '[ImportExport] Initialization',
+  },
+);
 </script>

--- a/app/frontend/src/composables/shared/index.ts
+++ b/app/frontend/src/composables/shared/index.ts
@@ -6,3 +6,4 @@ export * from './usePolling';
 export * from './useTheme';
 export * from './usePersistence';
 export * from './useSyncedQueryParam';
+export * from './useAsyncLifecycleTask';

--- a/app/frontend/src/composables/shared/useAsyncLifecycleTask.ts
+++ b/app/frontend/src/composables/shared/useAsyncLifecycleTask.ts
@@ -1,0 +1,104 @@
+import { onMounted } from 'vue'
+
+import { useDialogService, type UseDialogServiceReturn } from './useDialogService'
+import { useNotifications } from './useNotifications'
+
+type LifecycleHookRegistrar = (callback: () => void) => void
+
+type Resolveable<T> = T | ((error: unknown) => T)
+
+type ConfirmOptions = Parameters<UseDialogServiceReturn['confirm']>[0]
+
+type NotifyErrorHandler = (message: string, error: unknown) => void
+
+type AsyncLifecycleTaskOptions = {
+  hook?: LifecycleHookRegistrar
+  errorMessage?: Resolveable<string>
+  notificationDuration?: number
+  notifyError?: NotifyErrorHandler | null
+  dialog?: UseDialogServiceReturn
+  dialogOptions?: Resolveable<ConfirmOptions | null | undefined>
+  onError?: (error: unknown) => void | Promise<void>
+  onFinally?: () => void | Promise<void>
+  logLabel?: string
+  rethrow?: boolean
+}
+
+const resolveValue = <T>(value: Resolveable<T> | undefined, error: unknown): T | undefined => {
+  if (typeof value === 'function') {
+    return (value as (error: unknown) => T)(error)
+  }
+
+  return value
+}
+
+const defaultErrorMessage = 'An unexpected error occurred. Please try again.'
+
+export const useAsyncLifecycleTask = (
+  task: () => Promise<unknown>,
+  {
+    hook = onMounted,
+    errorMessage,
+    notificationDuration,
+    notifyError,
+    dialog,
+    dialogOptions,
+    onError,
+    onFinally,
+    logLabel = '[LifecycleTask]',
+    rethrow = false,
+  }: AsyncLifecycleTaskOptions = {},
+) => {
+  const notifications = useNotifications()
+  const dialogService = dialog ?? useDialogService()
+
+  const executeTask = async (): Promise<void> => {
+    try {
+      await task()
+    } catch (error) {
+      const message = resolveValue(errorMessage, error) ?? defaultErrorMessage
+
+      console.error(`${logLabel} failed`, error)
+
+      const effectiveNotify: NotifyErrorHandler | null =
+        notifyError === null
+          ? null
+          : notifyError ?? ((msg: string) => notifications.showError(msg, notificationDuration))
+
+      if (effectiveNotify) {
+        effectiveNotify(message, error)
+      }
+
+      const resolvedDialogOptions = resolveValue(dialogOptions, error)
+
+      if (resolvedDialogOptions) {
+        await dialogService.confirm({
+          confirmLabel: resolvedDialogOptions.confirmLabel ?? 'Dismiss',
+          cancelLabel: resolvedDialogOptions.cancelLabel ?? 'Close',
+          ...resolvedDialogOptions,
+          message: resolvedDialogOptions.message ?? message,
+        })
+      }
+
+      if (onError) {
+        await onError(error)
+      }
+
+      if (rethrow) {
+        throw error
+      }
+    } finally {
+      if (onFinally) {
+        await onFinally()
+      }
+    }
+  }
+
+  hook(() => {
+    void executeTask()
+  })
+
+  return { run: executeTask }
+}
+
+export type UseAsyncLifecycleTaskReturn = ReturnType<typeof useAsyncLifecycleTask>

--- a/app/frontend/src/features/lora/components/lora-gallery/LoraGallery.vue
+++ b/app/frontend/src/features/lora/components/lora-gallery/LoraGallery.vue
@@ -62,7 +62,7 @@
 </template>
 
 <script setup lang="ts">
-import { onMounted, ref } from 'vue';
+import { ref } from 'vue';
 
 import LoraGalleryBulkActions from './LoraGalleryBulkActions.vue';
 import LoraGalleryFilters from './LoraGalleryFilters.vue';
@@ -72,7 +72,7 @@ import LoraGalleryTagModal from './LoraGalleryTagModal.vue';
 import { useLoraGalleryData } from '../../composables/lora-gallery/useLoraGalleryData';
 import { useLoraGalleryFilters } from '../../composables/lora-gallery/useLoraGalleryFilters';
 import { useLoraGallerySelection } from '../../composables/lora-gallery/useLoraGallerySelection';
-import { useDialogService, useNotifications, useSyncedQueryParam } from '@/composables/shared';
+import { useAsyncLifecycleTask, useDialogService, useNotifications, useSyncedQueryParam } from '@/composables/shared';
 import type {
   LoraBulkAction,
   LoraUpdatePayload,
@@ -175,8 +175,20 @@ const handleLoraDelete = (id: string) => {
   deselect(id);
 };
 
-onMounted(async () => {
-  initializeSelection();
-  await initialize();
-});
+useAsyncLifecycleTask(
+  async () => {
+    initializeSelection();
+    await initialize();
+  },
+  {
+    errorMessage: (error) =>
+      error instanceof Error
+        ? `Failed to load the LoRA gallery: ${error.message}`
+        : 'Failed to load the LoRA gallery.',
+    notifyError: (message) => {
+      showError(message, 8000);
+    },
+    logLabel: '[LoraGallery] Initialization',
+  },
+);
 </script>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,9 @@
     "baseUrl": ".",
     "paths": {
       "@/*": ["app/frontend/src/*"],
-      "@/features/*": ["app/frontend/src/features/*"]
+      "@/features/*": ["app/frontend/src/features/*"],
+      "@/composables/generation/*": ["app/frontend/src/features/generation/composables/*"],
+      "@/stores/generation": ["app/frontend/src/features/generation/stores/form.ts"]
     },
     "types": ["vite/client"],
     "allowJs": false,

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -8,14 +8,28 @@ const vendorDir = resolve(frontendSrc, 'vendor');
 export default defineConfig({
   plugins: [vue()],
   resolve: {
-    alias: {
-      '@': frontendSrc,
-      'vue-virtual-scroller': resolve(vendorDir, 'vue-virtual-scroller.ts'),
-      'vue-virtual-scroller/dist/vue-virtual-scroller.css': resolve(
-        vendorDir,
-        'vue-virtual-scroller.css',
-      ),
-    },
+    alias: [
+      {
+        find: '@/composables/generation',
+        replacement: resolve(frontendSrc, 'features/generation/composables'),
+      },
+      {
+        find: '@/stores/generation',
+        replacement: resolve(frontendSrc, 'features/generation/stores/form.ts'),
+      },
+      {
+        find: '@',
+        replacement: frontendSrc,
+      },
+      {
+        find: 'vue-virtual-scroller',
+        replacement: resolve(vendorDir, 'vue-virtual-scroller.ts'),
+      },
+      {
+        find: 'vue-virtual-scroller/dist/vue-virtual-scroller.css',
+        replacement: resolve(vendorDir, 'vue-virtual-scroller.css'),
+      },
+    ],
   },
   test: {
     environment: 'jsdom',


### PR DESCRIPTION
## Summary
- add a reusable useAsyncLifecycleTask helper for guarded lifecycle async work
- refactor generation, gallery, import/export, and history setups to use the new helper
- expand vitest specs for initialization failures and update aliases for shared composables

## Testing
- npx vitest run tests/vue/composables/useGenerationStudio.integration.spec.ts tests/vue/LoraGallery.spec.js tests/vue/ImportExportView.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68dc372266e88329b019713e3b911e97