### PR TITLE
Fix hydration guard in recommendation watcher

### DIFF
--- a/app/frontend/src/features/recommendations/composables/useRecommendations.ts
+++ b/app/frontend/src/features/recommendations/composables/useRecommendations.ts
@@ -207,9 +207,11 @@ export const useRecommendations = (options: UseRecommendationsOptions = {}) => {
       return;
     }
 
-    if (isHydrated.value) {
-      scheduleRecommendationsRefresh({ immediate: true });
+    if (!isHydrated.value) {
+      return;
     }
+
+    scheduleRecommendationsRefresh({ immediate: true });
   });
 
   watch(


### PR DESCRIPTION
## Summary
- ensure the recommendations watcher returns early when hydration has not completed so follow-up watchers remain at the composable scope

## Testing
- npm run build *(fails: existing TypeScript errors in unrelated generation modules)*

------
https://chatgpt.com/codex/tasks/task_e_68dc4859b5288329aa6dc5371e0f2c41