### PR TITLE
feat(frontend): centralize HTTP client layer

### DIFF
--- a/app/frontend/src/composables/import-export/useBackupWorkflow.ts
+++ b/app/frontend/src/composables/import-export/useBackupWorkflow.ts
@@ -30,9 +30,18 @@ export function useBackupWorkflow(options: UseBackupWorkflowOptions): UseBackupW
     try {
 
       const response = await backendClient.getJson<
-        BackupHistoryItem[] | { history?: BackupHistoryItem[] | null } | null
+        | BackupHistoryItem[]
+        | { history?: BackupHistoryItem[] | null }
+        | { data?: BackupHistoryItem[] | { history?: BackupHistoryItem[] | null } | null }
+        | null
       >('/api/v1/backups/history');
-      const data = response ?? null;
+
+      const payload =
+        response && typeof response === 'object' && 'data' in response
+          ? (response as { data?: unknown }).data ?? null
+          : response;
+
+      const data = payload ?? null;
 
       if (Array.isArray(data)) {
         history.value = data as BackupHistoryItem[];

--- a/app/frontend/src/services/apiClient.ts
+++ b/app/frontend/src/services/apiClient.ts
@@ -1,289 +1,116 @@
-import type { ApiResponseMeta, ApiResult } from '@/types';
-import { ApiError } from '@/types';
+import {
+  createHttpClient,
+  ensureData,
+  type ApiRequestInit,
+  type ApiRequestResult,
+  type BlobResult,
+  type HttpClient,
+  type HttpClientErrorEvent,
+  type HttpClientHooks,
+  type HttpClientOptions,
+  type HttpClientRequestEvent,
+  type HttpClientResponseEvent,
+  type HttpClientRetryEvent,
+  type HttpClientTraceEvent,
+  type HttpClientTracePhase,
+  type HttpRetryContext,
+  type RequestTarget,
+  type ResponseParseMode,
+  type RetryOptions,
+} from './httpClient';
+import type { ApiResult } from '@/types';
 import { buildAuthenticatedHeaders } from '@/utils/httpAuth';
 
-export type RequestTarget = Parameters<typeof fetch>[0];
+const defaultClient = createHttpClient();
 
-export type ResponseParseMode = 'auto' | 'json' | 'text' | 'none';
-
-export interface ApiRequestInit extends RequestInit {
-  /**
-   * Controls how the response payload should be parsed.
-   *
-   * - `auto`: attempt to parse JSON when possible and fall back to text
-   * - `json`: always attempt JSON parsing
-   * - `text`: always attempt text parsing
-   * - `none`: skip payload parsing entirely
-   */
-  parseMode?: ResponseParseMode;
-}
-
-export interface ApiRequestResult<TPayload = unknown> {
-  data: TPayload | null;
-  meta: ApiResponseMeta;
-  response: Response;
-}
-
-export interface BlobResult {
-  blob: Blob;
-  response: Response;
-  meta: ApiResponseMeta;
-}
-
-const DEFAULT_CREDENTIALS: RequestCredentials = 'same-origin';
-
-const hasReadableBody = (response: Response): boolean => {
-  if (!response) {
-    return false;
-  }
-  if (response.status === 204 || response.status === 205 || response.status === 304) {
-    return false;
-  }
-  return typeof response.headers?.get === 'function' || typeof response.text === 'function';
-};
-
-const parseJsonSafely = async (response: Response) => {
-  if (typeof response.json !== 'function') {
-    return null;
-  }
-
-  try {
-    return await response.json();
-  } catch (error) {
-    if (import.meta.env.DEV) {
-      console.warn('[apiClient] Failed to parse JSON response', error);
-    }
-    return null;
-  }
-};
-
-const parseTextSafely = async (response: Response) => {
-  if (typeof response.text !== 'function') {
-    return null;
-  }
-
-  try {
-    return await response.text();
-  } catch (error) {
-    if (import.meta.env.DEV) {
-      console.warn('[apiClient] Failed to read text response', error);
-    }
-    return null;
-  }
-};
-
-const shouldTreatAsJson = (response: Response, mode: ResponseParseMode): boolean => {
-  if (mode === 'json') {
-    return true;
-  }
-  if (mode !== 'auto') {
-    return false;
-  }
-  const contentType = typeof response.headers?.get === 'function'
-    ? response.headers.get('content-type') ?? ''
-    : '';
-  return contentType.includes('application/json') || contentType.includes('+json');
-};
-
-const parseResponsePayload = async (
-  response: Response,
-  mode: ResponseParseMode,
-): Promise<unknown> => {
-  if (mode === 'none' || !hasReadableBody(response)) {
-    return null;
-  }
-
-  if (shouldTreatAsJson(response, mode)) {
-    const parsed = await parseJsonSafely(response);
-    if (parsed !== null || mode === 'json') {
-      return parsed;
-    }
-  }
-
-  if (mode === 'text' || mode === 'auto') {
-    return await parseTextSafely(response);
-  }
-
-  return null;
-};
-
-const deriveErrorMessage = (payload: unknown, response: Response): string => {
-  if (typeof payload === 'string' && payload.trim()) {
-    return payload;
-  }
-
-  if (payload && typeof payload === 'object') {
-    const record = payload as Record<string, unknown>;
-    const detail = record.detail;
-    const message = record.message;
-    const errors = record.errors;
-
-    if (typeof detail === 'string' && detail.trim()) {
-      return detail;
-    }
-
-    if (Array.isArray(detail)) {
-      const first = detail.find((value) => typeof value === 'string' && value.trim());
-      if (typeof first === 'string') {
-        return first;
-      }
-    }
-
-    if (typeof message === 'string' && message.trim()) {
-      return message;
-    }
-
-    if (typeof errors === 'string' && errors.trim()) {
-      return errors;
-    }
-
-    if (Array.isArray(errors)) {
-      const firstError = errors.find((value) => typeof value === 'string' && value.trim());
-      if (typeof firstError === 'string') {
-        return firstError;
-      }
-    }
-  }
-
-  return response.statusText || `Request failed with status ${response.status}`;
-};
-
-const toResponseMeta = (response: Response): ApiResponseMeta => ({
-  ok: response.ok,
-  status: response.status,
-  statusText: response.statusText,
-  headers: response.headers,
-  url: response.url,
-});
-
-const prepareRequestInit = ({ parseMode: _ignored, ...init }: ApiRequestInit = {}): RequestInit => {
-  const { headers, credentials, ...rest } = init;
-
-  return {
-    credentials: credentials ?? DEFAULT_CREDENTIALS,
-    ...rest,
-    headers: buildAuthenticatedHeaders(headers),
-  } satisfies RequestInit;
-};
+export {
+  createHttpClient,
+  ensureData,
+  type ApiRequestInit,
+  type ApiRequestResult,
+  type BlobResult,
+  type HttpClient,
+  type HttpClientErrorEvent,
+  type HttpClientHooks,
+  type HttpClientOptions,
+  type HttpClientRequestEvent,
+  type HttpClientResponseEvent,
+  type HttpClientRetryEvent,
+  type HttpClientTraceEvent,
+  type HttpClientTracePhase,
+  type HttpRetryContext,
+  type RequestTarget,
+  type ResponseParseMode,
+  type RetryOptions,
+} from './httpClient';
 
 export const performRequest = async <TPayload = unknown>(
   input: RequestTarget,
   init: ApiRequestInit = {},
-): Promise<ApiRequestResult<TPayload>> => {
-  const requestInit = prepareRequestInit(init);
-  const response = await fetch(input, requestInit);
-  const meta = toResponseMeta(response);
-  const payload = await parseResponsePayload(response, init.parseMode ?? 'auto');
-
-  if (!response.ok) {
-    throw new ApiError<TPayload>({
-      message: deriveErrorMessage(payload, response),
-      status: response.status,
-      statusText: response.statusText,
-      payload: (payload as TPayload | null) ?? null,
-      meta,
-      response,
-    });
-  }
-
-  return {
-    data: (payload as TPayload | null) ?? null,
-    meta,
-    response,
-  } satisfies ApiRequestResult<TPayload>;
-};
+): Promise<ApiRequestResult<TPayload>> => defaultClient.request<TPayload>(input, init);
 
 export const fetchParsed = async <TPayload = unknown>(
   input: RequestTarget,
   init: ApiRequestInit = {},
-): Promise<TPayload> => {
-  const { data } = await performRequest<TPayload>(input, { ...init, parseMode: init.parseMode ?? 'auto' });
-  return (data as TPayload) ?? (null as TPayload);
-};
+): Promise<TPayload> => defaultClient.fetchParsed<TPayload>(input, init);
 
 export const fetchJson = async <TPayload = unknown>(
   input: RequestTarget,
   init: ApiRequestInit = {},
-): Promise<TPayload> => {
-  const { data } = await performRequest<TPayload>(input, { ...init, parseMode: 'json' });
-  return (data as TPayload) ?? (null as TPayload);
-};
+): Promise<TPayload> => defaultClient.fetchJson<TPayload>(input, init);
 
 export const fetchText = async (
   input: RequestTarget,
   init: ApiRequestInit = {},
-): Promise<string | null> => {
-  const { data } = await performRequest<string | null>(input, { ...init, parseMode: 'text' });
-  return data ?? null;
-};
+): Promise<string | null> => defaultClient.fetchText(input, init);
 
 export const fetchVoid = async (
   input: RequestTarget,
   init: ApiRequestInit = {},
-): Promise<void> => {
-  await performRequest(input, { ...init, parseMode: 'none' });
-};
-
-const ensureHeaders = (init?: HeadersInit): Headers => {
-  return new Headers(init ?? {});
-};
-
-const createJsonInit = (method: string, body: unknown, options: RequestInit = {}): RequestInit => {
-  const headers = ensureHeaders(options.headers);
-  if (!(body instanceof FormData) && !headers.has('Content-Type')) {
-    headers.set('Content-Type', 'application/json');
-  }
-
-  const payload = body instanceof FormData ? body : JSON.stringify(body);
-
-  return {
-    ...options,
-    method,
-    headers,
-    body: payload,
-  } satisfies RequestInit;
-};
+): Promise<void> => defaultClient.fetchVoid(input, init);
 
 export const requestParsed = async <TPayload = unknown>(
   input: RequestTarget,
   init: ApiRequestInit = {},
-): Promise<ApiRequestResult<TPayload>> => performRequest<TPayload>(input, init);
+): Promise<ApiRequestResult<TPayload>> => defaultClient.request<TPayload>(input, init);
 
 export const requestJson = async <TPayload = unknown>(
   input: RequestTarget,
   init: ApiRequestInit = {},
-): Promise<ApiResult<TPayload>> => {
-  const result = await performRequest<TPayload>(input, { ...init, parseMode: 'json' });
-  return { data: result.data, meta: result.meta } satisfies ApiResult<TPayload>;
-};
+): Promise<ApiResult<TPayload>> => defaultClient.requestJson<TPayload>(input, init);
 
 export const getJson = async <TPayload = unknown>(
   input: RequestTarget,
   init: ApiRequestInit = {},
-): Promise<ApiResult<TPayload>> => requestJson<TPayload>(input, { ...init, method: 'GET' });
+): Promise<ApiResult<TPayload>> => defaultClient.getJson<TPayload>(input, init);
 
 export const postJson = async <TResponse = unknown, TBody = unknown>(
   input: RequestTarget,
   body: TBody,
   init: ApiRequestInit = {},
-): Promise<ApiResult<TResponse>> => requestJson<TResponse>(input, createJsonInit('POST', body, init));
+): Promise<ApiResult<TResponse>> => defaultClient.postJson<TResponse, TBody>(input, body, init);
 
 export const putJson = async <TResponse = unknown, TBody = unknown>(
   input: RequestTarget,
   body: TBody,
   init: ApiRequestInit = {},
-): Promise<ApiResult<TResponse>> => requestJson<TResponse>(input, createJsonInit('PUT', body, init));
+): Promise<ApiResult<TResponse>> => defaultClient.putJson<TResponse, TBody>(input, body, init);
 
 export const patchJson = async <TResponse = unknown, TBody = unknown>(
   input: RequestTarget,
   body: TBody,
   init: ApiRequestInit = {},
-): Promise<ApiResult<TResponse>> => requestJson<TResponse>(input, createJsonInit('PATCH', body, init));
+): Promise<ApiResult<TResponse>> => defaultClient.patchJson<TResponse, TBody>(input, body, init);
 
 export const deleteRequest = async <TResponse = unknown>(
   input: RequestTarget,
   init: ApiRequestInit = {},
-): Promise<ApiResult<TResponse>> => requestJson<TResponse>(input, { ...init, method: 'DELETE' });
+): Promise<ApiResult<TResponse>> => defaultClient.delete<TResponse>(input, init);
+
+export const requestBlob = async (
+  input: RequestTarget,
+  init: RequestInit = {},
+): Promise<BlobResult> => defaultClient.requestBlob(input, init);
 
 export type RequestTargetResolver =
   | RequestTarget
@@ -319,21 +146,21 @@ const resolveRequestTarget = (resolver: RequestTargetResolver): RequestTarget =>
   }
 };
 
-const mergeRequestInit = (
-  baseInit: ApiRequestInit = {},
-  overrideInit: ApiRequestInit = {},
-): ApiRequestInit => {
+const mergeConfiguredInit = (baseInit: ApiRequestInit = {}, overrideInit: ApiRequestInit = {}): ApiRequestInit => {
   const headers = buildAuthenticatedHeaders(baseInit.headers, overrideInit.headers);
-  const parseMode = overrideInit.parseMode ?? baseInit.parseMode;
-  const credentials = overrideInit.credentials ?? baseInit.credentials ?? DEFAULT_CREDENTIALS;
+  const credentials = overrideInit.credentials ?? baseInit.credentials;
   const signal = overrideInit.signal ?? baseInit.signal;
+  const parseMode = overrideInit.parseMode ?? baseInit.parseMode;
 
   const merged: ApiRequestInit = {
     ...baseInit,
     ...overrideInit,
     headers,
-    credentials,
   } satisfies ApiRequestInit;
+
+  if (credentials !== undefined) {
+    merged.credentials = credentials;
+  }
 
   if (parseMode !== undefined) {
     merged.parseMode = parseMode;
@@ -355,8 +182,8 @@ export const performConfiguredRequest = async <TPayload = unknown>(
   overrides: ApiRequestInit = {},
 ): Promise<ApiRequestResult<TPayload>> => {
   const target = resolveRequestTarget(config.target);
-  const init = mergeRequestInit(config.init, overrides);
-  return performRequest<TPayload>(target, init);
+  const init = mergeConfiguredInit(config.init, overrides);
+  return defaultClient.request<TPayload>(target, init);
 };
 
 export const requestConfiguredJson = async <TPayload = unknown>(
@@ -364,60 +191,6 @@ export const requestConfiguredJson = async <TPayload = unknown>(
   overrides: ApiRequestInit = {},
 ): Promise<ApiResult<TPayload>> => {
   const target = resolveRequestTarget(config.target);
-  const init = mergeRequestInit(config.init, overrides);
-  return requestJson<TPayload>(target, init);
+  const init = mergeConfiguredInit(config.init, overrides);
+  return defaultClient.requestJson<TPayload>(target, init);
 };
-
-export const requestBlob = async (
-  input: RequestTarget,
-  init: RequestInit = {},
-): Promise<BlobResult> => {
-  const requestInit = prepareRequestInit(init);
-  const response = await fetch(input, requestInit);
-  const meta = toResponseMeta(response);
-
-  if (!response.ok) {
-    const payload = await parseResponsePayload(response, 'auto');
-    throw new ApiError({
-      message: deriveErrorMessage(payload, response),
-      status: response.status,
-      statusText: response.statusText,
-      payload: payload ?? null,
-      meta,
-      response,
-    });
-  }
-
-  const blob = await response.blob();
-  return { blob, response, meta } satisfies BlobResult;
-};
-
-export function ensureData<T>(result: ApiResult<T>): T {
-  if (result.data == null) {
-    throw new Error('Request did not return a response body');
-  }
-  return result.data;
-}
-
-export function getFilenameFromContentDisposition(header?: string | null): string | null {
-  if (!header) {
-    return null;
-  }
-
-  const utf8Match = header.match(/filename\*=UTF-8''([^;]+)/i);
-  if (utf8Match?.[1]) {
-    try {
-      return decodeURIComponent(utf8Match[1]);
-    } catch {
-      return utf8Match[1];
-    }
-  }
-
-  const asciiMatch = header.match(/filename="?([^";]+)"?/i);
-  if (asciiMatch?.[1]) {
-    return asciiMatch[1];
-  }
-
-  return null;
-}
-

--- a/app/frontend/src/services/httpClient.ts
+++ b/app/frontend/src/services/httpClient.ts
@@ -1,0 +1,711 @@
+import { ApiError, type ApiResponseMeta, type ApiResult } from '@/types';
+import { buildAuthenticatedHeaders } from '@/utils/httpAuth';
+
+const DEFAULT_CREDENTIALS: RequestCredentials = 'same-origin';
+const DEFAULT_RETRY_METHODS = ['GET', 'HEAD', 'OPTIONS'];
+const DEFAULT_RETRY_ATTEMPTS = 1;
+const DEFAULT_RETRY_BASE_DELAY = 150;
+const DEFAULT_RETRY_MAX_DELAY = 1_500;
+
+const isAbsoluteUrl = (value: string): boolean => /^[a-zA-Z][a-zA-Z\d+.-]*:/.test(value);
+const trimTrailingSlash = (value: string): string => value.replace(/\/+$/, '');
+const trimLeadingSlash = (value: string): string => value.replace(/^\/+/, '');
+
+const splitPathSuffix = (input: string): { pathname: string; suffix: string } => {
+  const match = input.match(/^([^?#]*)(.*)$/);
+  return { pathname: match?.[1] ?? '', suffix: match?.[2] ?? '' };
+};
+
+const joinUrlSegments = (base: string, path: string): string => {
+  const { pathname, suffix } = splitPathSuffix(path);
+  const normalisedPath = trimLeadingSlash(pathname);
+
+  if (!base) {
+    const candidate = normalisedPath || pathname;
+    return (candidate ?? '') + suffix;
+  }
+
+  if (isAbsoluteUrl(base)) {
+    const prefix = trimTrailingSlash(base);
+    const combined = normalisedPath ? `${prefix}/${normalisedPath}` : prefix;
+    return `${combined}${suffix}`;
+  }
+
+  const trimmedBase = trimTrailingSlash(base);
+  const rootedBase = trimmedBase.length > 0
+    ? trimmedBase.startsWith('/')
+      ? trimmedBase
+      : `/${trimLeadingSlash(trimmedBase)}`
+    : '';
+
+  if (!normalisedPath) {
+    return rootedBase ? `${rootedBase}${suffix}` : suffix || rootedBase || '';
+  }
+
+  const combined = `${rootedBase}/${normalisedPath}`.replace(/\/{2,}/g, '/');
+  return `${combined}${suffix}`;
+};
+
+const now = (): number => {
+  if (typeof performance !== 'undefined' && typeof performance.now === 'function') {
+    return performance.now();
+  }
+  return Date.now();
+};
+
+const sleep = async (delay: number): Promise<void> => {
+  if (delay <= 0) {
+    return;
+  }
+  await new Promise((resolve) => {
+    setTimeout(resolve, delay);
+  });
+};
+
+const isAbortError = (error: unknown): boolean => {
+  if (!error) {
+    return false;
+  }
+  if (error instanceof DOMException) {
+    return error.name === 'AbortError';
+  }
+  if (typeof error === 'object') {
+    const candidate = error as { name?: string };
+    return candidate.name === 'AbortError';
+  }
+  return false;
+};
+
+export type RequestTarget = Parameters<typeof fetch>[0];
+
+export type ResponseParseMode = 'auto' | 'json' | 'text' | 'none';
+
+export interface ApiRequestInit extends RequestInit {
+  parseMode?: ResponseParseMode;
+}
+
+export interface ApiRequestResult<TPayload = unknown> {
+  data: TPayload | null;
+  meta: ApiResponseMeta;
+  response: Response;
+}
+
+export interface BlobResult {
+  blob: Blob;
+  response: Response;
+  meta: ApiResponseMeta;
+}
+
+export interface HttpClientRequestEvent {
+  url: string;
+  request: RequestInit;
+  attempt: number;
+  startedAt: number;
+}
+
+export interface HttpClientResponseEvent extends HttpClientRequestEvent {
+  response: Response;
+  durationMs: number;
+}
+
+export interface HttpClientErrorEvent extends HttpClientRequestEvent {
+  error: unknown;
+  durationMs: number;
+  response?: Response | null;
+}
+
+export interface HttpClientRetryEvent extends HttpClientErrorEvent {
+  nextAttempt: number;
+  delayMs: number;
+}
+
+export interface HttpRetryContext {
+  url: string;
+  init: ApiRequestInit;
+  attempt: number;
+  error: unknown;
+  response?: Response | null;
+}
+
+export interface RetryOptions {
+  attempts?: number;
+  baseDelayMs?: number;
+  maxDelayMs?: number;
+  retryOnMethods?: string[];
+  retryOnStatuses?: number[];
+  retryOnNetworkError?: boolean;
+  shouldRetry?: (context: HttpRetryContext) => boolean;
+}
+
+export interface HttpClientHooks {
+  onRequest?: (event: HttpClientRequestEvent) => void;
+  onResponse?: (event: HttpClientResponseEvent) => void;
+  onError?: (event: HttpClientErrorEvent) => void;
+  onRetry?: (event: HttpClientRetryEvent) => void;
+}
+
+export type HttpClientTracePhase = 'request' | 'response' | 'error' | 'retry';
+
+export interface HttpClientTraceEvent {
+  phase: HttpClientTracePhase;
+  url: string;
+  method: string;
+  attempt: number;
+  durationMs?: number;
+  status?: number;
+  delayMs?: number;
+  error?: unknown;
+}
+
+export interface HttpClientOptions {
+  baseUrl?: string | (() => string | null | undefined);
+  credentials?: RequestCredentials;
+  defaultInit?: ApiRequestInit;
+  fetch?: typeof fetch;
+  hooks?: HttpClientHooks;
+  retry?: RetryOptions;
+  trace?: boolean;
+  logger?: (event: HttpClientTraceEvent) => void;
+}
+
+export interface HttpClient {
+  resolve: (target?: RequestTarget) => string;
+  request: <TPayload = unknown>(target: RequestTarget, init?: ApiRequestInit) => Promise<ApiRequestResult<TPayload>>;
+  requestJson: <TPayload = unknown>(target: RequestTarget, init?: ApiRequestInit) => Promise<ApiResult<TPayload>>;
+  getJson: <TPayload = unknown>(target: RequestTarget, init?: ApiRequestInit) => Promise<ApiResult<TPayload>>;
+  postJson: <TResponse = unknown, TBody = unknown>(
+    target: RequestTarget,
+    body: TBody,
+    init?: ApiRequestInit,
+  ) => Promise<ApiResult<TResponse>>;
+  putJson: <TResponse = unknown, TBody = unknown>(
+    target: RequestTarget,
+    body: TBody,
+    init?: ApiRequestInit,
+  ) => Promise<ApiResult<TResponse>>;
+  patchJson: <TResponse = unknown, TBody = unknown>(
+    target: RequestTarget,
+    body: TBody,
+    init?: ApiRequestInit,
+  ) => Promise<ApiResult<TResponse>>;
+  delete: <TResponse = unknown>(target: RequestTarget, init?: ApiRequestInit) => Promise<ApiResult<TResponse>>;
+  fetchParsed: <TPayload = unknown>(target: RequestTarget, init?: ApiRequestInit) => Promise<TPayload>;
+  fetchJson: <TPayload = unknown>(target: RequestTarget, init?: ApiRequestInit) => Promise<TPayload>;
+  fetchText: (target: RequestTarget, init?: ApiRequestInit) => Promise<string | null>;
+  fetchVoid: (target: RequestTarget, init?: ApiRequestInit) => Promise<void>;
+  requestBlob: (target: RequestTarget, init?: RequestInit) => Promise<BlobResult>;
+}
+
+const hasReadableBody = (response: Response): boolean => {
+  if (!response) {
+    return false;
+  }
+  if (response.status === 204 || response.status === 205 || response.status === 304) {
+    return false;
+  }
+  return typeof response.headers?.get === 'function' || typeof response.text === 'function';
+};
+
+const parseJsonSafely = async (response: Response) => {
+  if (typeof response.json !== 'function') {
+    return null;
+  }
+
+  try {
+    return await response.json();
+  } catch (error) {
+    if (import.meta.env.DEV) {
+      console.warn('[httpClient] Failed to parse JSON response', error);
+    }
+    return null;
+  }
+};
+
+const parseTextSafely = async (response: Response) => {
+  if (typeof response.text !== 'function') {
+    return null;
+  }
+
+  try {
+    return await response.text();
+  } catch (error) {
+    if (import.meta.env.DEV) {
+      console.warn('[httpClient] Failed to read text response', error);
+    }
+    return null;
+  }
+};
+
+const shouldTreatAsJson = (response: Response, mode: ResponseParseMode): boolean => {
+  if (mode === 'json') {
+    return true;
+  }
+  if (mode !== 'auto') {
+    return false;
+  }
+  const contentType = typeof response.headers?.get === 'function' ? response.headers.get('content-type') ?? '' : '';
+  return contentType.includes('application/json') || contentType.includes('+json');
+};
+
+const parseResponsePayload = async (
+  response: Response,
+  mode: ResponseParseMode,
+): Promise<unknown> => {
+  if (mode === 'none' || !hasReadableBody(response)) {
+    return null;
+  }
+
+  if (shouldTreatAsJson(response, mode)) {
+    const parsed = await parseJsonSafely(response);
+    if (parsed !== null || mode === 'json') {
+      return parsed;
+    }
+  }
+
+  if (mode === 'text' || mode === 'auto') {
+    return await parseTextSafely(response);
+  }
+
+  return null;
+};
+
+const deriveErrorMessage = (payload: unknown, response: Response): string => {
+  if (typeof payload === 'string' && payload.trim()) {
+    return payload;
+  }
+
+  if (payload && typeof payload === 'object') {
+    const record = payload as Record<string, unknown>;
+    const detail = record.detail;
+    const message = record.message;
+    const errors = record.errors;
+
+    if (typeof detail === 'string' && detail.trim()) {
+      return detail;
+    }
+
+    if (Array.isArray(detail)) {
+      const first = detail.find((value) => typeof value === 'string' && value.trim());
+      if (typeof first === 'string') {
+        return first;
+      }
+    }
+
+    if (typeof message === 'string' && message.trim()) {
+      return message;
+    }
+
+    if (typeof errors === 'string' && errors.trim()) {
+      return errors;
+    }
+
+    if (Array.isArray(errors)) {
+      const firstError = errors.find((value) => typeof value === 'string' && value.trim());
+      if (typeof firstError === 'string') {
+        return firstError;
+      }
+    }
+  }
+
+  return response.statusText || `Request failed with status ${response.status}`;
+};
+
+const toResponseMeta = (response: Response): ApiResponseMeta => ({
+  ok: response.ok,
+  status: response.status,
+  statusText: response.statusText,
+  headers: response.headers,
+  url: response.url,
+});
+
+const normaliseMethod = (method?: string): string => {
+  if (!method) {
+    return 'GET';
+  }
+  return method.toUpperCase();
+};
+
+const computeDelay = (attempt: number, baseDelay: number, maxDelay: number): number => {
+  const delay = baseDelay * 2 ** Math.max(0, attempt - 2);
+  return Math.min(Math.max(0, delay), maxDelay);
+};
+
+const resolveBaseUrl = (resolver?: string | (() => string | null | undefined)): string | null => {
+  if (!resolver) {
+    return null;
+  }
+
+  try {
+    const resolved = typeof resolver === 'function' ? resolver() : resolver;
+    if (!resolved) {
+      return null;
+    }
+    const trimmed = resolved.trim();
+    return trimmed.length > 0 ? trimmed : null;
+  } catch (error) {
+    if (import.meta.env.DEV) {
+      console.warn('[httpClient] Failed to resolve base URL', error);
+    }
+    return null;
+  }
+};
+
+const resolveUrl = (target: RequestTarget, baseResolver?: string | (() => string | null | undefined)): string => {
+  if (typeof target === 'string') {
+    const trimmed = target.trim();
+    if (!trimmed) {
+      const base = resolveBaseUrl(baseResolver);
+      if (base) {
+        return base;
+      }
+      throw new Error('Invalid request URL');
+    }
+
+    if (isAbsoluteUrl(trimmed)) {
+      return trimmed;
+    }
+
+    const base = resolveBaseUrl(baseResolver);
+    if (!base) {
+      return trimmed;
+    }
+
+    try {
+      return joinUrlSegments(base, trimmed);
+    } catch (error) {
+      if (import.meta.env.DEV) {
+        console.warn('[httpClient] Failed to resolve request URL', error);
+      }
+      throw new Error('Invalid request URL');
+    }
+  }
+
+  if (typeof URL !== 'undefined' && target instanceof URL) {
+    return target.toString();
+  }
+
+  if (typeof Request !== 'undefined' && target instanceof Request) {
+    return target.url;
+  }
+
+  throw new Error('Invalid request URL');
+};
+
+const mergeRequestInit = (
+  baseInit: ApiRequestInit | undefined,
+  overrideInit: ApiRequestInit | undefined,
+  credentialsFallback: RequestCredentials,
+): ApiRequestInit => {
+  const headers = buildAuthenticatedHeaders(baseInit?.headers, overrideInit?.headers);
+  const credentials = overrideInit?.credentials ?? baseInit?.credentials ?? credentialsFallback;
+  const signal = overrideInit?.signal ?? baseInit?.signal;
+  const parseMode = overrideInit?.parseMode ?? baseInit?.parseMode;
+
+  const merged: ApiRequestInit = {
+    ...baseInit,
+    ...overrideInit,
+    headers,
+    credentials,
+  } satisfies ApiRequestInit;
+
+  if (parseMode !== undefined) {
+    merged.parseMode = parseMode;
+  } else {
+    delete merged.parseMode;
+  }
+
+  if (signal) {
+    merged.signal = signal;
+  } else {
+    delete merged.signal;
+  }
+
+  return merged;
+};
+
+const shouldRetryByStatus = (status: number, statuses?: number[]): boolean => {
+  if (Array.isArray(statuses) && statuses.length > 0) {
+    return statuses.includes(status);
+  }
+  return status >= 500 && status < 600;
+};
+
+export const ensureData = <T>(result: ApiResult<T>): T => {
+  if (result.data == null) {
+    throw new Error('Request did not return a response body');
+  }
+  return result.data;
+};
+
+export const createHttpClient = (options: HttpClientOptions = {}): HttpClient => {
+  const fetchImpl = options.fetch ?? globalThis.fetch;
+  if (typeof fetchImpl !== 'function') {
+    throw new Error('Fetch API is not available');
+  }
+
+  const defaultInit = options.defaultInit;
+  const credentialsFallback = options.credentials ?? DEFAULT_CREDENTIALS;
+  const hooks = options.hooks ?? {};
+
+  const retryOptions = options.retry ?? {};
+  const maxAttempts = Math.max(1, retryOptions.attempts ?? DEFAULT_RETRY_ATTEMPTS);
+  const retryOnMethods = (retryOptions.retryOnMethods ?? DEFAULT_RETRY_METHODS).map(normaliseMethod);
+  const retryOnNetworkError = retryOptions.retryOnNetworkError ?? true;
+  const baseDelay = Math.max(0, retryOptions.baseDelayMs ?? DEFAULT_RETRY_BASE_DELAY);
+  const maxDelay = Math.max(baseDelay, retryOptions.maxDelayMs ?? DEFAULT_RETRY_MAX_DELAY);
+
+  const shouldTrace = options.trace ?? false;
+  const logTrace = (event: HttpClientTraceEvent) => {
+    try {
+      options.logger?.(event);
+      if (shouldTrace) {
+        console.debug('[httpClient]', event);
+      }
+    } catch (error) {
+      if (import.meta.env.DEV) {
+        console.warn('[httpClient] Failed to emit trace event', error);
+      }
+    }
+  };
+
+  const emitRequest = (event: HttpClientRequestEvent) => {
+    hooks.onRequest?.(event);
+    logTrace({
+      phase: 'request',
+      url: event.url,
+      method: normaliseMethod(event.request.method),
+      attempt: event.attempt,
+    });
+  };
+
+  const emitResponse = (event: HttpClientResponseEvent) => {
+    hooks.onResponse?.(event);
+    logTrace({
+      phase: 'response',
+      url: event.url,
+      method: normaliseMethod(event.request.method),
+      attempt: event.attempt,
+      status: event.response.status,
+      durationMs: event.durationMs,
+    });
+  };
+
+  const emitError = (event: HttpClientErrorEvent) => {
+    hooks.onError?.(event);
+    logTrace({
+      phase: 'error',
+      url: event.url,
+      method: normaliseMethod(event.request.method),
+      attempt: event.attempt,
+      status: event.response?.status,
+      durationMs: event.durationMs,
+      error: event.error,
+    });
+  };
+
+  const emitRetry = (event: HttpClientRetryEvent) => {
+    hooks.onRetry?.(event);
+    logTrace({
+      phase: 'retry',
+      url: event.url,
+      method: normaliseMethod(event.request.method),
+      attempt: event.nextAttempt,
+      status: event.response?.status,
+      durationMs: event.durationMs,
+      delayMs: event.delayMs,
+      error: event.error,
+    });
+  };
+
+  const shouldRetry = (context: HttpRetryContext, method: string): boolean => {
+    if (maxAttempts <= 1) {
+      return false;
+    }
+
+    if (!retryOnMethods.includes(method)) {
+      return false;
+    }
+
+    if (retryOptions.shouldRetry) {
+      return retryOptions.shouldRetry(context);
+    }
+
+    if (context.response) {
+      return shouldRetryByStatus(context.response.status, retryOptions.retryOnStatuses);
+    }
+
+    if (!context.response && retryOnNetworkError && context.error && !isAbortError(context.error)) {
+      return true;
+    }
+
+    return false;
+  };
+
+  const request = async <TPayload>(
+    target: RequestTarget,
+    init: ApiRequestInit = {},
+  ): Promise<ApiRequestResult<TPayload>> => {
+    const mergedInit = mergeRequestInit(defaultInit, init, credentialsFallback);
+    const { parseMode = 'auto', ...rest } = mergedInit;
+    const requestInit = { ...rest } as RequestInit;
+    const method = normaliseMethod(requestInit.method);
+    const url = resolveUrl(target, options.baseUrl);
+
+    const execute = async (attempt: number): Promise<ApiRequestResult<TPayload>> => {
+      const startedAt = now();
+      emitRequest({ url, request: requestInit, attempt, startedAt });
+
+      try {
+        const response = await fetchImpl(url, requestInit);
+        const meta = toResponseMeta(response);
+        const payload = await parseResponsePayload(response, parseMode);
+
+        if (!response.ok) {
+          const error = new ApiError<TPayload>({
+            message: deriveErrorMessage(payload, response),
+            status: response.status,
+            statusText: response.statusText,
+            payload: (payload as TPayload | null) ?? null,
+            meta,
+            response,
+          });
+          const durationMs = now() - startedAt;
+          emitError({ url, request: requestInit, attempt, startedAt, durationMs, error, response });
+
+          const retryContext: HttpRetryContext = { url, init: mergedInit, attempt, error, response };
+          if (attempt < maxAttempts && shouldRetry(retryContext, method)) {
+            const nextAttempt = attempt + 1;
+            const delayMs = computeDelay(nextAttempt, baseDelay, maxDelay);
+            emitRetry({
+              url,
+              request: requestInit,
+              attempt,
+              startedAt,
+              durationMs,
+              error,
+              response,
+              nextAttempt,
+              delayMs,
+            });
+            await sleep(delayMs);
+            return execute(nextAttempt);
+          }
+
+          throw error;
+        }
+
+        const durationMs = now() - startedAt;
+        emitResponse({ url, request: requestInit, attempt, startedAt, response, durationMs });
+        return {
+          data: (payload as TPayload | null) ?? null,
+          meta,
+          response,
+        } satisfies ApiRequestResult<TPayload>;
+      } catch (error) {
+        if (error instanceof ApiError) {
+          throw error;
+        }
+
+        const durationMs = now() - startedAt;
+        emitError({ url, request: requestInit, attempt, startedAt, durationMs, error, response: undefined });
+
+        const retryContext: HttpRetryContext = { url, init: mergedInit, attempt, error, response: undefined };
+        if (attempt < maxAttempts && shouldRetry(retryContext, method)) {
+          const nextAttempt = attempt + 1;
+          const delayMs = computeDelay(nextAttempt, baseDelay, maxDelay);
+          emitRetry({
+            url,
+            request: requestInit,
+            attempt,
+            startedAt,
+            durationMs,
+            error,
+            response: undefined,
+            nextAttempt,
+            delayMs,
+          });
+          await sleep(delayMs);
+          return execute(nextAttempt);
+        }
+
+        throw error;
+      }
+    };
+
+    return execute(1);
+  };
+
+  const requestJson = async <TPayload>(
+    target: RequestTarget,
+    init: ApiRequestInit = {},
+  ): Promise<ApiResult<TPayload>> => {
+    const result = await request<TPayload>(target, { ...init, parseMode: 'json' });
+    return { data: result.data, meta: result.meta } satisfies ApiResult<TPayload>;
+  };
+
+  const fetchParsed = async <TPayload>(target: RequestTarget, init: ApiRequestInit = {}): Promise<TPayload> => {
+    const result = await request<TPayload>(target, init);
+    return (result.data as TPayload) ?? (null as TPayload);
+  };
+
+  const fetchJson = async <TPayload>(target: RequestTarget, init: ApiRequestInit = {}): Promise<TPayload> => {
+    const result = await request<TPayload>(target, { ...init, parseMode: 'json' });
+    return (result.data as TPayload) ?? (null as TPayload);
+  };
+
+  const fetchText = async (target: RequestTarget, init: ApiRequestInit = {}): Promise<string | null> => {
+    const result = await request<string | null>(target, { ...init, parseMode: 'text' });
+    return result.data ?? null;
+  };
+
+  const fetchVoid = async (target: RequestTarget, init: ApiRequestInit = {}): Promise<void> => {
+    await request(target, { ...init, parseMode: 'none' });
+  };
+
+  const resolve = (target: RequestTarget = ''): string => resolveUrl(target, options.baseUrl);
+
+  return {
+    resolve,
+    request,
+    requestJson,
+    getJson: <TPayload>(target: RequestTarget, init: ApiRequestInit = {}) =>
+      requestJson<TPayload>(target, { ...init, method: init.method ?? 'GET' }),
+    postJson: <TResponse, TBody>(target: RequestTarget, body: TBody, init: ApiRequestInit = {}) =>
+      requestJson<TResponse>(target, createJsonInit('POST', body, init)),
+    putJson: <TResponse, TBody>(target: RequestTarget, body: TBody, init: ApiRequestInit = {}) =>
+      requestJson<TResponse>(target, createJsonInit('PUT', body, init)),
+    patchJson: <TResponse, TBody>(target: RequestTarget, body: TBody, init: ApiRequestInit = {}) =>
+      requestJson<TResponse>(target, createJsonInit('PATCH', body, init)),
+    delete: <TResponse>(target: RequestTarget, init: ApiRequestInit = {}) =>
+      requestJson<TResponse>(target, { ...init, method: 'DELETE' }),
+    fetchParsed,
+    fetchJson,
+    fetchText,
+    fetchVoid,
+    requestBlob: async (target: RequestTarget, init: RequestInit = {}): Promise<BlobResult> => {
+      const result = await request<null>(target, { ...init, parseMode: 'none' });
+      const blob = await result.response.blob();
+      return { blob, response: result.response, meta: result.meta } satisfies BlobResult;
+    },
+  } satisfies HttpClient;
+};
+
+const ensureHeaders = (init?: HeadersInit): Headers => {
+  return new Headers(init ?? {});
+};
+
+const createJsonInit = (method: string, body: unknown, options: ApiRequestInit = {}): ApiRequestInit => {
+  const headers = ensureHeaders(options.headers);
+  if (!(body instanceof FormData) && !headers.has('Content-Type')) {
+    headers.set('Content-Type', 'application/json');
+  }
+
+  const payload = body instanceof FormData ? body : JSON.stringify(body);
+
+  return {
+    ...options,
+    method,
+    headers,
+    body: payload,
+  } satisfies ApiRequestInit;
+};

--- a/app/frontend/src/utils/httpAuth.ts
+++ b/app/frontend/src/utils/httpAuth.ts
@@ -1,6 +1,6 @@
 import runtimeConfig from '@/config/runtime';
 import { getBackendApiKey } from '@/config/backendSettings';
-import { normaliseBackendApiKey, tryGetSettingsStore } from '@/stores';
+import { normaliseBackendApiKey, tryGetSettingsStore } from '@/stores/settings';
 
 export const API_AUTH_HEADER = 'X-API-Key';
 

--- a/tests/vue/services/httpClient.spec.ts
+++ b/tests/vue/services/httpClient.spec.ts
@@ -1,0 +1,149 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/utils/httpAuth', () => ({
+  buildAuthenticatedHeaders: vi.fn((...sources: Array<Record<string, string> | undefined>) => ({
+    ...Object.assign({}, ...sources),
+    'X-API-Key': 'stub-key',
+  })),
+}));
+
+import { ApiError } from '@/types';
+import {
+  createHttpClient,
+  type ApiRequestInit,
+  type ApiRequestResult,
+  type HttpClientHooks,
+} from '@/services/httpClient';
+import { buildAuthenticatedHeaders } from '@/utils/httpAuth';
+
+const createJsonResponse = (payload: unknown, overrides: Partial<Response> = {}): Response => ({
+  ok: overrides.ok ?? true,
+  status: overrides.status ?? 200,
+  statusText: overrides.statusText ?? 'OK',
+  headers: new Headers({ 'content-type': 'application/json', ...(overrides.headers as HeadersInit | undefined) }),
+  json: vi.fn().mockResolvedValue(payload),
+  text: vi.fn().mockResolvedValue(typeof payload === 'string' ? payload : JSON.stringify(payload)),
+  blob: vi.fn().mockResolvedValue(new Blob([JSON.stringify(payload)], { type: 'application/json' })),
+}) as unknown as Response;
+
+const createTextResponse = (payload: string, overrides: Partial<Response> = {}): Response => ({
+  ok: overrides.ok ?? true,
+  status: overrides.status ?? 200,
+  statusText: overrides.statusText ?? 'OK',
+  headers: new Headers({ 'content-type': 'text/plain', ...(overrides.headers as HeadersInit | undefined) }),
+  text: vi.fn().mockResolvedValue(payload),
+}) as unknown as Response;
+
+describe('createHttpClient', () => {
+  const fetchMock = vi.fn<Parameters<typeof fetch>, ReturnType<typeof fetch>>();
+
+  beforeEach(() => {
+    fetchMock.mockReset();
+    vi.mocked(buildAuthenticatedHeaders).mockClear();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('resolves relative paths against the provided base URL', async () => {
+    fetchMock.mockResolvedValue(createJsonResponse({}));
+    const client = createHttpClient({
+      baseUrl: () => 'https://example.test/api/v1/',
+      fetch: fetchMock as unknown as typeof fetch,
+      trace: false,
+    });
+
+    await client.requestJson('/status');
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://example.test/api/v1/status',
+      expect.objectContaining({ credentials: 'same-origin' }),
+    );
+  });
+
+  it('merges authentication headers for every request', async () => {
+    fetchMock.mockResolvedValue(createJsonResponse({}));
+    const client = createHttpClient({
+      fetch: fetchMock as unknown as typeof fetch,
+      trace: false,
+    });
+
+    const init: ApiRequestInit = { headers: { 'X-Test': 'value' } };
+    await client.requestJson('https://api.example/status', init);
+
+    expect(buildAuthenticatedHeaders).toHaveBeenCalledWith(undefined, { 'X-Test': 'value' });
+    const [, requestInit] = fetchMock.mock.calls[0] ?? [];
+    expect(requestInit?.headers).toMatchObject({ 'X-Test': 'value', 'X-API-Key': 'stub-key' });
+  });
+
+  it('normalises API errors into ApiError instances', async () => {
+    fetchMock.mockResolvedValue(
+      createJsonResponse({ detail: 'nope' }, { ok: false, status: 500, statusText: 'Failure' }),
+    );
+    const client = createHttpClient({ fetch: fetchMock as unknown as typeof fetch, trace: false });
+
+    await expect(client.fetchJson('https://api.example/fail')).rejects.toMatchObject({
+      message: 'nope',
+      status: 500,
+    });
+  });
+
+  it('retries retryable responses when configured', async () => {
+    fetchMock
+      .mockResolvedValueOnce(createJsonResponse({}, { ok: false, status: 503, statusText: 'Unavailable' }))
+      .mockResolvedValueOnce(createJsonResponse({ payload: true }));
+    const hooks: HttpClientHooks = {
+      onRetry: vi.fn(),
+    };
+    const client = createHttpClient({
+      fetch: fetchMock as unknown as typeof fetch,
+      retry: { attempts: 2, baseDelayMs: 0, maxDelayMs: 0 },
+      hooks,
+      trace: false,
+    });
+
+    const result = await client.requestJson<{ payload: boolean }>('https://api.example/retry');
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(result.data).toEqual({ payload: true });
+    expect(hooks.onRetry).toHaveBeenCalledTimes(1);
+  });
+
+  it('invokes tracing logger hooks for requests and responses', async () => {
+    fetchMock.mockResolvedValue(createTextResponse('ok'));
+    const logger = vi.fn();
+    const client = createHttpClient({
+      fetch: fetchMock as unknown as typeof fetch,
+      logger,
+      trace: false,
+    });
+
+    const response: ApiRequestResult<string | null> = await client.request('https://api.example/text', {
+      parseMode: 'text',
+    });
+
+    expect(response.data).toBe('ok');
+    expect(logger).toHaveBeenCalledWith(expect.objectContaining({ phase: 'request', url: 'https://api.example/text' }));
+    expect(logger).toHaveBeenCalledWith(expect.objectContaining({ phase: 'response', url: 'https://api.example/text' }));
+  });
+
+  it('exposes the resolved base URL when no path is provided', () => {
+    const client = createHttpClient({ baseUrl: () => 'https://example.test/api/', trace: false });
+    expect(client.resolve()).toBe('https://example.test/api/');
+  });
+
+  it('preserves ApiError instances raised from failed requests', async () => {
+    const apiError = new ApiError({
+      message: 'boom',
+      status: 502,
+      statusText: 'Bad Gateway',
+      payload: null,
+      meta: { ok: false, status: 502, statusText: 'Bad Gateway', headers: undefined, url: 'https://api.example' },
+    });
+    fetchMock.mockRejectedValue(apiError);
+    const client = createHttpClient({ fetch: fetchMock as unknown as typeof fetch, trace: false });
+
+    await expect(client.requestJson('https://api.example/fail')).rejects.toBe(apiError);
+  });
+});

--- a/tests/vue/useBackupWorkflow.spec.ts
+++ b/tests/vue/useBackupWorkflow.spec.ts
@@ -57,7 +57,7 @@ describe('useBackupWorkflow', () => {
     const workflow = useBackupWorkflow({ notify, backendClient });
     await workflow.initialize();
 
-    expect(getJson).toHaveBeenCalledWith('https://custom.example/api/v1/backups/history');
+    expect(getJson).toHaveBeenCalledWith('https://custom.example/api/v1/backups/history', undefined);
     expect(workflow.backupHistory.value).toHaveLength(1);
     expect(workflow.backupHistory.value[0].id).toBe('b1');
   });
@@ -67,11 +67,19 @@ describe('useBackupWorkflow', () => {
     await workflow.initialize();
 
     await workflow.createFullBackup();
-    expect(postJson).toHaveBeenCalledWith('https://custom.example/api/v1/backup/create', { backup_type: 'full' });
+    expect(postJson).toHaveBeenCalledWith(
+      'https://custom.example/api/v1/backup/create',
+      { backup_type: 'full' },
+      undefined,
+    );
     expect(notify).toHaveBeenCalledWith('Full backup initiated: b2', 'success');
 
     await workflow.createQuickBackup();
-    expect(postJson).toHaveBeenCalledWith('https://custom.example/api/v1/backup/create', { backup_type: 'quick' });
+    expect(postJson).toHaveBeenCalledWith(
+      'https://custom.example/api/v1/backup/create',
+      { backup_type: 'quick' },
+      undefined,
+    );
     expect(notify).toHaveBeenCalledWith('Quick backup initiated: b2', 'success');
   });
 

--- a/tests/vue/useExportWorkflow.spec.ts
+++ b/tests/vue/useExportWorkflow.spec.ts
@@ -84,7 +84,11 @@ describe('useExportWorkflow', () => {
     await workflow.initialize();
     await nextTick();
 
-    expect(postJson).toHaveBeenCalledWith('https://custom.example/api/v1/export/estimate', expect.any(Object));
+    expect(postJson).toHaveBeenCalledWith(
+      'https://custom.example/api/v1/export/estimate',
+      expect.any(Object),
+      undefined,
+    );
     expect(workflow.estimatedSize.value).toBe('10 MB');
     expect(workflow.estimatedTime.value).toBe('5 minutes');
   });


### PR DESCRIPTION
## Summary
- add a configurable `createHttpClient` factory that unifies request parsing, retries, tracing, and authentication headers
- switch the legacy API and backend clients to delegate to the shared HTTP client helpers
- update import/export workflows and associated tests to handle the new client response shapes and coverage

## Testing
- `npm run test:unit -- tests/vue/services/httpClient.spec.ts`
- `npm run test:unit -- tests/vue/useBackupWorkflow.spec.ts`
- `npm run test:unit -- tests/vue/useExportWorkflow.spec.ts`
- `npm run test:unit` *(fails: multiple suites still rely on outdated MSW handlers and mocks)*

------
https://chatgpt.com/codex/tasks/task_e_68dc70fcfd44832994a51e242e394ae1