### PR TITLE
Refactor LoRA summaries to share catalog accessor

### DIFF
--- a/app/frontend/src/features/lora/composables/useAdapterSummaries.ts
+++ b/app/frontend/src/features/lora/composables/useAdapterSummaries.ts
@@ -1,0 +1,26 @@
+import { computed, type ComputedRef } from 'vue';
+import { storeToRefs } from 'pinia';
+
+import { useAdapterCatalogStore } from '../stores/adapterCatalog';
+import type { AdapterListQuery, AdapterSummary } from '@/types';
+
+export interface AdapterSummaryCatalog {
+  summaries: ComputedRef<AdapterSummary[]>;
+  error: ComputedRef<unknown>;
+  isLoading: ComputedRef<boolean>;
+  ensureLoaded: (overrides?: AdapterListQuery) => Promise<AdapterSummary[]>;
+  refresh: (overrides?: AdapterListQuery) => Promise<AdapterSummary[]>;
+}
+
+export const useAdapterSummaries = (): AdapterSummaryCatalog => {
+  const catalogStore = useAdapterCatalogStore();
+  const { adapters, error, isLoading } = storeToRefs(catalogStore);
+
+  return {
+    summaries: computed(() => adapters.value ?? []),
+    error: computed(() => error.value),
+    isLoading: computed(() => Boolean(isLoading.value)),
+    ensureLoaded: catalogStore.ensureLoaded,
+    refresh: catalogStore.refresh,
+  };
+};

--- a/app/frontend/src/features/lora/index.ts
+++ b/app/frontend/src/features/lora/index.ts
@@ -1,2 +1,2 @@
-export { LoraGallery, useAdapterCatalogStore, fetchTopAdapters } from './public';
+export { LoraGallery, useAdapterCatalogStore, useAdapterSummaries, fetchTopAdapters } from './public';
 export type { AdapterCatalogStore } from './public';

--- a/app/frontend/src/features/lora/public.ts
+++ b/app/frontend/src/features/lora/public.ts
@@ -1,6 +1,7 @@
 export { default as LoraGallery } from './components/lora-gallery/LoraGallery.vue';
 
 export { useAdapterCatalogStore } from './stores/adapterCatalog';
+export { useAdapterSummaries } from './composables/useAdapterSummaries';
 export type { AdapterCatalogStore } from './stores/adapterCatalog';
 
 export { fetchTopAdapters } from './services/lora/loraService';

--- a/app/frontend/src/features/recommendations/composables/useLoraSummaries.ts
+++ b/app/frontend/src/features/recommendations/composables/useLoraSummaries.ts
@@ -1,8 +1,7 @@
-import { computed, ref } from 'vue';
+import { computed } from 'vue';
 
-import { fetchAdapterList } from '@/features/lora/services/lora/loraService';
-import { useBackendClient, useBackendEnvironmentSubscription } from '@/services';
-import type { AdapterListQuery, AdapterListResponse, AdapterSummary } from '@/types';
+import { useAdapterSummaries } from '@/features/lora/public';
+import type { AdapterListQuery, AdapterSummary } from '@/types';
 
 export interface UseLoraSummariesOptions {
   /**
@@ -21,97 +20,32 @@ const SUMMARY_QUERY_DEFAULTS: AdapterListQuery = {
   perPage: 200,
 };
 
-const mergeQuery = (base: AdapterListQuery, overrides: AdapterListQuery = {}): AdapterListQuery => ({
-  ...base,
-  ...overrides,
-});
-
-const mapToSummaries = (payload: AdapterListResponse | null | undefined): AdapterSummary[] => {
-  if (!payload || !Array.isArray(payload.items)) {
-    return [];
-  }
-
-  return payload.items.map((item) => ({
-    id: item.id,
-    name: item.name,
-    description: item.description ?? undefined,
-    active: item.active ?? true,
-  }));
-};
-
 export const useLoraSummaries = (options: UseLoraSummariesOptions = {}) => {
-  const backendClient = useBackendClient();
-
-  const items = ref<AdapterSummary[]>([]);
-  const error = ref<unknown>(null);
-  const isLoading = ref(false);
-  const hasLoaded = ref(false);
-  const pending = ref<Promise<AdapterSummary[]> | null>(null);
-
   const baseQuery: AdapterListQuery = { ...SUMMARY_QUERY_DEFAULTS, ...(options.initialQuery ?? {}) };
-  const lastQuery = ref<AdapterListQuery>({ ...baseQuery });
+  const catalog = useAdapterSummaries();
 
-  const runFetch = async (query: AdapterListQuery): Promise<AdapterSummary[]> => {
-    if (pending.value) {
-      return pending.value;
-    }
-
-    const request = (async () => {
-      isLoading.value = true;
-      error.value = null;
-
-      try {
-        const payload = await fetchAdapterList(query, backendClient);
-        items.value = mapToSummaries(payload);
-        lastQuery.value = { ...query };
-        hasLoaded.value = true;
-        return items.value;
-      } catch (err) {
-        error.value = err;
-        items.value = [];
-        throw err;
-      } finally {
-        isLoading.value = false;
-        pending.value = null;
-      }
-    })();
-
-    pending.value = request;
-    return request;
-  };
+  const mergeWithBaseQuery = (overrides: AdapterListQuery = {}): AdapterListQuery => ({
+    ...baseQuery,
+    ...overrides,
+  });
 
   const load = async (overrides: AdapterListQuery = {}): Promise<AdapterSummary[]> =>
-    runFetch(mergeQuery(baseQuery, overrides));
+    catalog.ensureLoaded(mergeWithBaseQuery(overrides));
 
-  const ensureLoaded = async (overrides: AdapterListQuery = {}): Promise<AdapterSummary[]> => {
-    if (!hasLoaded.value || Object.keys(overrides).length > 0) {
-      return load(overrides);
-    }
-    return items.value;
-  };
+  const ensureLoaded = async (overrides: AdapterListQuery = {}): Promise<AdapterSummary[]> =>
+    catalog.ensureLoaded(mergeWithBaseQuery(overrides));
 
   const refresh = async (overrides: AdapterListQuery = {}): Promise<AdapterSummary[]> =>
-    runFetch(mergeQuery(lastQuery.value, overrides));
-
-  useBackendEnvironmentSubscription(() => {
-    hasLoaded.value = false;
-    items.value = [];
-    error.value = null;
-    pending.value = null;
-
-    if (options.autoLoad !== false) {
-      void refresh();
-    }
-  });
+    catalog.refresh(mergeWithBaseQuery(overrides));
 
   if (options.autoLoad !== false) {
     void load();
   }
 
   return {
-    loras: computed(() => items.value),
-    error: computed(() => error.value),
-    isLoading: computed(() => isLoading.value),
+    loras: computed(() => catalog.summaries.value),
+    error: computed(() => catalog.error.value),
+    isLoading: computed(() => catalog.isLoading.value),
     load,
     ensureLoaded,
     refresh,

--- a/tests/vue/useLoraSummaries.spec.ts
+++ b/tests/vue/useLoraSummaries.spec.ts
@@ -1,0 +1,93 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { computed, ref } from 'vue';
+import { mount } from '@vue/test-utils';
+
+import type { AdapterListQuery, AdapterSummary } from '@/types';
+
+vi.mock('@/features/lora/public', async () => {
+  const actual = await vi.importActual<typeof import('@/features/lora/public')>('@/features/lora/public');
+  return {
+    ...actual,
+    useAdapterSummaries: vi.fn(),
+  };
+});
+
+import { useAdapterSummaries } from '@/features/lora/public';
+import { useLoraSummaries } from '@/features/recommendations/composables/useLoraSummaries';
+
+const useAdapterSummariesMock = vi.mocked(useAdapterSummaries);
+
+describe('useLoraSummaries', () => {
+  const summaries = ref<AdapterSummary[]>([]);
+  const error = ref<unknown>(null);
+  const isLoading = ref(false);
+  const ensureLoaded = vi.fn<(query?: AdapterListQuery) => Promise<AdapterSummary[]>>();
+  const refresh = vi.fn<(query?: AdapterListQuery) => Promise<AdapterSummary[]>>();
+
+  const mountComposable = (options?: Parameters<typeof useLoraSummaries>[0]) => {
+    let state: ReturnType<typeof useLoraSummaries> | undefined;
+    const wrapper = mount({
+      setup() {
+        state = useLoraSummaries(options);
+        return () => null;
+      },
+    });
+
+    return { state: state!, destroy: () => wrapper.unmount() };
+  };
+
+  beforeEach(() => {
+    summaries.value = [];
+    error.value = null;
+    isLoading.value = false;
+    ensureLoaded.mockClear().mockResolvedValue([]);
+    refresh.mockClear().mockResolvedValue([]);
+
+    useAdapterSummariesMock.mockReturnValue({
+      summaries: computed(() => summaries.value),
+      error: computed(() => error.value),
+      isLoading: computed(() => isLoading.value),
+      ensureLoaded,
+      refresh,
+    });
+  });
+
+  it('loads summaries immediately by default', () => {
+    mountComposable();
+
+    expect(ensureLoaded).toHaveBeenCalledWith({ page: 1, perPage: 200 });
+  });
+
+  it('merges custom queries when loading summaries', async () => {
+    ensureLoaded.mockResolvedValue([
+      { id: 'alpha', name: 'Alpha', active: true },
+    ] as never);
+
+    const { state } = mountComposable({ initialQuery: { tag: 'featured' } });
+
+    await state.load({ perPage: 50 });
+
+    expect(ensureLoaded).toHaveBeenCalledWith({ page: 1, perPage: 50, tag: 'featured' });
+  });
+
+  it('exposes catalog derived state', () => {
+    summaries.value = [{ id: 'alpha', name: 'Alpha', active: true } as never];
+    error.value = new Error('boom');
+    isLoading.value = true;
+
+    const { state } = mountComposable();
+
+    expect(state.loras.value).toEqual(summaries.value);
+    expect(state.error.value).toBe(error.value);
+    expect(state.isLoading.value).toBe(true);
+  });
+
+  it('supports manual refresh', async () => {
+    const { state } = mountComposable({ autoLoad: false });
+
+    await state.refresh({ page: 2 });
+
+    expect(refresh).toHaveBeenCalledWith({ page: 2, perPage: 200 });
+    expect(ensureLoaded).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add a shared adapter summaries composable backed by the catalog store and export it for reuse
- refactor the recommendations `useLoraSummaries` helper to delegate to the shared accessor
- cover the shared dependency with a focused unit test

## Testing
- npm run test:unit -- useLoraSummaries

------
https://chatgpt.com/codex/tasks/task_e_68dc4e11c52c8329877af1fb807f5037