### PR TITLE
feat: enforce schema-first data flow

### DIFF
--- a/app/frontend/src/features/generation/services/queueClient.ts
+++ b/app/frontend/src/features/generation/services/queueClient.ts
@@ -6,7 +6,6 @@ import {
   startGeneration,
 } from './generationService';
 import { requestJson } from '@/services/apiClient';
-import { normalizeJobStatus } from '@/utils/status';
 import {
   logValidationIssues,
   parseGenerationJobStatuses,
@@ -73,11 +72,7 @@ export const createGenerationQueueClient = (
         buildGenerationUrl('jobs/active'),
         withCredentials(),
       );
-      const parsed = parseGenerationJobStatuses(result.data, 'active job');
-      return parsed.map((status) => ({
-        ...status,
-        status: normalizeJobStatus(status.status),
-      }));
+      return parseGenerationJobStatuses(result.data, 'active job');
     } catch (error) {
       console.error('Failed to load active jobs:', error);
       throw error;

--- a/app/frontend/src/features/history/composables/useGenerationHistory.ts
+++ b/app/frontend/src/features/history/composables/useGenerationHistory.ts
@@ -65,17 +65,8 @@ export const useGenerationHistory = ({
   const filteredResults = computed(() => data.value);
 
   const stats = computed<GenerationHistoryStats>(() => {
-    const sanitize = (value: unknown): number =>
-      typeof value === 'number' && Number.isFinite(value) ? value : 0;
-
     if (serverStats.value) {
-      const snapshot = serverStats.value;
-      return {
-        total_results: sanitize(snapshot.total_results),
-        avg_rating: sanitize(snapshot.avg_rating),
-        total_favorites: sanitize(snapshot.total_favorites),
-        total_size: sanitize(snapshot.total_size),
-      };
+      return serverStats.value;
     }
 
     const results = filteredResults.value;

--- a/app/frontend/src/schemas/index.ts
+++ b/app/frontend/src/schemas/index.ts
@@ -1,3 +1,12 @@
+/**
+ * Runtime schemas shared across the frontend.
+ *
+ * Backend contract updates must be reflected here to keep runtime parsing in
+ * sync with API responses. Treat these exports as the single source of truth
+ * for payload validation when wiring new endpoints or adjusting existing
+ * ones.
+ */
 export * from './json';
 export * from './generation';
+export * from './lora';
 export * from './system';

--- a/app/frontend/src/schemas/lora.ts
+++ b/app/frontend/src/schemas/lora.ts
@@ -1,0 +1,320 @@
+import { z, type ZodIssue } from 'zod';
+
+import type {
+  AdapterListQuery,
+  AdapterListResponse,
+  AdapterRead,
+  AdapterStats,
+  AdapterStatsMetric,
+  LoraTagListResponse,
+} from '@/types';
+
+import { JsonObjectSchema } from './json';
+
+export class LoraSchemaParseError extends Error {
+  public readonly issues?: readonly ZodIssue[];
+
+  constructor(message: string, options?: { cause?: unknown; issues?: readonly ZodIssue[] }) {
+    super(message);
+    this.name = 'LoraSchemaParseError';
+    if (options?.cause !== undefined) {
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-expect-error Node 16 does not yet define ErrorOptions in lib.dom.d.ts
+      this.cause = options.cause;
+    }
+    this.issues = options?.issues;
+  }
+}
+
+const ADAPTER_STATS_KEYS: readonly AdapterStatsMetric[] = [
+  'downloadCount',
+  'favoriteCount',
+  'commentCount',
+  'thumbsUpCount',
+  'rating',
+  'ratingCount',
+  'usage_count',
+  'generations',
+  'activations',
+  'success_rate',
+  'avg_time',
+  'avg_generation_time',
+];
+
+const coerceFiniteNumber = (value: unknown): number | undefined => {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (!trimmed) {
+      return undefined;
+    }
+    const parsed = Number(trimmed);
+    if (Number.isFinite(parsed)) {
+      return parsed;
+    }
+  }
+
+  return undefined;
+};
+
+const RequiredFiniteNumber = () =>
+  z.union([z.number(), z.string()]).transform((value, ctx) => {
+    const parsed = coerceFiniteNumber(value);
+    if (parsed === undefined) {
+      ctx.addIssue({ code: z.ZodIssueCode.custom, message: 'Expected a finite number' });
+      return z.NEVER;
+    }
+    return parsed;
+  });
+
+const OptionalFiniteNumber = () =>
+  z.union([z.number(), z.string(), z.null(), z.undefined()]).transform((value, ctx) => {
+    if (value == null) {
+      return null;
+    }
+    const parsed = coerceFiniteNumber(value);
+    if (parsed === undefined) {
+      ctx.addIssue({ code: z.ZodIssueCode.custom, message: 'Expected a finite number' });
+      return z.NEVER;
+    }
+    return parsed;
+  });
+
+const OptionalCount = () =>
+  z.union([z.number(), z.string(), z.null(), z.undefined()]).transform((value, ctx) => {
+    if (value == null) {
+      return undefined;
+    }
+    const parsed = coerceFiniteNumber(value);
+    if (parsed === undefined) {
+      ctx.addIssue({ code: z.ZodIssueCode.custom, message: 'Expected a numeric count' });
+      return z.NEVER;
+    }
+    return Math.max(0, Math.trunc(parsed));
+  });
+
+const AdapterStatsSchema = z
+  .union([z.record(z.unknown()), z.null(), z.undefined()])
+  .transform((stats): AdapterStats | null => {
+    if (!stats) {
+      return null;
+    }
+
+    const normalized: AdapterStats = {};
+    const record = stats as Record<string, unknown>;
+
+    for (const metric of ADAPTER_STATS_KEYS) {
+      const value = coerceFiniteNumber(record[metric]);
+      if (value !== undefined) {
+        normalized[metric] = value;
+      }
+    }
+
+    return Object.keys(normalized).length > 0 ? normalized : {};
+  });
+
+const NullableString = z.union([z.string(), z.null()]).optional();
+
+const OptionalStringArray = z.array(z.string()).optional().transform((value) => value ?? []);
+
+const AdapterReadBaseSchema = z
+  .object({
+    id: z.union([z.string(), z.number()]).transform((value) => String(value)),
+    name: z.string(),
+    version: NullableString,
+    canonical_version_name: NullableString,
+    description: NullableString,
+    author_username: NullableString,
+    visibility: z.string(),
+    published_at: NullableString,
+    tags: OptionalStringArray,
+    trained_words: OptionalStringArray,
+    triggers: OptionalStringArray,
+    file_path: z.string(),
+    weight: RequiredFiniteNumber(),
+    active: z.boolean(),
+    ordinal: OptionalFiniteNumber(),
+    archetype: NullableString,
+    archetype_confidence: OptionalFiniteNumber(),
+    primary_file_name: NullableString,
+    primary_file_size_kb: OptionalFiniteNumber(),
+    primary_file_sha256: NullableString,
+    primary_file_download_url: NullableString,
+    primary_file_local_path: NullableString,
+    supports_generation: z.boolean(),
+    sd_version: NullableString,
+    nsfw_level: RequiredFiniteNumber(),
+    activation_text: NullableString,
+    stats: AdapterStatsSchema,
+    extra: z.union([JsonObjectSchema, z.record(z.unknown()), z.null(), z.undefined()]).transform((value) =>
+      value == null ? null : (value as Record<string, unknown>),
+    ),
+    json_file_path: NullableString,
+    json_file_mtime: NullableString,
+    json_file_size: OptionalFiniteNumber(),
+    last_ingested_at: NullableString,
+    created_at: z.string(),
+    updated_at: z.string(),
+    last_updated: NullableString,
+  })
+  .passthrough();
+
+export const AdapterReadSchema: z.ZodType<AdapterRead> = AdapterReadBaseSchema.transform((value) => ({
+  ...value,
+  ordinal: value.ordinal ?? null,
+  archetype_confidence: value.archetype_confidence ?? null,
+  primary_file_size_kb: value.primary_file_size_kb ?? null,
+  nsfw_level: value.nsfw_level ?? 0,
+  stats: value.stats ?? {},
+  extra: value.extra ?? null,
+  json_file_size: value.json_file_size ?? null,
+  last_ingested_at: value.last_ingested_at ?? null,
+  published_at: value.published_at ?? null,
+  created_at: value.created_at ?? null,
+  updated_at: value.updated_at ?? null,
+  last_updated: value.last_updated ?? null,
+}));
+
+const AdapterListResponseBaseSchema = z
+  .object({
+    items: z.array(AdapterReadSchema).optional().transform((value) => value ?? []),
+    total: OptionalCount(),
+    filtered: OptionalCount(),
+    page: OptionalCount(),
+    pages: OptionalCount(),
+    per_page: OptionalCount(),
+  })
+  .passthrough();
+
+const AdapterListPayloadSchema = z.union([
+  z.null(),
+  z.undefined(),
+  z.array(AdapterReadSchema),
+  AdapterListResponseBaseSchema,
+]);
+
+const LoraTagListSchema: z.ZodType<LoraTagListResponse> = z
+  .object({ tags: z.array(z.string()).optional() })
+  .passthrough();
+
+const formatIssues = (issues: readonly ZodIssue[]): string =>
+  issues
+    .map((issue) => {
+      const path = issue.path.length > 0 ? issue.path.join('.') : '(root)';
+      return `${path}: ${issue.message}`;
+    })
+    .join('; ');
+
+const createParseError = (context: string, error: unknown): LoraSchemaParseError => {
+  if (error instanceof z.ZodError) {
+    const message = `${context} validation failed: ${formatIssues(error.issues)}`;
+    console.warn(`[lora] ${context} validation failed`, { issues: error.issues });
+    return new LoraSchemaParseError(message, { cause: error, issues: error.issues });
+  }
+
+  console.warn(`[lora] ${context} validation failed`, { error });
+  return new LoraSchemaParseError(`${context} validation failed`, { cause: error });
+};
+
+const finalizeListResponse = (
+  base: z.infer<typeof AdapterListResponseBaseSchema>,
+  fallbackPage: number,
+  fallbackPerPage?: number,
+): AdapterListResponse => {
+  const items = base.items ?? [];
+  const perPage = base.per_page ?? fallbackPerPage ?? items.length;
+  const total = base.total ?? items.length;
+  const filtered = base.filtered ?? total;
+  const page = base.page ?? fallbackPage;
+  const pages = base.pages ?? (perPage > 0 ? Math.max(1, Math.ceil(filtered / perPage)) : filtered > 0 ? 1 : 0);
+
+  return {
+    items,
+    total,
+    filtered,
+    page,
+    pages,
+    per_page: perPage,
+  } satisfies AdapterListResponse;
+};
+
+const resolveFallbackPage = (query: AdapterListQuery): number => {
+  const page = query.page;
+  if (typeof page === 'number' && Number.isFinite(page)) {
+    return Math.max(1, Math.trunc(page));
+  }
+  return 1;
+};
+
+const resolveFallbackPerPage = (query: AdapterListQuery): number | undefined => {
+  const perPage = query.perPage;
+  if (typeof perPage === 'number' && Number.isFinite(perPage)) {
+    return Math.max(0, Math.trunc(perPage));
+  }
+  return undefined;
+};
+
+export const parseAdapterRead = (value: unknown, context = 'adapter read'): AdapterRead => {
+  const result = AdapterReadSchema.safeParse(value);
+  if (!result.success) {
+    throw createParseError(context, result.error);
+  }
+  return result.data;
+};
+
+export const parseAdapterListPayload = (
+  value: unknown,
+  query: AdapterListQuery = {},
+  context = 'adapter list response',
+): AdapterListResponse => {
+  const result = AdapterListPayloadSchema.safeParse(value);
+  if (!result.success) {
+    throw createParseError(context, result.error);
+  }
+
+  const fallbackPage = resolveFallbackPage(query);
+  const fallbackPerPage = resolveFallbackPerPage(query);
+
+  const data = result.data;
+  if (!data) {
+    const perPage = fallbackPerPage ?? 0;
+    return {
+      items: [],
+      total: 0,
+      filtered: 0,
+      page: fallbackPage,
+      pages: 0,
+      per_page: perPage,
+    } satisfies AdapterListResponse;
+  }
+
+  if (Array.isArray(data)) {
+    const items = data;
+    const perPage = fallbackPerPage ?? items.length;
+    const total = items.length;
+    const filtered = total;
+    const pages = perPage > 0 ? Math.max(1, Math.ceil(filtered / perPage)) : filtered > 0 ? 1 : 0;
+    return {
+      items,
+      total,
+      filtered,
+      page: fallbackPage,
+      pages,
+      per_page: perPage,
+    } satisfies AdapterListResponse;
+  }
+
+  return finalizeListResponse(data, fallbackPage, fallbackPerPage);
+};
+
+export const parseAdapterTags = (value: unknown, context = 'adapter tag list'): string[] => {
+  const result = LoraTagListSchema.safeParse(value);
+  if (!result.success) {
+    throw createParseError(context, result.error);
+  }
+
+  return Array.isArray(result.data.tags) ? [...result.data.tags] : [];
+};

--- a/app/frontend/src/services/generation/generationService.ts
+++ b/app/frontend/src/services/generation/generationService.ts
@@ -1,0 +1,1 @@
+export * from '@/features/generation/services/generationService';

--- a/app/frontend/src/services/generation/queueClient.ts
+++ b/app/frontend/src/services/generation/queueClient.ts
@@ -1,0 +1,1 @@
+export * from '@/features/generation/services/queueClient';

--- a/app/frontend/src/services/generation/validation.ts
+++ b/app/frontend/src/services/generation/validation.ts
@@ -1,0 +1,1 @@
+export * from '@/features/generation/services/validation';

--- a/app/frontend/src/services/index.ts
+++ b/app/frontend/src/services/index.ts
@@ -1,0 +1,2 @@
+export * from '@/features/lora/services/lora/loraService';
+export * from '@/features/generation/services/generationService';

--- a/tests/vue/loraService.spec.ts
+++ b/tests/vue/loraService.spec.ts
@@ -16,6 +16,47 @@ import type { AdapterListResponse } from '@/types';
 
 const originalFetch = global.fetch;
 
+const createAdapterPayload = (
+  overrides: Partial<AdapterListResponse['items'][number]> = {},
+): AdapterListResponse['items'][number] => ({
+  id: 'adapter-1',
+  name: 'Adapter One',
+  version: '1.0',
+  canonical_version_name: null,
+  description: null,
+  author_username: null,
+  visibility: 'Public',
+  published_at: null,
+  tags: [],
+  trained_words: [],
+  triggers: [],
+  file_path: '/weights/adapter-1.safetensors',
+  weight: 0.5,
+  active: true,
+  ordinal: null,
+  archetype: null,
+  archetype_confidence: null,
+  primary_file_name: null,
+  primary_file_size_kb: null,
+  primary_file_sha256: null,
+  primary_file_download_url: null,
+  primary_file_local_path: null,
+  supports_generation: true,
+  sd_version: null,
+  nsfw_level: 0,
+  activation_text: null,
+  stats: null,
+  extra: null,
+  json_file_path: null,
+  json_file_mtime: null,
+  json_file_size: null,
+  last_ingested_at: null,
+  created_at: '2024-01-01T00:00:00Z',
+  updated_at: '2024-01-02T00:00:00Z',
+  last_updated: null,
+  ...overrides,
+});
+
 afterEach(() => {
   if (originalFetch) {
     global.fetch = originalFetch;
@@ -237,12 +278,7 @@ describe('loraService', () => {
   });
 
   it('updates LoRA weights using PATCH requests', async () => {
-    const payload = {
-      id: 'adapter-1',
-      name: 'Adapter One',
-      weight: 0.5,
-      active: true,
-    };
+    const payload = createAdapterPayload({ id: 'adapter-1', weight: 0.5 });
 
     const response = {
       ok: true,
@@ -267,10 +303,7 @@ describe('loraService', () => {
   });
 
   it('toggles LoRA active state via POST requests', async () => {
-    const payload = {
-      id: 'adapter-2',
-      active: true,
-    };
+    const payload = createAdapterPayload({ id: 'adapter-2', active: true });
 
     const response = {
       ok: true,

--- a/tests/vue/schemas/dataFlow.spec.ts
+++ b/tests/vue/schemas/dataFlow.spec.ts
@@ -1,0 +1,201 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  GenerationJobStatusSchema,
+  GenerationRequestPayloadSchema,
+  GenerationResultSchema,
+  parseAdapterListPayload,
+  parseAdapterTags,
+} from '@/schemas';
+import { parseHistoryListPayload } from '@/features/history/services/historySchemas';
+
+describe('schema data flow round-trips', () => {
+  it('normalizes generation job statuses before storing them', () => {
+    const rawJob = {
+      id: 1,
+      jobId: '42',
+      prompt: undefined,
+      name: undefined,
+      status: 'Completed',
+      progress: 0.5,
+      message: undefined,
+      error: undefined,
+      params: null,
+      created_at: '2024-01-01T00:00:00Z',
+      startTime: undefined,
+      finished_at: null,
+      result: null,
+    } as const;
+
+    const parsed = GenerationJobStatusSchema.parse(rawJob);
+    expect(parsed.status).toBe('completed');
+    expect(parsed.jobId).toBe('42');
+
+    const roundTrip = GenerationJobStatusSchema.parse(JSON.parse(JSON.stringify(parsed)));
+    expect(roundTrip).toEqual(parsed);
+  });
+
+  it('trims and stabilises generation request payloads', () => {
+    const payload = GenerationRequestPayloadSchema.parse({
+      prompt: 'Generate',
+      negative_prompt: '   ',
+      steps: 30,
+      sampler_name: 'Euler',
+      cfg_scale: 7,
+      width: 512,
+      height: 512,
+      seed: -1,
+      batch_size: 1,
+      n_iter: 1,
+      denoising_strength: undefined,
+    });
+
+    expect(payload.negative_prompt).toBeNull();
+    expect(payload.denoising_strength).toBeNull();
+
+    const roundTrip = GenerationRequestPayloadSchema.parse(JSON.parse(JSON.stringify(payload)));
+    expect(roundTrip).toEqual(payload);
+  });
+
+  it('preserves generation results through round trips', () => {
+    const result = GenerationResultSchema.parse({
+      id: 9,
+      job_id: 4,
+      result_id: 9,
+      prompt: 'Test',
+      negative_prompt: undefined,
+      image_url: undefined,
+      thumbnail_url: undefined,
+      width: 512,
+      height: 512,
+      steps: 20,
+      cfg_scale: 7,
+      seed: null,
+      created_at: '2024-01-01T00:00:00Z',
+      finished_at: null,
+      status: 'Completed',
+      generation_info: undefined,
+    });
+
+    expect(result.negative_prompt).toBeNull();
+    expect(result.status).toBe('completed');
+
+    const roundTrip = GenerationResultSchema.parse(JSON.parse(JSON.stringify(result)));
+    expect(roundTrip).toEqual(result);
+  });
+
+  it('round-trips history payloads without losing information', () => {
+    const payload = {
+      results: [
+        {
+          id: 1,
+          job_id: 2,
+          status: 'completed',
+          prompt: 'test',
+          negative_prompt: null,
+          image_url: null,
+          thumbnail_url: null,
+          width: 512,
+          height: 512,
+          steps: 20,
+          cfg_scale: 7,
+          seed: null,
+          created_at: '2024-01-01T00:00:00Z',
+          finished_at: null,
+          updated_at: null,
+          sampler_name: null,
+          sampler: null,
+          model: null,
+          model_name: null,
+          clip_skip: null,
+          generation_info: null,
+          metadata: null,
+          loras: null,
+          rating: null,
+          is_favorite: false,
+          rating_updated_at: null,
+          favorite_updated_at: null,
+        },
+      ],
+      stats: {
+        total_results: 1,
+        avg_rating: 0,
+        total_favorites: 0,
+        total_size: 0,
+      },
+      page: 1,
+      pages: 1,
+      total: 1,
+      per_page: 10,
+    };
+
+    const parsed = parseHistoryListPayload(payload, 'history test');
+    expect(parsed).not.toBeNull();
+    expect(Array.isArray(parsed)).toBe(false);
+
+    if (parsed && !Array.isArray(parsed)) {
+      const roundTrip = parseHistoryListPayload(JSON.parse(JSON.stringify(parsed)), 'history round trip');
+      expect(roundTrip).toEqual(parsed);
+    }
+  });
+
+  it('normalizes adapter payloads and keeps schema round-trip safe', () => {
+    const payload = {
+      items: [
+        {
+          id: 42,
+          name: 'Adapter',
+          version: '1.0',
+          canonical_version_name: null,
+          description: 'desc',
+          author_username: 'tester',
+          visibility: 'Public',
+          published_at: null,
+          tags: ['tag'],
+          trained_words: ['word'],
+          triggers: [],
+          file_path: '/weights/adapter.safetensors',
+          weight: '0.8',
+          active: true,
+          ordinal: null,
+          archetype: null,
+          archetype_confidence: null,
+          primary_file_name: null,
+          primary_file_size_kb: null,
+          primary_file_sha256: null,
+          primary_file_download_url: null,
+          primary_file_local_path: null,
+          supports_generation: true,
+          sd_version: null,
+          nsfw_level: '0',
+          activation_text: null,
+          stats: { usage_count: '5' },
+          extra: null,
+          json_file_path: null,
+          json_file_mtime: null,
+          json_file_size: null,
+          last_ingested_at: null,
+          created_at: '2024-01-01T00:00:00Z',
+          updated_at: '2024-01-02T00:00:00Z',
+          last_updated: null,
+        },
+      ],
+      total: '1',
+      filtered: '1',
+      page: '1',
+      pages: '1',
+      per_page: '25',
+    };
+
+    const parsed = parseAdapterListPayload(payload, { perPage: 25 }, 'adapter list');
+    expect(parsed.items).toHaveLength(1);
+    expect(parsed.items[0].weight).toBeCloseTo(0.8);
+    expect(parsed.total).toBe(1);
+    expect(parsed.per_page).toBe(25);
+
+    const roundTrip = parseAdapterListPayload(JSON.parse(JSON.stringify(parsed)), { perPage: 25 }, 'adapter list round trip');
+    expect(roundTrip).toEqual(parsed);
+
+    expect(parseAdapterTags({ tags: ['foo', 'bar'] })).toEqual(['foo', 'bar']);
+  });
+});


### PR DESCRIPTION
## Summary
- add a GenerationRequestPayload schema and enforce parsing across generation services
- introduce LoRA adapter schemas, rework service parsing, and expose re-exported service entrypoints
- document schema update policy and add schema round-trip tests to guard data flows

## Testing
- npm run test:unit -- tests/vue/schemas/dataFlow.spec.ts tests/vue/loraService.spec.ts tests/vue/generationService.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68dc9f2838fc832985fe4124e21877bc