### PR TITLE
Add async resource helper and refresh store tests

### DIFF
--- a/app/frontend/src/composables/shared/index.ts
+++ b/app/frontend/src/composables/shared/index.ts
@@ -7,3 +7,4 @@ export * from './useTheme';
 export * from './usePersistence';
 export * from './useSyncedQueryParam';
 export * from './useAsyncLifecycleTask';
+export * from './useAsyncResource';

--- a/app/frontend/src/composables/shared/useAsyncResource.ts
+++ b/app/frontend/src/composables/shared/useAsyncResource.ts
@@ -1,0 +1,307 @@
+import { computed, isRef, onScopeDispose, ref, type ComputedRef, type Ref } from 'vue';
+
+import { useBackendRefresh, type BackendRefreshOptions, type BackendRefreshSubscription } from '@/services';
+
+export interface AsyncResourceBackendRefreshOptions<TArgs>
+  extends BackendRefreshOptions {
+  /**
+   * When provided, determines whether backend refresh triggers should execute the refresh callback.
+   */
+  enabled?: Ref<boolean> | boolean | (() => boolean);
+  /**
+   * Resolves the arguments that should be passed to the refresh handler when triggered by backend
+   * changes. Defaults to the most recent arguments supplied to the resource.
+   */
+  getArgs?: () => TArgs | undefined;
+}
+
+export interface UseAsyncResourceOptions<TArgs, TResult> {
+  /**
+   * Initial arguments used before the first explicit fetch.
+   */
+  initialArgs?: TArgs;
+  /**
+   * Initial data value assigned to the resource.
+   */
+  initialValue?: TResult | null;
+  /**
+   * Custom cache key resolver used to determine whether two argument sets are equivalent.
+   */
+  getKey?: (args: TArgs | undefined) => unknown;
+  /**
+   * Custom staleness predicate to determine whether a cached response should be refreshed.
+   */
+  isStale?: (context: {
+    lastLoadedAt: number | null;
+    lastArgs: TArgs | undefined;
+    nextArgs: TArgs | undefined;
+  }) => boolean;
+  /**
+   * When true, the resource will execute an immediate refresh using the initial arguments.
+   */
+  immediate?: boolean;
+  /**
+   * Enables backend refresh integration. When `true`, default options are used. When an object is
+   * provided, the helper will be configured with the supplied backend refresh options.
+   */
+  backendRefresh?: boolean | AsyncResourceBackendRefreshOptions<TArgs>;
+  /**
+   * Invoked after the fetcher resolves successfully. Receives the resolved arguments for the
+   * request.
+   */
+  onSuccess?: (result: TResult, context: { args: TArgs }) => void;
+  /**
+   * Invoked when the fetcher throws an error. Receives the arguments used for the request.
+   */
+  onError?: (error: unknown, context: { args: TArgs }) => void;
+}
+
+export interface AsyncResourceResult<TArgs, TResult> {
+  data: Ref<TResult | null>;
+  error: Ref<unknown>;
+  isLoading: Ref<boolean>;
+  lastLoadedAt: Ref<number | null>;
+  isLoaded: ComputedRef<boolean>;
+  lastArgs: Ref<TArgs | undefined>;
+  ensureLoaded: (args?: TArgs) => Promise<TResult | null>;
+  refresh: (args?: TArgs) => Promise<TResult | null>;
+  invalidate: () => void;
+  setData: (value: TResult | null, options?: { markLoaded?: boolean; args?: TArgs }) => void;
+  mutate: (
+    updater: (current: TResult | null) => TResult | null,
+    options?: { markLoaded?: boolean; args?: TArgs },
+  ) => TResult | null;
+  setError: (value: unknown) => void;
+  clearError: () => void;
+  reset: () => void;
+  backendRefresh?: BackendRefreshSubscription | null;
+}
+
+const resolveKey = <TArgs>(
+  args: TArgs | undefined,
+  resolver?: (args: TArgs | undefined) => unknown,
+): unknown => {
+  if (resolver) {
+    return resolver(args);
+  }
+
+  try {
+    return JSON.stringify(args ?? null);
+  } catch (error) {
+    if (import.meta.env.DEV) {
+      console.warn('[useAsyncResource] Failed to serialise arguments for cache key', error);
+    }
+    return args as unknown;
+  }
+};
+
+const resolveEnabled = (input?: Ref<boolean> | boolean | (() => boolean)): boolean => {
+  if (typeof input === 'function') {
+    return Boolean(input());
+  }
+
+  if (isRef(input)) {
+    return Boolean(input.value);
+  }
+
+  if (typeof input === 'boolean') {
+    return input;
+  }
+
+  return true;
+};
+
+export const useAsyncResource = <TResult, TArgs = void>(
+  fetcher: (args: TArgs) => Promise<TResult>,
+  options: UseAsyncResourceOptions<TArgs, TResult> = {},
+): AsyncResourceResult<TArgs, TResult> => {
+  const {
+    initialArgs,
+    initialValue = null,
+    getKey,
+    isStale,
+    immediate = false,
+    backendRefresh: backendRefreshOptions = false,
+    onSuccess,
+    onError,
+  } = options;
+
+  const data = ref<TResult | null>(initialValue);
+  const error = ref<unknown>(null);
+  const isLoading = ref(false);
+  const lastLoadedAt = ref<number | null>(null);
+  const lastArgs = ref<TArgs | undefined>(initialArgs);
+
+  let pending: Promise<TResult> | null = null;
+  let lastKey: unknown = resolveKey(initialArgs, getKey);
+
+  const ensureArgs = (args?: TArgs): TArgs => {
+    if (args !== undefined) {
+      return args;
+    }
+    if (lastArgs.value !== undefined) {
+      return lastArgs.value;
+    }
+    if (initialArgs !== undefined) {
+      return initialArgs;
+    }
+    return undefined as unknown as TArgs;
+  };
+
+  const runFetch = (args?: TArgs): Promise<TResult> => {
+    if (pending) {
+      return pending;
+    }
+
+    const nextArgs = ensureArgs(args);
+    const requestKey = resolveKey(nextArgs, getKey);
+
+    const request = (async () => {
+      isLoading.value = true;
+      error.value = null;
+
+      try {
+        const result = await fetcher(nextArgs);
+        data.value = result;
+        lastArgs.value = nextArgs;
+        lastKey = requestKey;
+        lastLoadedAt.value = Date.now();
+        onSuccess?.(result, { args: nextArgs });
+        return result;
+      } catch (err) {
+        error.value = err;
+        onError?.(err, { args: nextArgs });
+        throw err;
+      } finally {
+        isLoading.value = false;
+        pending = null;
+      }
+    })();
+
+    pending = request;
+    return request;
+  };
+
+  const refresh = async (args?: TArgs): Promise<TResult | null> => {
+    const result = await runFetch(args);
+    return result ?? data.value;
+  };
+
+  const ensureLoaded = async (args?: TArgs): Promise<TResult | null> => {
+    const targetArgs = ensureArgs(args);
+    const targetKey = resolveKey(targetArgs, getKey);
+
+    if (pending) {
+      await pending;
+      return data.value;
+    }
+
+    const hasLoaded = lastLoadedAt.value != null;
+    const needsRefresh =
+      !hasLoaded
+      || targetKey !== lastKey
+      || Boolean(
+        isStale?.({
+          lastLoadedAt: lastLoadedAt.value,
+          lastArgs: lastArgs.value,
+          nextArgs: targetArgs,
+        }),
+      );
+
+    if (needsRefresh) {
+      await runFetch(targetArgs);
+    }
+
+    return data.value;
+  };
+
+  const invalidate = () => {
+    lastLoadedAt.value = null;
+  };
+
+  const setData = (
+    value: TResult | null,
+    { markLoaded = false, args }: { markLoaded?: boolean; args?: TArgs } = {},
+  ) => {
+    data.value = value;
+    if (markLoaded) {
+      lastLoadedAt.value = Date.now();
+      if (args !== undefined) {
+        lastArgs.value = args;
+        lastKey = resolveKey(args, getKey);
+      }
+    }
+  };
+
+  const mutate = (
+    updater: (current: TResult | null) => TResult | null,
+    { markLoaded = true, args }: { markLoaded?: boolean; args?: TArgs } = {},
+  ): TResult | null => {
+    const nextValue = updater(data.value);
+    setData(nextValue, { markLoaded, args });
+    return nextValue;
+  };
+
+  const setError = (value: unknown) => {
+    error.value = value;
+  };
+
+  const clearError = () => {
+    error.value = null;
+  };
+
+  const reset = () => {
+    pending = null;
+    isLoading.value = false;
+    error.value = null;
+    data.value = initialValue;
+    lastArgs.value = initialArgs;
+    lastKey = resolveKey(initialArgs, getKey);
+    lastLoadedAt.value = null;
+  };
+
+  let backendRefresh: BackendRefreshSubscription | null = null;
+
+  if (backendRefreshOptions) {
+    const refreshOptions: AsyncResourceBackendRefreshOptions<TArgs> =
+      typeof backendRefreshOptions === 'boolean' ? {} : backendRefreshOptions;
+
+    backendRefresh = useBackendRefresh(() => {
+      if (!resolveEnabled(refreshOptions.enabled)) {
+        return;
+      }
+      const args = refreshOptions.getArgs?.();
+      void refresh(args);
+    }, refreshOptions);
+  }
+
+  if (immediate) {
+    void refresh(initialArgs);
+  }
+
+  onScopeDispose(() => {
+    pending = null;
+  });
+
+  return {
+    data,
+    error,
+    isLoading,
+    lastLoadedAt,
+    isLoaded: computed(() => lastLoadedAt.value != null),
+    lastArgs,
+    ensureLoaded,
+    refresh,
+    invalidate,
+    setData,
+    mutate,
+    setError,
+    clearError,
+    reset,
+    backendRefresh,
+  } satisfies AsyncResourceResult<TArgs, TResult>;
+};
+
+export type UseAsyncResourceReturn<TArgs, TResult> = ReturnType<
+  typeof useAsyncResource<TResult, TArgs>
+>;

--- a/tests/vue/stores/adapterCatalogStore.spec.ts
+++ b/tests/vue/stores/adapterCatalogStore.spec.ts
@@ -1,0 +1,99 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createPinia, setActivePinia } from 'pinia';
+
+import * as services from '@/services';
+import * as loraService from '@/features/lora/services/lora/loraService';
+import { useAdapterCatalogStore } from '@/features/lora/stores/adapterCatalog';
+
+const backendRefreshCallbacks: Array<() => void> = [];
+
+const useBackendClientSpy = vi.spyOn(services, 'useBackendClient');
+const useBackendRefreshSpy = vi.spyOn(services, 'useBackendRefresh');
+const fetchAdapterListSpy = vi.spyOn(loraService, 'fetchAdapterList');
+const fetchAdapterTagsSpy = vi.spyOn(loraService, 'fetchAdapterTags');
+const performBulkLoraActionSpy = vi.spyOn(loraService, 'performBulkLoraAction');
+
+const flushAsync = async () => {
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+};
+
+const createResponse = () => ({
+  items: [
+    { id: 'alpha', name: 'Alpha', description: 'First', active: true },
+    { id: 'beta', name: 'Beta', description: 'Second', active: false },
+  ],
+  total: 2,
+  filtered: 2,
+  page: 1,
+  pages: 1,
+  per_page: 200,
+});
+
+describe('adapterCatalog store', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    backendRefreshCallbacks.splice(0, backendRefreshCallbacks.length);
+    useBackendClientSpy.mockReset().mockReturnValue({});
+    useBackendRefreshSpy.mockReset().mockImplementation((callback: () => void) => {
+      backendRefreshCallbacks.push(callback);
+      return {
+        start: vi.fn(),
+        stop: vi.fn(),
+        restart: vi.fn(() => {
+          callback();
+        }),
+        isActive: vi.fn(() => true),
+        trigger: vi.fn(() => {
+          callback();
+        }),
+      };
+    });
+    fetchAdapterListSpy.mockReset().mockResolvedValue(createResponse());
+    fetchAdapterTagsSpy.mockReset().mockResolvedValue(['alpha', 'beta']);
+    performBulkLoraActionSpy.mockReset().mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    backendRefreshCallbacks.splice(0, backendRefreshCallbacks.length);
+  });
+
+  it('caches adapter summaries and reloads when query changes', async () => {
+    const store = useAdapterCatalogStore();
+
+    await store.ensureLoaded();
+    expect(fetchAdapterListSpy).toHaveBeenCalledTimes(1);
+    expect(store.adapters).toHaveLength(2);
+
+    await store.ensureLoaded();
+    expect(fetchAdapterListSpy).toHaveBeenCalledTimes(1);
+
+    await store.ensureLoaded({ page: 2 });
+    expect(fetchAdapterListSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it('refreshes when backend signals an update', async () => {
+    const store = useAdapterCatalogStore();
+    await store.ensureLoaded();
+    expect(backendRefreshCallbacks).toHaveLength(1);
+
+    fetchAdapterListSpy.mockClear();
+    backendRefreshCallbacks[0]?.();
+    await flushAsync();
+
+    expect(fetchAdapterListSpy).toHaveBeenCalledTimes(1);
+    expect(fetchAdapterTagsSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it('surfaces errors from the adapter endpoint', async () => {
+    const store = useAdapterCatalogStore();
+    fetchAdapterListSpy.mockRejectedValueOnce(new Error('failure'));
+
+    await expect(store.refresh()).rejects.toThrow('failure');
+    await flushAsync();
+    expect(store.error).toBeInstanceOf(Error);
+    expect(store.adapters).toEqual([]);
+  });
+});

--- a/tests/vue/stores/adminMetricsStore.spec.ts
+++ b/tests/vue/stores/adminMetricsStore.spec.ts
@@ -1,0 +1,101 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createPinia, setActivePinia } from 'pinia';
+
+import * as services from '@/services';
+import * as systemMetrics from '@/utils/systemMetrics';
+import { useAdminMetricsStore } from '@/stores/adminMetrics';
+
+const backendRefreshCallbacks: Array<() => void> = [];
+
+const fetchDashboardStatsSpy = vi.spyOn(services, 'fetchDashboardStats');
+const deriveMetricsSpy = vi.spyOn(services, 'deriveMetricsFromDashboard');
+const emptyMetricsSpy = vi.spyOn(services, 'emptyMetricsSnapshot');
+const useBackendClientSpy = vi.spyOn(services, 'useBackendClient');
+const useBackendRefreshSpy = vi.spyOn(services, 'useBackendRefresh');
+const buildResourceStatsSpy = vi.spyOn(systemMetrics, 'buildResourceStats');
+const defaultResourceStatsSpy = vi.spyOn(systemMetrics, 'defaultResourceStats');
+const defaultSystemStatusSpy = vi.spyOn(systemMetrics, 'defaultSystemStatus', 'get');
+const deriveSeveritySpy = vi.spyOn(systemMetrics, 'deriveSeverityFromMetrics');
+const mergeStatusLevelsSpy = vi.spyOn(systemMetrics, 'mergeStatusLevels');
+const normaliseStatusSpy = vi.spyOn(systemMetrics, 'normaliseStatus');
+
+const flushAsync = async () => {
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+};
+
+const createSummary = () => ({
+  stats: { total_loras: 5 },
+  system_health: { status: 'healthy' },
+});
+
+describe('adminMetrics store', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    backendRefreshCallbacks.splice(0, backendRefreshCallbacks.length);
+    useBackendClientSpy.mockReset().mockReturnValue({});
+    useBackendRefreshSpy.mockReset().mockImplementation((callback: () => void) => {
+      backendRefreshCallbacks.push(callback);
+      return {
+        start: vi.fn(),
+        stop: vi.fn(),
+        restart: vi.fn(() => {
+          callback();
+        }),
+        isActive: vi.fn(() => true),
+        trigger: vi.fn(() => {
+          callback();
+        }),
+      };
+    });
+    fetchDashboardStatsSpy.mockReset().mockResolvedValue(createSummary());
+    deriveMetricsSpy.mockReset().mockReturnValue({});
+    emptyMetricsSpy.mockReset().mockReturnValue({});
+    buildResourceStatsSpy.mockReset().mockReturnValue({});
+    defaultResourceStatsSpy.mockReset().mockReturnValue({ cpu: 0 });
+    deriveSeveritySpy.mockReset().mockReturnValue('ok');
+    mergeStatusLevelsSpy.mockReset().mockImplementation((_, derived) => derived ?? 'healthy');
+    normaliseStatusSpy.mockReset().mockReturnValue('healthy');
+    defaultSystemStatusSpy.mockReturnValue('healthy');
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    backendRefreshCallbacks.splice(0, backendRefreshCallbacks.length);
+  });
+
+  it('loads dashboard metrics and caches the result', async () => {
+    const store = useAdminMetricsStore();
+
+    await store.refresh();
+    await flushAsync();
+    expect(fetchDashboardStatsSpy).toHaveBeenCalledTimes(1);
+    expect(store.summary).toEqual(createSummary());
+
+    await store.refresh();
+    await flushAsync();
+    expect(fetchDashboardStatsSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it('exposes error information when the backend fails', async () => {
+    const store = useAdminMetricsStore();
+    fetchDashboardStatsSpy.mockRejectedValueOnce(new Error('offline'));
+
+    await expect(store.refresh()).rejects.toThrow('offline');
+    await flushAsync();
+    expect(store.error).toBeInstanceOf(Error);
+    expect(store.apiAvailable).toBe(false);
+  });
+
+  it('reacts to backend refresh signals', async () => {
+    const store = useAdminMetricsStore();
+    await store.refresh();
+    expect(backendRefreshCallbacks).toHaveLength(1);
+
+    fetchDashboardStatsSpy.mockClear().mockResolvedValue(createSummary());
+    backendRefreshCallbacks[0]?.();
+    await flushAsync();
+    expect(fetchDashboardStatsSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/vue/stores/performanceAnalyticsStore.spec.ts
+++ b/tests/vue/stores/performanceAnalyticsStore.spec.ts
@@ -1,0 +1,113 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createPinia, setActivePinia } from 'pinia';
+
+import * as services from '@/services';
+import * as analyticsService from '@/features/analytics/services/analyticsService';
+import * as loraPublic from '@/features/lora/public';
+import { usePerformanceAnalyticsStore } from '@/features/analytics/stores/performanceAnalytics';
+
+const backendRefreshCallbacks: Array<() => void> = [];
+
+const useBackendClientSpy = vi.spyOn(services, 'useBackendClient');
+const useBackendRefreshSpy = vi.spyOn(services, 'useBackendRefresh');
+const fetchPerformanceAnalyticsSpy = vi.spyOn(analyticsService, 'fetchPerformanceAnalytics');
+const fetchTopAdaptersSpy = vi.spyOn(loraPublic, 'fetchTopAdapters');
+
+const flushAsync = async () => {
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+};
+
+const createSummary = () => ({
+  generatedAt: '2024-01-01T00:00:00Z',
+  timeRange: '24h',
+  kpis: {
+    total_generations: 10,
+    generation_growth: 5,
+    avg_generation_time: 42,
+    time_improvement: 2,
+    success_rate: 98,
+    total_failed: 1,
+    active_loras: 3,
+    total_loras: 5,
+  },
+  chartData: {
+    generationVolume: [],
+    performance: [],
+    loraUsage: [],
+    resourceUsage: [],
+  },
+  errorAnalysis: [],
+  performanceInsights: [],
+});
+
+const createTopLoras = () => [
+  { id: 1, name: 'Alpha', version: '1.0', usage_count: 10, success_rate: 95, avg_time: 40 },
+];
+
+describe('performanceAnalytics store', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    backendRefreshCallbacks.splice(0, backendRefreshCallbacks.length);
+    useBackendClientSpy.mockReset().mockReturnValue({});
+    useBackendRefreshSpy.mockReset().mockImplementation((callback: () => void) => {
+      backendRefreshCallbacks.push(callback);
+      return {
+        start: vi.fn(),
+        stop: vi.fn(),
+        restart: vi.fn(() => {
+          callback();
+        }),
+        isActive: vi.fn(() => true),
+        trigger: vi.fn(() => {
+          callback();
+        }),
+      };
+    });
+    fetchPerformanceAnalyticsSpy.mockReset().mockResolvedValue(createSummary());
+    fetchTopAdaptersSpy.mockReset().mockResolvedValue(createTopLoras());
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    backendRefreshCallbacks.splice(0, backendRefreshCallbacks.length);
+  });
+
+  it('caches analytics data for repeated loads', async () => {
+    const store = usePerformanceAnalyticsStore();
+
+    await store.ensureLoaded();
+    expect(fetchPerformanceAnalyticsSpy).toHaveBeenCalledTimes(1);
+
+    await store.ensureLoaded();
+    expect(fetchPerformanceAnalyticsSpy).toHaveBeenCalledTimes(1);
+
+    fetchPerformanceAnalyticsSpy.mockClear().mockResolvedValue(createSummary());
+    store.setTimeRange('7d');
+    await flushAsync();
+    expect(fetchPerformanceAnalyticsSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('resets to defaults when the analytics endpoint fails', async () => {
+    const store = usePerformanceAnalyticsStore();
+    fetchPerformanceAnalyticsSpy.mockRejectedValueOnce(new Error('unavailable'));
+
+    await expect(store.loadAllData()).rejects.toThrow('unavailable');
+    await flushAsync();
+    expect(store.kpis.total_generations).toBe(0);
+    expect(store.chartData.generationVolume).toEqual([]);
+  });
+
+  it('responds to backend refresh triggers', async () => {
+    const store = usePerformanceAnalyticsStore();
+    await store.ensureLoaded();
+    expect(backendRefreshCallbacks).toHaveLength(1);
+
+    fetchPerformanceAnalyticsSpy.mockClear().mockResolvedValue(createSummary());
+    backendRefreshCallbacks[0]?.();
+    await flushAsync();
+
+    expect(fetchPerformanceAnalyticsSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/vue/useAsyncResource.spec.ts
+++ b/tests/vue/useAsyncResource.spec.ts
@@ -1,0 +1,98 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { effectScope, nextTick } from 'vue';
+
+import * as services from '@/services';
+import { useAsyncResource } from '@/composables/shared';
+
+const backendRefreshCallbacks: Array<() => void> = [];
+
+const useBackendRefreshSpy = vi.spyOn(services, 'useBackendRefresh');
+
+describe('useAsyncResource', () => {
+  beforeEach(() => {
+    backendRefreshCallbacks.splice(0, backendRefreshCallbacks.length);
+    useBackendRefreshSpy.mockReset().mockImplementation((callback: () => void) => {
+      backendRefreshCallbacks.push(callback);
+      return {
+        start: vi.fn(),
+        stop: vi.fn(),
+        restart: vi.fn(() => {
+          callback();
+        }),
+        isActive: vi.fn(() => true),
+        trigger: vi.fn(() => {
+          callback();
+        }),
+      };
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    backendRefreshCallbacks.splice(0, backendRefreshCallbacks.length);
+  });
+
+  it('dedupes concurrent refresh calls', async () => {
+    const fetcher = vi.fn(async (value: number) => {
+      await Promise.resolve();
+      return value;
+    });
+
+    const scope = effectScope();
+    const resource = scope.run(() => useAsyncResource(fetcher, { initialArgs: 1 }))!;
+
+    const first = resource.refresh(1);
+    const second = resource.refresh(1);
+
+    await Promise.all([first, second]);
+    expect(fetcher).toHaveBeenCalledTimes(1);
+
+    scope.stop();
+  });
+
+  it('uses cached data until arguments change', async () => {
+    const fetcher = vi.fn(async (value: number) => value * 2);
+
+    const scope = effectScope();
+    const resource = scope.run(() => useAsyncResource(fetcher, { initialArgs: 1 }))!;
+
+    await resource.ensureLoaded(1);
+    await resource.ensureLoaded(1);
+    expect(fetcher).toHaveBeenCalledTimes(1);
+
+    await resource.ensureLoaded(2);
+    expect(fetcher).toHaveBeenCalledTimes(2);
+
+    scope.stop();
+  });
+
+  it('tracks errors and supports backend-triggered refresh', async () => {
+    let shouldFail = true;
+    const fetcher = vi.fn(async () => {
+      if (shouldFail) {
+        throw new Error('boom');
+      }
+      return 'ok';
+    });
+
+    const scope = effectScope();
+    const resource = scope.run(() =>
+      useAsyncResource(fetcher, { backendRefresh: true, initialArgs: undefined }),
+    )!;
+
+    await expect(resource.refresh()).rejects.toThrow('boom');
+    expect(resource.error.value).toBeInstanceOf(Error);
+
+    shouldFail = false;
+    backendRefreshCallbacks.at(-1)?.();
+    await nextTick();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(fetcher).toHaveBeenCalledTimes(2);
+    expect(resource.error.value).toBeNull();
+    expect(resource.data.value).toBe('ok');
+
+    scope.stop();
+  });
+});


### PR DESCRIPTION
## Summary
- add a reusable `useAsyncResource` composable that provides caching, deduped requests, and backend refresh hooks
- refactor catalog, analytics, admin metrics, and recommendations stores to adopt the new helper and simplify refresh logic
- add focused unit tests covering the helper and updated stores, including refresh and error handling scenarios

## Testing
- `npx vitest run tests/vue/useAsyncResource.spec.ts`
- `npx vitest run tests/vue/stores/adapterCatalogStore.spec.ts`
- `npx vitest run tests/vue/stores/performanceAnalyticsStore.spec.ts`
- `npx vitest run tests/vue/stores/adminMetricsStore.spec.ts`
- `npx vitest run tests/vue/useRecommendations.spec.ts`


------
https://chatgpt.com/codex/tasks/task_e_68dc3fd6ec18832983475d7d98585348