### PR TITLE
Refactor frontend imports to remove shared barrels

### DIFF
--- a/app/frontend/src/App.vue
+++ b/app/frontend/src/App.vue
@@ -43,7 +43,7 @@ import MainNavigation from '@/components/layout/MainNavigation.vue';
 import MobileNav from '@/components/layout/MobileNav.vue';
 import Notifications from '@/components/shared/Notifications.vue';
 import DialogRenderer from '@/components/shared/DialogRenderer.vue';
-import { useSettingsStore } from '@/stores';
+import { useSettingsStore } from '@/stores/settings';
 
 const settingsStore = useSettingsStore();
 const { isLoading, isLoaded } = storeToRefs(settingsStore);

--- a/app/frontend/src/components/dashboard/DashboardGenerationSummary.vue
+++ b/app/frontend/src/components/dashboard/DashboardGenerationSummary.vue
@@ -97,7 +97,7 @@ import { computed, onMounted, ref, watch } from 'vue';
 import { storeToRefs } from 'pinia';
 import { RouterLink } from 'vue-router';
 
-import { useBackendClient } from '@/services';
+import { useBackendClient } from '@/services/backendClient';
 import { listResults as listHistoryResults } from '@/features/history/services';
 import { useGenerationResultsStore } from '@/features/generation/public';
 import { formatFileSize, formatRelativeTime } from '@/utils/format';
@@ -106,7 +106,7 @@ import type {
   GenerationHistoryResult,
   GenerationHistoryStats,
 } from '@/types';
-import { useSettingsStore } from '@/stores';
+import { useSettingsStore } from '@/stores/settings';
 
 const SUMMARY_QUERY = Object.freeze({ page_size: 4, sort: 'created_at_desc' as const });
 

--- a/app/frontend/src/components/layout/MainNavigation.vue
+++ b/app/frontend/src/components/layout/MainNavigation.vue
@@ -81,7 +81,7 @@
 import { computed } from 'vue';
 import { useRoute, useRouter, RouterLink } from 'vue-router';
 
-import { useAppStore } from '@/stores';
+import { useAppStore } from '@/stores/app';
 import { useSyncedQueryParam, useTheme } from '@/composables/shared';
 import { NAVIGATION_ITEMS } from '@/config/navigation';
 

--- a/app/frontend/src/composables/import-export/useBackupWorkflow.ts
+++ b/app/frontend/src/composables/import-export/useBackupWorkflow.ts
@@ -1,7 +1,7 @@
 import { ref, type Ref } from 'vue';
 
 import { ensureData } from '@/services/apiClient';
-import { useBackendClient, type BackendClient } from '@/services';
+import { useBackendClient, type BackendClient } from '@/services/backendClient';
 import type { BackupCreateRequest, BackupHistoryItem } from '@/types';
 import type { NotifyFn } from './useExportWorkflow';
 

--- a/app/frontend/src/composables/import-export/useExportWorkflow.ts
+++ b/app/frontend/src/composables/import-export/useExportWorkflow.ts
@@ -1,7 +1,7 @@
 import { computed, reactive, ref, watch, type ComputedRef } from 'vue';
 
 import { ensureData, getFilenameFromContentDisposition } from '@/services/apiClient';
-import { useBackendClient, type BackendClient } from '@/services';
+import { useBackendClient, type BackendClient } from '@/services/backendClient';
 import { downloadFile } from '@/utils/browser';
 import { formatFileSize as formatBytes } from '@/utils/format';
 import type { ExportConfig, ExportEstimate } from '@/types';

--- a/app/frontend/src/composables/import-export/useImportWorkflow.ts
+++ b/app/frontend/src/composables/import-export/useImportWorkflow.ts
@@ -1,7 +1,7 @@
 import { computed, reactive, ref, type ComputedRef } from 'vue';
 
 import { ensureData } from '@/services/apiClient';
-import { useBackendClient, type BackendClient } from '@/services';
+import { useBackendClient, type BackendClient } from '@/services/backendClient';
 import type { ImportConfig } from '@/types';
 import type { NotifyFn, ProgressCallbacks } from './useExportWorkflow';
 

--- a/app/frontend/src/composables/shared/useAsyncResource.ts
+++ b/app/frontend/src/composables/shared/useAsyncResource.ts
@@ -1,6 +1,10 @@
 import { computed, isRef, onScopeDispose, ref, type ComputedRef, type Ref } from 'vue';
 
-import { useBackendRefresh, type BackendRefreshOptions, type BackendRefreshSubscription } from '@/services';
+import {
+  useBackendRefresh,
+  type BackendRefreshOptions,
+  type BackendRefreshSubscription,
+} from '@/services/system/backendRefresh';
 
 export interface AsyncResourceBackendRefreshOptions<TArgs>
   extends BackendRefreshOptions {

--- a/app/frontend/src/composables/shared/useNotifications.ts
+++ b/app/frontend/src/composables/shared/useNotifications.ts
@@ -1,6 +1,6 @@
 import { storeToRefs } from 'pinia';
 
-import { useAppStore } from '@/stores';
+import { useAppStore } from '@/stores/app';
 
 import type { NotificationType } from '@/types';
 

--- a/app/frontend/src/composables/shared/useTheme.ts
+++ b/app/frontend/src/composables/shared/useTheme.ts
@@ -1,7 +1,7 @@
 import { computed, watch } from 'vue';
 import { storeToRefs } from 'pinia';
 
-import { useAppStore } from '@/stores';
+import { useAppStore } from '@/stores/app';
 
 type ThemePreference = 'light' | 'dark';
 

--- a/app/frontend/src/composables/system/useAdminMetrics.ts
+++ b/app/frontend/src/composables/system/useAdminMetrics.ts
@@ -1,8 +1,8 @@
 import { computed, onBeforeUnmount, onMounted } from 'vue';
 import { storeToRefs } from 'pinia';
 
-import { useAdminMetricsStore } from '@/stores';
-import type { AdminMetricsStore } from '@/stores';
+import { useAdminMetricsStore } from '@/stores/adminMetrics';
+import type { AdminMetricsStore } from '@/stores/adminMetrics';
 import { usePolling, type PollingController } from '../shared/usePolling';
 
 const formatRelativeTime = (input: Date | null): string => {

--- a/app/frontend/src/features/analytics/stores/performanceAnalytics.ts
+++ b/app/frontend/src/features/analytics/stores/performanceAnalytics.ts
@@ -2,7 +2,7 @@ import { computed, ref, watch } from 'vue';
 import { defineStore } from 'pinia';
 
 import { useAsyncResource } from '@/composables/shared';
-import { useBackendClient } from '@/services';
+import { useBackendClient } from '@/services/backendClient';
 import { fetchTopAdapters } from '@/features/lora/public';
 import { exportAnalyticsReport, fetchPerformanceAnalytics } from '../services/analyticsService';
 import { formatDuration as formatDurationLabel } from '@/utils/format';

--- a/app/frontend/src/features/generation/composables/useGenerationOrchestratorManager.ts
+++ b/app/frontend/src/features/generation/composables/useGenerationOrchestratorManager.ts
@@ -13,7 +13,7 @@ import {
   DEFAULT_HISTORY_LIMIT,
 } from '../stores/useGenerationOrchestratorStore';
 import { useGenerationStudioUiStore } from '../stores/ui';
-import { useSettingsStore } from '@/stores';
+import { useSettingsStore } from '@/stores/settings';
 import type {
   GenerationJob,
   GenerationRequestPayload,

--- a/app/frontend/src/features/generation/stores/systemStatusController.ts
+++ b/app/frontend/src/features/generation/stores/systemStatusController.ts
@@ -2,7 +2,8 @@ import { computed, ref, type ComputedRef } from 'vue';
 import { storeToRefs } from 'pinia';
 
 import { ApiError } from '@/composables/shared';
-import { fetchSystemStatus, useBackendClient, type BackendClient } from '@/services';
+import { useBackendClient, type BackendClient } from '@/services/backendClient';
+import { fetchSystemStatus } from '@/services/system/systemService';
 import { resolveBackendBaseUrl } from '@/utils/backend';
 import { generationPollingConfig } from '../config/polling';
 import { useGenerationConnectionStore } from './connection';

--- a/app/frontend/src/features/history/components/GenerationHistoryController.vue
+++ b/app/frontend/src/features/history/components/GenerationHistoryController.vue
@@ -24,7 +24,7 @@ import {
   type DimensionFilterOption,
 } from '@/features/history';
 import { PERSISTENCE_KEYS, useAsyncLifecycleTask, usePersistence } from '@/composables/shared';
-import { useBackendRefresh } from '@/services';
+import { useBackendRefresh } from '@/services/system/backendRefresh';
 import { useBackendBase } from '@/utils/backend';
 import { formatHistoryDate } from '@/utils/format';
 import type { GenerationHistoryResult } from '@/types';

--- a/app/frontend/src/features/history/composables/useGenerationHistory.ts
+++ b/app/frontend/src/features/history/composables/useGenerationHistory.ts
@@ -2,7 +2,7 @@ import { computed, ref, type ComputedRef } from 'vue';
 import type { MaybeRefOrGetter } from 'vue';
 
 import { debounce, type DebouncedFunction } from '@/utils/async';
-import { useBackendClient } from '@/services';
+import { useBackendClient } from '@/services/backendClient';
 import { listResults as listHistoryResults } from '@/features/history/services';
 import type {
   GenerationHistoryQuery,

--- a/app/frontend/src/features/history/composables/useHistoryActions.ts
+++ b/app/frontend/src/features/history/composables/useHistoryActions.ts
@@ -3,7 +3,7 @@ import type { Router } from 'vue-router';
 
 import { PERSISTENCE_KEYS, usePersistence } from '@/composables/shared';
 import { downloadFile } from '@/utils/browser';
-import { useBackendClient } from '@/services';
+import { useBackendClient } from '@/services/backendClient';
 import {
   deleteResult as deleteHistoryResult,
   deleteResults as deleteHistoryResults,

--- a/app/frontend/src/features/lora/composables/lora-gallery/useLoraCardActions.ts
+++ b/app/frontend/src/features/lora/composables/lora-gallery/useLoraCardActions.ts
@@ -2,7 +2,7 @@ import { computed, ref, watch, type Ref } from 'vue';
 import { useRouter } from 'vue-router';
 
 import { useNotifications } from '@/composables/shared';
-import { useBackendClient } from '@/services';
+import { useBackendClient } from '@/services/backendClient';
 import {
   buildRecommendationsUrl,
   deleteLora as deleteLoraRequest,

--- a/app/frontend/src/features/lora/stores/adapterCatalog.ts
+++ b/app/frontend/src/features/lora/stores/adapterCatalog.ts
@@ -3,7 +3,7 @@ import { defineStore } from 'pinia';
 
 import { ApiError, useAsyncResource } from '@/composables/shared';
 import { fetchAdapterList, fetchAdapterTags, performBulkLoraAction } from '../services/lora/loraService';
-import { useBackendClient } from '@/services';
+import { useBackendClient } from '@/services/backendClient';
 
 import type {
   AdapterRead,

--- a/app/frontend/src/features/recommendations/composables/useRecommendations.ts
+++ b/app/frontend/src/features/recommendations/composables/useRecommendations.ts
@@ -3,9 +3,9 @@ import { storeToRefs } from 'pinia';
 
 import { useAsyncResource } from '@/composables/shared';
 
-import { useBackendClient } from '@/services';
+import { useBackendClient } from '@/services/backendClient';
 
-import { useBackendEnvironment, useSettingsStore } from '@/stores';
+import { useBackendEnvironment, useSettingsStore } from '@/stores/settings';
 import { useAdapterCatalogStore } from '@/features/lora/public';
 import type { AdapterSummary, RecommendationItem, RecommendationResponse } from '@/types';
 import { debounce, type DebouncedFunction } from '@/utils/async';

--- a/app/frontend/src/services/index.ts
+++ b/app/frontend/src/services/index.ts
@@ -1,3 +1,0 @@
-export * from './apiClient';
-export * from './backendClient';
-export * from './system';

--- a/app/frontend/src/services/system/index.ts
+++ b/app/frontend/src/services/system/index.ts
@@ -1,4 +1,0 @@
-export * from './systemService';
-export * from './backendEnvironmentEventBus';
-export * from './backendEnvironmentBus';
-export * from './backendRefresh';

--- a/app/frontend/src/stores/adminMetrics.ts
+++ b/app/frontend/src/stores/adminMetrics.ts
@@ -3,12 +3,12 @@ import { defineStore } from 'pinia';
 
 import { useAsyncResource } from '@/composables/shared';
 
+import { useBackendClient } from '@/services/backendClient';
 import {
   deriveMetricsFromDashboard,
   emptyMetricsSnapshot,
   fetchDashboardStats,
-  useBackendClient,
-} from '@/services';
+} from '@/services/system/systemService';
 import {
   buildResourceStats,
   defaultResourceStats,

--- a/app/frontend/src/stores/index.ts
+++ b/app/frontend/src/stores/index.ts
@@ -1,4 +1,0 @@
-export * from './settings';
-export * from './app';
-export * from './adminMetrics';
-

--- a/app/frontend/src/utils/backend.ts
+++ b/app/frontend/src/utils/backend.ts
@@ -5,7 +5,7 @@ import {
   getResolvedBackendUrl,
   tryGetSettingsStore,
   type SettingsStore,
-} from '@/stores';
+} from '@/stores/settings';
 
 import {
   DEFAULT_BACKEND_BASE,


### PR DESCRIPTION
## Summary
- remove the shared services and stores barrel files so features import the concrete modules they rely on
- update generation, history, LoRA, analytics, and recommendation modules to reference backend clients and refresh helpers directly

## Testing
- `npm run build` *(fails: existing TypeScript errors throughout the frontend codebase)*
- `npm run test:unit` *(fails: numerous Vitest suites already failing in this repository)*

------
https://chatgpt.com/codex/tasks/task_e_68dc95dbbca48329ac62b70ae877ec7c