### PR TITLE
Refactor recommendations catalog integration

### DIFF
--- a/app/frontend/src/features/recommendations/composables/useRecommendations.ts
+++ b/app/frontend/src/features/recommendations/composables/useRecommendations.ts
@@ -6,10 +6,9 @@ import { useAsyncResource } from '@/composables/shared';
 import { useBackendClient } from '@/services';
 
 import { useBackendEnvironment, useSettingsStore } from '@/stores';
+import { useAdapterCatalogStore } from '@/features/lora/public';
 import type { AdapterSummary, RecommendationItem, RecommendationResponse } from '@/types';
 import { debounce, type DebouncedFunction } from '@/utils/async';
-
-import { useLoraSummaries } from './useLoraSummaries';
 
 const WEIGHT_KEYS = ['semantic', 'artistic', 'technical'] as const;
 type WeightKey = (typeof WEIGHT_KEYS)[number];
@@ -65,16 +64,29 @@ const normaliseRecommendations = (
   return [];
 };
 
+const unwrapMaybeRef = <T>(input: T | Ref<T>): T => {
+  if (typeof input === 'object' && input !== null && 'value' in input) {
+    return (input as Ref<T>).value;
+  }
+  return input as T;
+};
+
 export const useRecommendations = (options: UseRecommendationsOptions = {}) => {
   const backendClient = useBackendClient();
   const settingsStore = useSettingsStore();
   const backendEnvironment = useBackendEnvironment();
 
-  const { loras, error: lorasErrorRaw, isLoading: lorasLoading, ensureLoaded: ensureLorasLoaded } = useLoraSummaries();
+  const catalogStore = useAdapterCatalogStore();
+  const loras = computed<AdapterSummary[]>(() => {
+    const adapters = unwrapMaybeRef(catalogStore.adapters);
+    return Array.isArray(adapters) ? adapters : [];
+  });
+  const catalogError = computed(() => unwrapMaybeRef(catalogStore.error));
+  const catalogIsLoading = computed(() => Boolean(unwrapMaybeRef(catalogStore.isLoading)));
   const { isLoaded: settingsLoaded } = storeToRefs(settingsStore);
 
   const lorasError = computed<string>(() =>
-    lorasErrorRaw.value ? toErrorMessage(lorasErrorRaw.value, 'Unable to load available LoRAs') : '',
+    catalogError.value ? toErrorMessage(catalogError.value, 'Unable to load available LoRAs') : '',
   );
 
   const selectedLoraId = ref<AdapterSummary['id'] | ''>(options.initialLoraId ?? '');
@@ -256,12 +268,12 @@ export const useRecommendations = (options: UseRecommendationsOptions = {}) => {
     }
   });
 
-  void ensureLorasLoaded();
+  void catalogStore.ensureLoaded();
 
   return {
     loras,
     lorasError,
-    isLoadingLoras: computed<boolean>(() => lorasLoading.value),
+    isLoadingLoras: catalogIsLoading,
     selectedLoraId,
     selectedLora,
     limit,

--- a/tests/vue/useRecommendations.spec.ts
+++ b/tests/vue/useRecommendations.spec.ts
@@ -1,11 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { computed } from 'vue';
 import { mount } from '@vue/test-utils';
 import { createPinia, setActivePinia } from 'pinia';
 
 import * as services from '@/services';
 import * as stores from '@/stores';
-import * as loraSummariesModule from '@/features/recommendations/composables/useLoraSummaries';
+import * as loraCatalogModule from '@/features/lora/public';
 import { useRecommendations } from '@/features/recommendations/composables/useRecommendations';
 import { useSettingsStore } from '@/stores';
 
@@ -18,7 +17,7 @@ const backendClientMock = {
 const useBackendClientSpy = vi.spyOn(services, 'useBackendClient');
 const useBackendRefreshSpy = vi.spyOn(services, 'useBackendRefresh');
 const useBackendEnvironmentSpy = vi.spyOn(stores, 'useBackendEnvironment');
-const useLoraSummariesSpy = vi.spyOn(loraSummariesModule, 'useLoraSummaries');
+const useAdapterCatalogStoreSpy = vi.spyOn(loraCatalogModule, 'useAdapterCatalogStore');
 
 describe('useRecommendations', () => {
   beforeEach(() => {
@@ -45,15 +44,23 @@ describe('useRecommendations', () => {
       readyPromise: Promise.resolve(),
       onBackendUrlChange: vi.fn(),
     } as never);
-    useLoraSummariesSpy.mockReset().mockReturnValue({
-      loras: computed(() => [
-        { id: 'alpha', name: 'Alpha', description: 'First', active: true },
-        { id: 'beta', name: 'Beta', description: 'Second', active: true },
-      ]),
-      error: computed(() => null),
-      isLoading: computed(() => false),
-      ensureLoaded: vi.fn(),
-    });
+    const adapterSummaries = [
+      { id: 'alpha', name: 'Alpha', description: 'First', active: true },
+      { id: 'beta', name: 'Beta', description: 'Second', active: true },
+    ];
+
+    useAdapterCatalogStoreSpy.mockReset().mockReturnValue({
+      get adapters() {
+        return adapterSummaries;
+      },
+      get error() {
+        return null;
+      },
+      get isLoading() {
+        return false;
+      },
+      ensureLoaded: vi.fn().mockResolvedValue(adapterSummaries),
+    } as never);
 
     const settingsStore = useSettingsStore();
     settingsStore.reset();


### PR DESCRIPTION
## Summary
- reuse the adapter catalog store inside the recommendations composable instead of instantiating a separate summaries fetcher
- normalize adapter access through a helper that unwraps store refs and continue to expose the existing reactive API for consumers
- refresh the recommendations composable unit tests to mock the catalog store interface

## Testing
- npx vitest run tests/vue/useRecommendations.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68dc49c703b083298a0a1cfa927a0c83