### PR TITLE
Centralize generation polling configuration

### DIFF
--- a/app/frontend/src/features/generation/composables/useGenerationQueueClient.ts
+++ b/app/frontend/src/features/generation/composables/useGenerationQueueClient.ts
@@ -1,7 +1,7 @@
 import { ref, shallowRef } from 'vue';
 
 import { createGenerationQueueClient, type GenerationQueueClient } from '../services/queueClient';
-import { DEFAULT_POLL_INTERVAL } from '../services/updates';
+import { generationPollingConfig } from '../config/polling';
 import { parseGenerationJobStatuses, parseGenerationResults } from '../services/validation';
 import type { GenerationJobInput } from '../stores/queue';
 import type {
@@ -69,7 +69,7 @@ export const useGenerationQueueClient = (
   callbacks: QueueClientCallbacks,
 ) => {
   const queueClientRef = shallowRef<GenerationQueueClient | null>(options.queueClient ?? null);
-  const pollInterval = ref(options.pollIntervalMs ?? DEFAULT_POLL_INTERVAL);
+  const pollInterval = ref(options.pollIntervalMs ?? generationPollingConfig.queueMs);
   const pollTimer = ref<number | null>(null);
   const logDebug = (...args: unknown[]): void => {
     if (typeof callbacks.logger === 'function') {
@@ -172,7 +172,9 @@ export const useGenerationQueueClient = (
 
   const setPollInterval = (nextInterval: number): void => {
     const numeric = Math.floor(Number(nextInterval));
-    pollInterval.value = Number.isFinite(numeric) && numeric > 0 ? numeric : DEFAULT_POLL_INTERVAL;
+    pollInterval.value = Number.isFinite(numeric) && numeric > 0
+      ? numeric
+      : generationPollingConfig.queueMs;
 
     if (pollTimer.value != null) {
       stopPolling();

--- a/app/frontend/src/features/generation/composables/useJobQueue.ts
+++ b/app/frontend/src/features/generation/composables/useJobQueue.ts
@@ -1,6 +1,7 @@
 import { computed, unref, type MaybeRefOrGetter } from 'vue';
 import { storeToRefs } from 'pinia';
 
+import { generationPollingConfig } from '../config/polling';
 import { useGenerationConnectionStore } from '../stores/connection';
 import { useGenerationQueueStore } from '../stores/queue';
 import { useGenerationResultsStore } from '../stores/results';
@@ -12,8 +13,6 @@ import type { UseNotificationsReturn } from '@/composables/shared';
 
 import { useJobQueueTransport } from './useJobQueueTransport';
 import { useJobQueuePolling } from './useJobQueuePolling';
-
-const DEFAULT_POLL_INTERVAL = 2000;
 
 export interface UseJobQueueOptions {
   pollInterval?: MaybeRefOrGetter<number>;
@@ -39,7 +38,7 @@ const resolveBoolean = (value?: MaybeRefOrGetter<boolean>): boolean => {
 
 const resolveNumber = (
   value?: MaybeRefOrGetter<number>,
-  fallback = DEFAULT_POLL_INTERVAL,
+  fallback = generationPollingConfig.queueMs,
 ): number => {
   if (value === undefined) {
     return fallback;

--- a/app/frontend/src/features/generation/config/polling.ts
+++ b/app/frontend/src/features/generation/config/polling.ts
@@ -1,0 +1,155 @@
+import { runtimeConfig } from '@/config/runtime';
+import { tryGetSettingsStore } from '@/stores/settings';
+import type { FrontendRuntimeSettings } from '@/types';
+
+export interface GenerationPollingIntervals {
+  /**
+   * Queue polling interval in milliseconds.
+   * Controls how frequently the SPA polls the REST queue endpoint when no
+   * WebSocket updates are available.
+   */
+  queueMs: number;
+  /**
+   * WebSocket reconnect delay in milliseconds.
+   * Determines how long the client waits before attempting to re-open a
+   * dropped progress WebSocket connection.
+   */
+  websocketRetryMs: number;
+  /**
+   * System status polling interval in milliseconds.
+   * Governs how often the SPA requests system health snapshots when the
+   * realtime feed is unavailable.
+   */
+  systemStatusMs: number;
+}
+
+export type GenerationPollingOverrides = Partial<GenerationPollingIntervals>;
+
+const DEFAULT_INTERVALS: GenerationPollingIntervals = Object.freeze({
+  queueMs: 2_000,
+  websocketRetryMs: 3_000,
+  systemStatusMs: 10_000,
+});
+
+const parsePositiveInteger = (value: unknown): number | null => {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    const rounded = Math.floor(value);
+    return rounded > 0 ? rounded : null;
+  }
+
+  if (typeof value === 'string') {
+    const numeric = Number.parseInt(value, 10);
+    if (Number.isFinite(numeric)) {
+      return numeric > 0 ? numeric : null;
+    }
+  }
+
+  return null;
+};
+
+const normaliseOverrides = (overrides: GenerationPollingOverrides | null | undefined) => {
+  if (!overrides || typeof overrides !== 'object') {
+    return {} as GenerationPollingOverrides;
+  }
+
+  const normalised: GenerationPollingOverrides = {};
+
+  if ('queueMs' in overrides) {
+    const parsed = parsePositiveInteger(overrides.queueMs);
+    if (parsed != null) {
+      normalised.queueMs = parsed;
+    }
+  }
+
+  if ('websocketRetryMs' in overrides) {
+    const parsed = parsePositiveInteger(overrides.websocketRetryMs);
+    if (parsed != null) {
+      normalised.websocketRetryMs = parsed;
+    }
+  }
+
+  if ('systemStatusMs' in overrides) {
+    const parsed = parsePositiveInteger(overrides.systemStatusMs);
+    if (parsed != null) {
+      normalised.systemStatusMs = parsed;
+    }
+  }
+
+  return normalised;
+};
+
+const readRuntimeConfigOverrides = (): GenerationPollingOverrides => {
+  const overrides =
+    (runtimeConfig.generationPolling as GenerationPollingOverrides | undefined | null) ?? null;
+  return normaliseOverrides(overrides);
+};
+
+const readSettingsOverrides = (): GenerationPollingOverrides => {
+  const store = tryGetSettingsStore();
+  const settings: FrontendRuntimeSettings | null | undefined = store?.rawSettings ?? null;
+
+  if (!settings || typeof settings !== 'object') {
+    return {};
+  }
+
+  const overrides = normaliseOverrides(
+    (settings as { generationPolling?: GenerationPollingOverrides | null | undefined })
+      .generationPolling,
+  );
+
+  return overrides;
+};
+
+const resolveInterval = (
+  key: keyof GenerationPollingIntervals,
+  fallback: number,
+): number => {
+  const settingsOverrides = readSettingsOverrides();
+  if (settingsOverrides[key] != null) {
+    return settingsOverrides[key] as number;
+  }
+
+  const runtimeOverrides = readRuntimeConfigOverrides();
+  if (runtimeOverrides[key] != null) {
+    return runtimeOverrides[key] as number;
+  }
+
+  return fallback;
+};
+
+export const generationPollingConfig = {
+  /**
+   * Default interval values used when no runtime overrides are present.
+   */
+  defaults: DEFAULT_INTERVALS,
+  /**
+   * Effective queue polling interval in milliseconds.
+   */
+  get queueMs(): number {
+    return resolveInterval('queueMs', DEFAULT_INTERVALS.queueMs);
+  },
+  /**
+   * Effective WebSocket reconnect delay in milliseconds.
+   */
+  get websocketRetryMs(): number {
+    return resolveInterval('websocketRetryMs', DEFAULT_INTERVALS.websocketRetryMs);
+  },
+  /**
+   * Effective system status polling interval in milliseconds.
+   */
+  get systemStatusMs(): number {
+    return resolveInterval('systemStatusMs', DEFAULT_INTERVALS.systemStatusMs);
+  },
+  /**
+   * Resolve a snapshot of the polling configuration.
+   */
+  resolve(): GenerationPollingIntervals {
+    return {
+      queueMs: this.queueMs,
+      websocketRetryMs: this.websocketRetryMs,
+      systemStatusMs: this.systemStatusMs,
+    };
+  },
+} as const;
+
+export default generationPollingConfig;

--- a/app/frontend/src/features/generation/services/updates.ts
+++ b/app/frontend/src/features/generation/services/updates.ts
@@ -1,7 +1,5 @@
 import type { GenerationErrorMessage } from '@/types';
 
-export const DEFAULT_POLL_INTERVAL = 2000;
-
 export const extractGenerationErrorMessage = (message: GenerationErrorMessage): string => {
   if (typeof message.error === 'string' && message.error.trim()) {
     return message.error;

--- a/app/frontend/src/features/generation/services/websocketManager.ts
+++ b/app/frontend/src/features/generation/services/websocketManager.ts
@@ -1,3 +1,4 @@
+import { generationPollingConfig } from '../config/polling';
 import { resolveGenerationBaseUrl } from './generationService';
 import { ensureArray } from './validation';
 import type {
@@ -9,7 +10,7 @@ import type {
   WebSocketMessage,
 } from '@/types';
 
-const RECONNECT_DELAY = 3000;
+const RECONNECT_DELAY = generationPollingConfig.websocketRetryMs;
 
 const appendWebSocketPath = (path: string): string => {
   const trimmed = path.replace(/\/+$/, '');

--- a/app/frontend/src/features/generation/stores/connection.ts
+++ b/app/frontend/src/features/generation/stores/connection.ts
@@ -1,7 +1,7 @@
 import { reactive, ref } from 'vue';
 import { defineStore } from 'pinia';
 
-import { DEFAULT_POLL_INTERVAL } from '../services/updates';
+import { generationPollingConfig } from '../config/polling';
 import type { SystemStatusPayload, SystemStatusState } from '@/types';
 
 export const DEFAULT_SYSTEM_STATUS: SystemStatusState = {
@@ -20,7 +20,7 @@ export const createDefaultSystemStatus = (): SystemStatusState => ({
 export const useGenerationConnectionStore = defineStore('generation-connection', () => {
   const systemStatus = reactive<SystemStatusState>(createDefaultSystemStatus());
   const isConnected = ref(false);
-  const pollIntervalMs = ref(DEFAULT_POLL_INTERVAL);
+  const pollIntervalMs = ref(generationPollingConfig.queueMs);
   const systemStatusReady = ref(false);
   const systemStatusLastUpdated = ref<Date | null>(null);
   const systemStatusApiAvailable = ref(true);
@@ -32,7 +32,9 @@ export const useGenerationConnectionStore = defineStore('generation-connection',
 
   function setPollInterval(interval: number): void {
     const numeric = Math.floor(Number(interval));
-    pollIntervalMs.value = Number.isFinite(numeric) && numeric > 0 ? numeric : DEFAULT_POLL_INTERVAL;
+    pollIntervalMs.value = Number.isFinite(numeric) && numeric > 0
+      ? numeric
+      : generationPollingConfig.queueMs;
   }
 
   function updateSystemStatus(status: Partial<SystemStatusState>): void {
@@ -78,7 +80,7 @@ export const useGenerationConnectionStore = defineStore('generation-connection',
   function reset(): void {
     resetSystemStatus();
     isConnected.value = false;
-    pollIntervalMs.value = DEFAULT_POLL_INTERVAL;
+    pollIntervalMs.value = generationPollingConfig.queueMs;
     queueManagerActive.value = false;
   }
 

--- a/app/frontend/src/features/generation/stores/systemStatusController.ts
+++ b/app/frontend/src/features/generation/stores/systemStatusController.ts
@@ -4,10 +4,9 @@ import { storeToRefs } from 'pinia';
 import { ApiError } from '@/composables/shared';
 import { fetchSystemStatus, useBackendClient, type BackendClient } from '@/services';
 import { resolveBackendBaseUrl } from '@/utils/backend';
+import { generationPollingConfig } from '../config/polling';
 import { useGenerationConnectionStore } from './connection';
 import { useGenerationOrchestratorManagerStore } from './orchestratorManagerStore';
-
-const DEFAULT_POLL_INTERVAL = 10_000;
 
 export interface SystemStatusController {
   readonly isPolling: ComputedRef<boolean>;
@@ -116,7 +115,7 @@ const createController = (
 
     pollHandle.value = setInterval(() => {
       void refresh();
-    }, DEFAULT_POLL_INTERVAL);
+    }, generationPollingConfig.systemStatusMs);
   };
 
   const ensureHydrated = async (): Promise<void> => {

--- a/app/frontend/src/types/app.ts
+++ b/app/frontend/src/types/app.ts
@@ -12,9 +12,17 @@ import type {
 } from './system';
 
 
+export interface GenerationPollingSettings {
+  queueMs?: number | string | null;
+  websocketRetryMs?: number | string | null;
+  systemStatusMs?: number | string | null;
+  [key: string]: unknown;
+}
+
 export interface FrontendRuntimeSettings {
   backendUrl: string;
   backendApiKey?: string | null;
+  generationPolling?: GenerationPollingSettings | null;
   [key: string]: unknown;
 }
 

--- a/app/main.py
+++ b/app/main.py
@@ -102,9 +102,15 @@ SPA_STATIC_APP = SPAStaticFiles(SPA_DIST_DIR)
 async def frontend_settings():
     """Expose runtime configuration for the Vue SPA."""
     backend_url = _normalise_public_api_url(backend_settings.BACKEND_URL)
+    polling_config = {
+        "queueMs": backend_settings.GENERATION_QUEUE_POLL_INTERVAL_MS,
+        "websocketRetryMs": backend_settings.GENERATION_WEBSOCKET_RETRY_INTERVAL_MS,
+        "systemStatusMs": backend_settings.GENERATION_SYSTEM_STATUS_POLL_INTERVAL_MS,
+    }
     return {
         "backendUrl": backend_url,
         "backendApiKey": backend_settings.API_KEY or None,
+        "generationPolling": polling_config,
     }
 
 

--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -63,6 +63,11 @@ class Settings(BaseSettings):
     SDNEXT_DEFAULT_CFG_SCALE: float = 7.0
     SDNEXT_OUTPUT_DIR: Optional[str] = None  # local storage for generated images
 
+    # Generation polling intervals (milliseconds)
+    GENERATION_QUEUE_POLL_INTERVAL_MS: int = Field(default=2_000, gt=0)
+    GENERATION_WEBSOCKET_RETRY_INTERVAL_MS: int = Field(default=3_000, gt=0)
+    GENERATION_SYSTEM_STATUS_POLL_INTERVAL_MS: int = Field(default=10_000, gt=0)
+
     # CORS settings for backend API
     CORS_ORIGINS: List[str] = Field(
         default_factory=lambda: [

--- a/tests/api/test_frontend_settings.py
+++ b/tests/api/test_frontend_settings.py
@@ -2,6 +2,8 @@
 
 from fastapi.testclient import TestClient
 
+from backend.core.config import settings as backend_settings
+
 
 def test_frontend_settings_endpoint(client: TestClient):
     """Frontend settings endpoint exposes runtime configuration."""
@@ -10,3 +12,8 @@ def test_frontend_settings_endpoint(client: TestClient):
     payload = response.json()
     assert "backendUrl" in payload
     assert payload["backendUrl"].endswith("/api/v1")
+    assert payload["generationPolling"] == {
+        "queueMs": backend_settings.GENERATION_QUEUE_POLL_INTERVAL_MS,
+        "websocketRetryMs": backend_settings.GENERATION_WEBSOCKET_RETRY_INTERVAL_MS,
+        "systemStatusMs": backend_settings.GENERATION_SYSTEM_STATUS_POLL_INTERVAL_MS,
+    }

--- a/tests/mocks/api-mocks.js
+++ b/tests/mocks/api-mocks.js
@@ -4,6 +4,9 @@
  */
 
 import { afterEach, beforeEach, vi } from 'vitest';
+import { generationPollingConfig } from '../../app/frontend/src/features/generation/config/polling';
+
+const defaultGenerationPolling = generationPollingConfig.resolve();
 
 // Mock fetch globally for all tests
 global.fetch = vi.fn();
@@ -499,6 +502,7 @@ const apiMocks = {
 
     'GET /frontend/settings': () => ({
         backendUrl: '/api/v1',
+        generationPolling: defaultGenerationPolling,
         features: {
             enableRecommendations: true,
             enableImportExport: true,


### PR DESCRIPTION
## Summary
- add a shared generation polling config that normalizes runtime overrides and exposes queue, websocket, and system status intervals
- expose backend polling interval settings through `/frontend/settings` and update frontend consumers to import the shared config
- refresh tests and mocks to assert the configurable intervals are honoured

## Testing
- pytest tests/api/test_frontend_settings.py

------
https://chatgpt.com/codex/tasks/task_e_68dc401dfda483298b86472b0c8562a7