### PR TITLE
Fix router base URL handling

### DIFF
--- a/app/frontend/src/router/index.ts
+++ b/app/frontend/src/router/index.ts
@@ -1,7 +1,12 @@
 import { createRouter, createWebHistory } from 'vue-router';
 
+const historyBase =
+  typeof import.meta.env.BASE_URL === 'string' && import.meta.env.BASE_URL.length > 0
+    ? import.meta.env.BASE_URL
+    : '/';
+
 const router = createRouter({
-  history: createWebHistory(),
+  history: createWebHistory(historyBase),
   routes: [
     {
       path: '/',

--- a/tests/vue/router/index.spec.ts
+++ b/tests/vue/router/index.spec.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+const importRouter = () => import('@/router');
+
+const resetLocation = () => {
+  window.history.replaceState({}, '', '/');
+};
+
+describe('app router base url handling', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    resetLocation();
+    vi.stubGlobal('scrollTo', vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
+    resetLocation();
+  });
+
+  it('uses BASE_URL from the Vite environment when provided', async () => {
+    vi.stubEnv('BASE_URL', '/demo/app/');
+
+    const { default: router } = await importRouter();
+
+    expect(router.options.history.base).toBe('/demo/app');
+  });
+
+  it('prefixes navigations with the configured base path', async () => {
+    vi.stubEnv('BASE_URL', '/demo/app/');
+
+    const { default: router } = await importRouter();
+
+    await router.push('/loras');
+
+    expect(window.location.pathname).toBe('/demo/app/loras');
+    expect(router.currentRoute.value.fullPath).toBe('/loras');
+  });
+
+  it('resolves deep links that include the base path', async () => {
+    vi.stubEnv('BASE_URL', '/demo/app/');
+    window.history.replaceState({}, '', '/demo/app/generate');
+
+    const { default: router } = await importRouter();
+
+    expect(router.options.history.location).toBe('/generate');
+
+    await router.push('/generate');
+
+    expect(router.currentRoute.value.name).toBe('generate');
+    expect(router.currentRoute.value.fullPath).toBe('/generate');
+    expect(window.location.pathname).toBe('/demo/app/generate');
+  });
+});


### PR DESCRIPTION
## Summary
- ensure the Vue router history honors the configured BASE_URL for subpath deployments
- add targeted Vitest coverage to confirm navigation and deep links work with custom bases

## Testing
- npx vitest run tests/vue/router/index.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68dc4b4d5bf88329921c7194ce3f7075