### PR TITLE
Add runtime validation for history service responses

### DIFF
--- a/app/frontend/src/features/history/services/historySchemas.ts
+++ b/app/frontend/src/features/history/services/historySchemas.ts
@@ -1,0 +1,171 @@
+import { z, type ZodIssue } from 'zod';
+
+import { JsonObjectSchema } from '@/schemas/json';
+import type {
+  GenerationHistoryListPayload,
+  GenerationHistoryListResponse,
+  GenerationHistoryResult,
+  GenerationHistoryStats,
+  GenerationLoraReference,
+} from '@/types';
+
+export class HistoryServiceParseError extends Error {
+  public readonly issues?: readonly ZodIssue[];
+
+  constructor(message: string, options?: { cause?: unknown; issues?: readonly ZodIssue[] }) {
+    super(message);
+    this.name = 'HistoryServiceParseError';
+    if (options?.cause !== undefined) {
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-expect-error Node 16 does not yet define ErrorOptions in lib.dom.d.ts
+      this.cause = options.cause;
+    }
+    this.issues = options?.issues;
+  }
+}
+
+const NullableString = z.union([z.string(), z.null()]).optional();
+const NullableNumber = z.number().finite().nullable().optional();
+
+const GenerationLoraReferenceSchema: z.ZodType<GenerationLoraReference> = z
+  .object({
+    id: z.string(),
+    name: NullableString,
+    version: NullableString,
+    weight: NullableNumber,
+    adapter_id: NullableString,
+    extra: JsonObjectSchema.nullish(),
+  })
+  .passthrough();
+
+const GenerationHistoryStatsSchema: z.ZodType<GenerationHistoryStats> = z
+  .object({
+    total_results: z.number().finite(),
+    avg_rating: z.number().finite(),
+    total_favorites: z.number().finite(),
+    total_size: z.number().finite(),
+  })
+  .transform((stats) => ({
+    total_results: stats.total_results,
+    avg_rating: stats.avg_rating,
+    total_favorites: stats.total_favorites,
+    total_size: stats.total_size,
+  }));
+
+const GenerationHistoryResultSchema: z.ZodType<GenerationHistoryResult> = z
+  .object({
+    id: z.union([z.string(), z.number()]),
+    job_id: z.union([z.string(), z.number()]).optional(),
+    jobId: z.union([z.string(), z.number()]).optional(),
+    status: z.string().optional().nullable(),
+    prompt: z.string().optional(),
+    negative_prompt: NullableString,
+    image_url: NullableString,
+    thumbnail_url: NullableString,
+    width: z.number().finite().optional(),
+    height: z.number().finite().optional(),
+    steps: z.number().finite().optional(),
+    cfg_scale: z.number().finite().optional(),
+    seed: NullableNumber,
+    created_at: z.string().optional(),
+    finished_at: NullableString,
+    updated_at: NullableString,
+    sampler_name: NullableString,
+    sampler: NullableString,
+    model: NullableString,
+    model_name: NullableString,
+    clip_skip: NullableNumber,
+    generation_info: JsonObjectSchema.nullish(),
+    metadata: JsonObjectSchema.nullish(),
+    loras: z.array(GenerationLoraReferenceSchema).nullish(),
+    rating: NullableNumber,
+    is_favorite: z.boolean().optional(),
+    rating_updated_at: NullableString,
+    favorite_updated_at: NullableString,
+  })
+  .passthrough();
+
+const GenerationHistoryListResponseSchema: z.ZodType<GenerationHistoryListResponse> = z
+  .object({
+    results: z.array(GenerationHistoryResultSchema),
+    stats: GenerationHistoryStatsSchema.optional(),
+    page: z.number().int().optional(),
+    page_size: z.number().int().optional(),
+    total: z.number().int().optional(),
+    pages: z.number().int().optional(),
+    has_more: z.boolean().optional(),
+    next_page: z.number().int().nullable().optional(),
+    previous_page: z.number().int().nullable().optional(),
+  })
+  .passthrough();
+
+const GenerationHistoryListPayloadSchema: z.ZodType<GenerationHistoryListPayload> = z.union([
+  z.array(GenerationHistoryResultSchema),
+  GenerationHistoryListResponseSchema,
+]);
+
+const formatIssues = (issues: readonly ZodIssue[]): string =>
+  issues
+    .map((issue) => {
+      const path = issue.path.length > 0 ? issue.path.join('.') : '(root)';
+      return `${path}: ${issue.message}`;
+    })
+    .join('; ');
+
+const createParseError = (context: string, error: unknown): HistoryServiceParseError => {
+  if (error instanceof z.ZodError) {
+    const message = `${context} validation failed: ${formatIssues(error.issues)}`;
+    console.warn(`[history] ${context} validation failed`, { issues: error.issues });
+    return new HistoryServiceParseError(message, { cause: error, issues: error.issues });
+  }
+
+  console.warn(`[history] ${context} validation failed`, { error });
+  return new HistoryServiceParseError(`${context} validation failed`, { cause: error });
+};
+
+export const parseHistoryResult = (value: unknown, context = 'history result'):
+  | GenerationHistoryResult
+  | null => {
+  if (value == null) {
+    return null;
+  }
+
+  const result = GenerationHistoryResultSchema.safeParse(value);
+  if (!result.success) {
+    throw createParseError(context, result.error);
+  }
+
+  return result.data;
+};
+
+export const parseHistoryListPayload = (
+  value: unknown,
+  context = 'history list response',
+): GenerationHistoryListPayload | null => {
+  if (value == null) {
+    return null;
+  }
+
+  const result = GenerationHistoryListPayloadSchema.safeParse(value);
+  if (!result.success) {
+    throw createParseError(context, result.error);
+  }
+
+  return result.data;
+};
+
+export const parseHistoryStats = (
+  value: unknown,
+  context = 'history stats',
+): GenerationHistoryStats | null => {
+  if (value == null) {
+    return null;
+  }
+
+  const result = GenerationHistoryStatsSchema.safeParse(value);
+  if (!result.success) {
+    throw createParseError(context, result.error);
+  }
+
+  return result.data;
+};

--- a/app/frontend/src/features/history/services/historyService.ts
+++ b/app/frontend/src/features/history/services/historyService.ts
@@ -19,6 +19,7 @@ import type {
   GenerationHistoryPayload,
   GenerationRatingUpdate,
 } from '@/types';
+import { parseHistoryListPayload, parseHistoryResult } from './historySchemas';
 
 const historyPaths = createBackendPathResolver('generation');
 const historyPath = historyPaths.path;
@@ -134,7 +135,8 @@ export const listResults = async (
     target,
     withSameOrigin({ signal: options.signal }),
   );
-  return toListOutput((result.data as GenerationHistoryListPayload | null) ?? null);
+  const parsed = parseHistoryListPayload(result.data, 'generation history list response');
+  return toListOutput(parsed);
 };
 
 export const rateResult = async (
@@ -148,7 +150,7 @@ export const rateResult = async (
     { rating },
     withSameOrigin(),
   );
-  return (result.data as GenerationHistoryResult | null) ?? null;
+  return parseHistoryResult(result.data, 'generation history rating response');
 };
 
 export const favoriteResult = async (
@@ -162,7 +164,7 @@ export const favoriteResult = async (
     { is_favorite: isFavorite },
     withSameOrigin(),
   );
-  return (result.data as GenerationHistoryResult | null) ?? null;
+  return parseHistoryResult(result.data, 'generation history favorite response');
 };
 
 export const favoriteResults = async (

--- a/tests/vue/GenerationHistory.spec.js
+++ b/tests/vue/GenerationHistory.spec.js
@@ -2,13 +2,14 @@ import { mount, shallowMount } from '@vue/test-utils';
 import { defineComponent, nextTick, ref } from 'vue';
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 
-import GenerationHistory from '../../app/frontend/src/components/history/GenerationHistory.vue';
-import GenerationHistoryController from '../../app/frontend/src/components/history/GenerationHistoryController.vue';
-import GenerationHistoryView from '../../app/frontend/src/components/history/GenerationHistoryView.vue';
-import HistoryModalController from '../../app/frontend/src/components/history/HistoryModalController.vue';
-import HistoryToast from '../../app/frontend/src/components/history/HistoryToast.vue';
-import { useGenerationHistory } from '../../app/frontend/src/composables/history/useGenerationHistory';
-import { useHistoryModalCoordinator } from '../../app/frontend/src/composables/history/useHistoryModalCoordinator';
+import GenerationHistory from '../../app/frontend/src/features/history/components/GenerationHistory.vue';
+import GenerationHistoryController from '../../app/frontend/src/features/history/components/GenerationHistoryController.vue';
+import GenerationHistoryView from '../../app/frontend/src/features/history/components/GenerationHistoryView.vue';
+import HistoryModalController from '../../app/frontend/src/features/history/components/HistoryModalController.vue';
+import HistoryToast from '../../app/frontend/src/features/history/components/HistoryToast.vue';
+import { useGenerationHistory } from '../../app/frontend/src/features/history/composables/useGenerationHistory';
+import { useHistoryModalCoordinator } from '../../app/frontend/src/features/history/composables/useHistoryModalCoordinator';
+import { HistoryServiceParseError } from '../../app/frontend/src/features/history/services/historySchemas';
 
 const routerMock = vi.hoisted(() => ({
   push: vi.fn(),
@@ -29,7 +30,7 @@ const serviceMocks = vi.hoisted(() => ({
   deleteResults: vi.fn(),
 }));
 
-vi.mock('../../app/frontend/src/services/history/historyService', () => ({
+vi.mock('../../app/frontend/src/features/history/services/historyService', () => ({
   listResults: serviceMocks.listResults,
   rateResult: serviceMocks.rateResult,
   favoriteResult: serviceMocks.favoriteResult,
@@ -40,7 +41,7 @@ vi.mock('../../app/frontend/src/services/history/historyService', () => ({
   deleteResults: serviceMocks.deleteResults,
 }));
 
-vi.mock('../../app/frontend/src/services/history', () => ({
+vi.mock('../../app/frontend/src/features/history/services', () => ({
   listResults: serviceMocks.listResults,
   rateResult: serviceMocks.rateResult,
   favoriteResult: serviceMocks.favoriteResult,
@@ -553,14 +554,16 @@ describe('GenerationHistory.vue', () => {
   });
 
   it('shows an error toast when history loading fails', async () => {
-    serviceMocks.listResults.mockRejectedValue(new Error('failed to load'));
+    serviceMocks.listResults.mockRejectedValue(
+      new HistoryServiceParseError('generation history list response validation failed: results.0.id: Required'),
+    );
 
     const wrapper = mount(GenerationHistory);
     await flush();
 
     const toast = wrapper.findComponent(HistoryToast);
     expect(toast.exists()).toBe(true);
-    expect(toast.text()).toContain('failed to load');
+    expect(toast.text()).toContain('validation failed');
 
     wrapper.unmount();
   });

--- a/tests/vue/services/history/historyService.spec.ts
+++ b/tests/vue/services/history/historyService.spec.ts
@@ -1,0 +1,132 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  favoriteResult,
+  listResults,
+  rateResult,
+} from '@/features/history/services/historyService';
+import { HistoryServiceParseError } from '@/features/history/services/historySchemas';
+import type { BackendClient } from '@/services/backendClient';
+import type { GenerationHistoryResult } from '@/types';
+
+const iso = '2024-01-01T00:00:00Z';
+
+type BackendStub = BackendClient & {
+  resolve: ReturnType<typeof vi.fn>;
+  requestJson: ReturnType<typeof vi.fn>;
+  getJson: ReturnType<typeof vi.fn>;
+  postJson: ReturnType<typeof vi.fn>;
+  putJson: ReturnType<typeof vi.fn>;
+  patchJson: ReturnType<typeof vi.fn>;
+  delete: ReturnType<typeof vi.fn>;
+  requestBlob: ReturnType<typeof vi.fn>;
+};
+
+const createBackendStub = (): BackendStub => ({
+  resolve: vi.fn((path?: string) => path ?? ''),
+  requestJson: vi.fn(),
+  getJson: vi.fn(),
+  postJson: vi.fn(),
+  putJson: vi.fn(),
+  patchJson: vi.fn(),
+  delete: vi.fn(),
+  requestBlob: vi.fn(),
+}) as unknown as BackendStub;
+
+describe('historyService runtime validation', () => {
+  let backend: BackendStub;
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  const validResult: GenerationHistoryResult = {
+    id: 1,
+    prompt: 'Prompt',
+    negative_prompt: null,
+    image_url: null,
+    thumbnail_url: null,
+    created_at: iso,
+    finished_at: null,
+    generation_info: null,
+    metadata: null,
+    rating: null,
+    is_favorite: false,
+    rating_updated_at: null,
+    favorite_updated_at: null,
+  };
+
+  beforeEach(() => {
+    backend = createBackendStub();
+    backend.requestJson.mockReset();
+    backend.putJson.mockReset();
+    backend.resolve.mockClear();
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  it('parses list responses and returns sanitized results', async () => {
+    backend.requestJson.mockResolvedValue({
+      data: {
+        results: [
+          validResult,
+          { ...validResult, id: '2', rating: 5, is_favorite: true },
+        ],
+        stats: {
+          total_results: 2,
+          avg_rating: 2.5,
+          total_favorites: 1,
+          total_size: 123,
+        },
+      },
+    });
+
+    const output = await listResults({}, {}, backend);
+
+    expect(output.results).toHaveLength(2);
+    expect(output.results[0]).toEqual(validResult);
+    expect(output.results[1]?.id).toBe('2');
+    expect(output.stats).toEqual({
+      total_results: 2,
+      avg_rating: 2.5,
+      total_favorites: 1,
+      total_size: 123,
+    });
+  });
+
+  it('throws a HistoryServiceParseError when list payload is invalid', async () => {
+    backend.requestJson.mockResolvedValue({
+      data: { results: [{ ...validResult, id: null }] },
+    });
+
+    await expect(listResults({}, {}, backend)).rejects.toBeInstanceOf(
+      HistoryServiceParseError,
+    );
+  });
+
+  it('parses rating responses and returns sanitized data', async () => {
+    backend.putJson.mockResolvedValue({
+      data: { ...validResult, id: 42, rating: 5, is_favorite: true },
+    });
+
+    const result = await rateResult(42, 5, backend);
+
+    expect(result).toEqual({ ...validResult, id: 42, rating: 5, is_favorite: true });
+  });
+
+  it('throws a HistoryServiceParseError when rating payload is invalid', async () => {
+    backend.putJson.mockResolvedValue({ data: { ...validResult, id: undefined } });
+
+    await expect(rateResult(1, 2, backend)).rejects.toBeInstanceOf(HistoryServiceParseError);
+  });
+
+  it('throws a HistoryServiceParseError when favorite payload is invalid', async () => {
+    backend.putJson.mockResolvedValueOnce({
+      data: { ...validResult, id: undefined },
+    });
+
+    await expect(favoriteResult(1, true, backend)).rejects.toBeInstanceOf(
+      HistoryServiceParseError,
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add zod schemas for generation history payloads and expose parsing helpers for reuse
- update history service methods to validate backend responses before updating stores
- extend and adjust vitest coverage to exercise validation success and failure scenarios

## Testing
- npm run test:unit -- tests/vue/services/history/historyService.spec.ts
- npm run test:unit -- tests/vue/GenerationHistory.spec.js

------
https://chatgpt.com/codex/tasks/task_e_68dc4b5856b48329bbfbabc70d9e0d12