### PR TITLE
Improve generation transport observability and resilience

### DIFF
--- a/app/frontend/src/features/generation/composables/useGenerationSocketBridge.ts
+++ b/app/frontend/src/features/generation/composables/useGenerationSocketBridge.ts
@@ -10,6 +10,10 @@ import type {
   SystemStatusPayload,
   SystemStatusState,
 } from '@/types';
+import type {
+  GenerationTransportError,
+  GenerationWebSocketStateSnapshot,
+} from '../types/transport';
 
 interface SocketBridgeOptions {
   getBackendUrl: () => string | null | undefined;
@@ -23,7 +27,9 @@ interface SocketBridgeCallbacks {
   onError?: (message: GenerationErrorMessage) => void;
   onQueueUpdate?: (jobs: GenerationJobInput[]) => void;
   onSystemStatus?: (payload: SystemStatusPayload | Partial<SystemStatusState>) => void;
-  onConnectionChange?: (connected: boolean) => void;
+  onConnectionChange?: (connected: boolean, snapshot?: GenerationWebSocketStateSnapshot) => void;
+  onConnectionStateChange?: (snapshot: GenerationWebSocketStateSnapshot) => void;
+  onTransportError?: (error: GenerationTransportError) => void;
 }
 
 export const useGenerationSocketBridge = (
@@ -59,6 +65,12 @@ export const useGenerationSocketBridge = (
       },
       onConnectionChange: (connected) => {
         callbacks.onConnectionChange?.(connected);
+      },
+      onStateChange: (snapshot) => {
+        callbacks.onConnectionStateChange?.(snapshot);
+      },
+      onTransportError: (error) => {
+        callbacks.onTransportError?.(error);
       },
     });
 

--- a/app/frontend/src/features/generation/composables/useGenerationTransport.ts
+++ b/app/frontend/src/features/generation/composables/useGenerationTransport.ts
@@ -12,6 +12,10 @@ import type {
   SystemStatusState,
   NotificationType,
 } from '@/types';
+import type {
+  GenerationTransportError,
+  GenerationWebSocketStateSnapshot,
+} from '../types/transport';
 
 import { useGenerationQueueClient } from './useGenerationQueueClient';
 import { useGenerationSocketBridge } from './useGenerationSocketBridge';
@@ -36,7 +40,9 @@ export interface GenerationTransportCallbacks {
   onComplete?: (message: GenerationCompleteMessage) => GenerationResult | void;
   onError?: (message: GenerationErrorMessage) => void;
   onRecentResults?: (results: GenerationResult[]) => void;
-  onConnectionChange?: (connected: boolean) => void;
+  onConnectionChange?: (connected: boolean, snapshot?: GenerationWebSocketStateSnapshot) => void;
+  onConnectionStateChange?: (snapshot: GenerationWebSocketStateSnapshot) => void;
+  onTransportError?: (error: GenerationTransportError) => void;
   shouldPollQueue?: () => boolean;
   onNotify?: (message: string, type?: NotificationType) => void;
   logger?: (...args: unknown[]) => void;
@@ -82,6 +88,9 @@ export const useGenerationTransport = (
       },
       onHydrateSystemStatus: callbacks.onHydrateSystemStatus,
       onReleaseSystemStatus: callbacks.onReleaseSystemStatus,
+      onTransportError: (error) => {
+        callbacks.onTransportError?.(error);
+      },
     },
   );
 
@@ -113,8 +122,14 @@ export const useGenerationTransport = (
       onSystemStatus: (payload) => {
         callbacks.onSystemStatus?.(payload);
       },
-      onConnectionChange: (connected) => {
-        callbacks.onConnectionChange?.(connected);
+      onConnectionChange: (connected, snapshot) => {
+        callbacks.onConnectionChange?.(connected, snapshot);
+      },
+      onConnectionStateChange: (snapshot) => {
+        callbacks.onConnectionStateChange?.(snapshot);
+      },
+      onTransportError: (error) => {
+        callbacks.onTransportError?.(error);
       },
     },
   );

--- a/app/frontend/src/features/generation/stores/orchestrator/transportModule.ts
+++ b/app/frontend/src/features/generation/stores/orchestrator/transportModule.ts
@@ -1,9 +1,40 @@
-import { ref } from 'vue';
+import { computed, readonly, ref } from 'vue';
 
 import type { GenerationTransportAdapter } from '../../composables/createGenerationTransportAdapter';
+import type {
+  GenerationTransportError,
+  GenerationTransportMetricsSnapshot,
+  GenerationTransportPhase,
+  GenerationWebSocketStateSnapshot,
+} from '../../types/transport';
+
+const FREEZE = <T>(value: T): Readonly<T> => Object.freeze({ ...(value as Record<string, unknown>) }) as Readonly<T>;
+
+const initialMetricsState = () => ({
+  phase: 'idle' as GenerationTransportPhase,
+  reconnectAttempt: 0,
+  consecutiveFailures: 0,
+  nextRetryDelayMs: null as number | null,
+  lastConnectedAt: null as number | null,
+  lastDisconnectedAt: null as number | null,
+  downtimeMs: null as number | null,
+  totalDowntimeMs: 0,
+  lastError: null as GenerationTransportError | null,
+  lastEvent: null as GenerationWebSocketStateSnapshot | null,
+});
 
 export const createTransportModule = () => {
   const transport = ref<GenerationTransportAdapter | null>(null);
+  const connectionSnapshot = ref<GenerationWebSocketStateSnapshot | null>(null);
+  const phase = ref<GenerationTransportPhase>('idle');
+  const reconnectAttempt = ref(0);
+  const consecutiveFailures = ref(0);
+  const nextRetryDelayMs = ref<number | null>(null);
+  const lastConnectedAt = ref<number | null>(null);
+  const lastDisconnectedAt = ref<number | null>(null);
+  const downtimeMs = ref<number | null>(null);
+  const totalDowntimeMs = ref(0);
+  const lastError = ref<GenerationTransportError | null>(null);
 
   const ensureTransport = (): GenerationTransportAdapter => {
     const instance = transport.value;
@@ -25,15 +56,100 @@ export const createTransportModule = () => {
     transport.value?.reconnect();
   };
 
+  const recordTransportError = (error: GenerationTransportError): void => {
+    lastError.value = Object.freeze({ ...error });
+  };
+
+  const resetMetrics = (): void => {
+    const base = initialMetricsState();
+    phase.value = base.phase;
+    reconnectAttempt.value = base.reconnectAttempt;
+    consecutiveFailures.value = base.consecutiveFailures;
+    nextRetryDelayMs.value = base.nextRetryDelayMs;
+    lastConnectedAt.value = base.lastConnectedAt;
+    lastDisconnectedAt.value = base.lastDisconnectedAt;
+    downtimeMs.value = base.downtimeMs;
+    totalDowntimeMs.value = base.totalDowntimeMs;
+    lastError.value = base.lastError;
+    connectionSnapshot.value = base.lastEvent;
+  };
+
+  const recordConnectionSnapshot = (snapshot: GenerationWebSocketStateSnapshot): void => {
+    const frozenSnapshot = Object.freeze({ ...snapshot });
+    connectionSnapshot.value = frozenSnapshot;
+    reconnectAttempt.value = frozenSnapshot.reconnectAttempt;
+    consecutiveFailures.value = frozenSnapshot.consecutiveFailures;
+    nextRetryDelayMs.value = frozenSnapshot.nextRetryDelayMs;
+    if (frozenSnapshot.lastConnectedAt != null) {
+      lastConnectedAt.value = frozenSnapshot.lastConnectedAt;
+    }
+    if (frozenSnapshot.lastDisconnectedAt != null) {
+      lastDisconnectedAt.value = frozenSnapshot.lastDisconnectedAt;
+    }
+    downtimeMs.value = frozenSnapshot.downtimeMs;
+    if (frozenSnapshot.event === 'connect:success' && frozenSnapshot.downtimeMs != null) {
+      totalDowntimeMs.value += frozenSnapshot.downtimeMs;
+    }
+
+    if (frozenSnapshot.error && frozenSnapshot.event !== 'connect:success') {
+      recordTransportError({
+        source: 'websocket',
+        context: frozenSnapshot.event,
+        message: frozenSnapshot.error.message,
+        timestamp: frozenSnapshot.timestamp,
+        statusCode: frozenSnapshot.error.code,
+        attempt: frozenSnapshot.error.attempt ?? frozenSnapshot.reconnectAttempt,
+        url: frozenSnapshot.url,
+        details: frozenSnapshot.error,
+      });
+    }
+
+    switch (frozenSnapshot.event) {
+      case 'connect:start':
+        phase.value = 'connecting';
+        break;
+      case 'reconnect:scheduled':
+        phase.value = 'reconnecting';
+        break;
+      case 'connect:success':
+        phase.value = 'connected';
+        break;
+      case 'disconnect':
+        phase.value = 'disconnected';
+        break;
+      case 'error':
+        phase.value = 'disconnected';
+        break;
+      default:
+        break;
+    }
+  };
+
   const clearTransport = (): void => {
     transport.value?.clear();
     transport.value = null;
+    resetMetrics();
   };
 
   const withTransport = <T>(callback: (adapter: GenerationTransportAdapter) => T): T => {
     const instance = ensureTransport();
     return callback(instance);
   };
+
+  const metrics = computed<GenerationTransportMetricsSnapshot>(() =>
+    FREEZE({
+      phase: phase.value,
+      reconnectAttempt: reconnectAttempt.value,
+      consecutiveFailures: consecutiveFailures.value,
+      nextRetryDelayMs: nextRetryDelayMs.value,
+      lastConnectedAt: lastConnectedAt.value,
+      lastDisconnectedAt: lastDisconnectedAt.value,
+      downtimeMs: downtimeMs.value,
+      totalDowntimeMs: totalDowntimeMs.value,
+      lastError: lastError.value,
+      lastEvent: connectionSnapshot.value,
+    }),
+  );
 
   return {
     ensureTransport,
@@ -42,6 +158,20 @@ export const createTransportModule = () => {
     reconnect,
     clearTransport,
     withTransport,
+    recordConnectionSnapshot,
+    recordTransportError,
+    resetMetrics,
+    metrics,
+    phase: readonly(phase),
+    reconnectAttempt: readonly(reconnectAttempt),
+    consecutiveFailures: readonly(consecutiveFailures),
+    nextRetryDelayMs: readonly(nextRetryDelayMs),
+    lastConnectedAt: readonly(lastConnectedAt),
+    lastDisconnectedAt: readonly(lastDisconnectedAt),
+    downtimeMs: readonly(downtimeMs),
+    totalDowntimeMs: readonly(totalDowntimeMs),
+    lastError: readonly(lastError),
+    lastSnapshot: readonly(connectionSnapshot),
   };
 };
 

--- a/app/frontend/src/features/generation/types/transport.ts
+++ b/app/frontend/src/features/generation/types/transport.ts
@@ -1,0 +1,60 @@
+export type GenerationTransportPhase =
+  | 'idle'
+  | 'connecting'
+  | 'connected'
+  | 'disconnected'
+  | 'reconnecting';
+
+export type GenerationWebSocketEventName =
+  | 'connect:start'
+  | 'connect:success'
+  | 'disconnect'
+  | 'reconnect:scheduled'
+  | 'error';
+
+export interface GenerationWebSocketErrorDetails {
+  message: string;
+  code?: number;
+  reason?: string;
+  wasClean?: boolean;
+  attempt?: number;
+  cause?: unknown;
+}
+
+export interface GenerationWebSocketStateSnapshot {
+  event: GenerationWebSocketEventName;
+  timestamp: number;
+  url: string;
+  connected: boolean;
+  reconnectAttempt: number;
+  consecutiveFailures: number;
+  nextRetryDelayMs: number | null;
+  lastConnectedAt: number | null;
+  lastDisconnectedAt: number | null;
+  downtimeMs: number | null;
+  error: GenerationWebSocketErrorDetails | null;
+}
+
+export interface GenerationTransportError {
+  source: 'websocket' | 'http';
+  context: string;
+  message: string;
+  timestamp: number;
+  statusCode?: number;
+  attempt?: number;
+  url?: string;
+  details?: unknown;
+}
+
+export interface GenerationTransportMetricsSnapshot {
+  phase: GenerationTransportPhase;
+  reconnectAttempt: number;
+  consecutiveFailures: number;
+  nextRetryDelayMs: number | null;
+  lastConnectedAt: number | null;
+  lastDisconnectedAt: number | null;
+  downtimeMs: number | null;
+  totalDowntimeMs: number;
+  lastError: GenerationTransportError | null;
+  lastEvent: GenerationWebSocketStateSnapshot | null;
+}

--- a/tests/vue/services/generation/websocketManager.spec.ts
+++ b/tests/vue/services/generation/websocketManager.spec.ts
@@ -1,0 +1,115 @@
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
+
+import { createGenerationWebSocketManager } from '@/features/generation/services/websocketManager';
+import type { GenerationWebSocketStateSnapshot } from '@/features/generation/types/transport';
+
+let originalWebSocket: typeof WebSocket | undefined;
+
+class MockWebSocket {
+  static instances: MockWebSocket[] = [];
+
+  onopen: (() => void) | null = null;
+
+  onclose: ((event: CloseEvent) => void) | null = null;
+
+  onerror: ((event: Event) => void) | null = null;
+
+  onmessage: ((event: MessageEvent) => void) | null = null;
+
+  readonly url: string;
+
+  constructor(url: string) {
+    this.url = url;
+    MockWebSocket.instances.push(this);
+  }
+
+  close(): void {}
+
+  triggerOpen(): void {
+    this.onopen?.();
+  }
+
+  triggerClose(event: Partial<CloseEvent> = {}): void {
+    this.onclose?.(event as CloseEvent);
+  }
+
+  triggerError(event: Partial<Event> = {}): void {
+    this.onerror?.(event as Event);
+  }
+}
+
+describe('createGenerationWebSocketManager', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    MockWebSocket.instances = [];
+    originalWebSocket = (globalThis as { WebSocket?: typeof WebSocket }).WebSocket;
+    (globalThis as { WebSocket?: typeof WebSocket }).WebSocket =
+      MockWebSocket as unknown as typeof WebSocket;
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.useRealTimers();
+    if (originalWebSocket) {
+      (globalThis as { WebSocket?: typeof WebSocket }).WebSocket = originalWebSocket;
+    } else {
+      delete (globalThis as { WebSocket?: typeof WebSocket }).WebSocket;
+    }
+  });
+
+  it('emits structured telemetry for reconnect attempts', () => {
+    const states: GenerationWebSocketStateSnapshot[] = [];
+    const errors: unknown[] = [];
+    const manager = createGenerationWebSocketManager({
+      getBackendUrl: () => 'https://example.test/api',
+      onStateChange: (snapshot) => {
+        states.push(snapshot);
+      },
+      onTransportError: (error) => {
+        errors.push(error);
+      },
+    });
+
+    const timeoutSpy = vi.spyOn(globalThis, 'setTimeout');
+
+    manager.start();
+
+    expect(MockWebSocket.instances).toHaveLength(1);
+    expect(states.at(-1)?.event).toBe('connect:start');
+
+    MockWebSocket.instances[0].triggerOpen();
+
+    expect(states.at(-1)?.event).toBe('connect:success');
+
+    MockWebSocket.instances[0].triggerClose({
+      code: 1006,
+      reason: 'abnormal',
+      wasClean: false,
+    });
+
+    expect(states.at(-1)?.event).toBe('reconnect:scheduled');
+    expect(states.at(-1)?.reconnectAttempt).toBe(1);
+    expect(errors).toHaveLength(1);
+    const firstDelay = (timeoutSpy.mock.calls.at(-1)?.[1] as number) ?? 0;
+    expect(firstDelay).toBeGreaterThan(0);
+
+    vi.advanceTimersByTime(firstDelay);
+
+    expect(MockWebSocket.instances).toHaveLength(2);
+    expect(states.at(-1)?.event).toBe('connect:start');
+
+    MockWebSocket.instances[1].triggerClose({
+      code: 1006,
+      reason: 'again',
+      wasClean: false,
+    });
+
+    const secondDelay = (timeoutSpy.mock.calls.at(-1)?.[1] as number) ?? 0;
+    expect(secondDelay).toBeGreaterThan(firstDelay);
+    expect(states.filter((snapshot) => snapshot.event === 'disconnect')).toHaveLength(2);
+    const scheduled = states.filter((snapshot) => snapshot.event === 'reconnect:scheduled');
+    expect(scheduled.at(-1)?.reconnectAttempt).toBe(2);
+
+    manager.stop();
+  });
+});

--- a/tests/vue/stores/orchestrator/transportModule.spec.ts
+++ b/tests/vue/stores/orchestrator/transportModule.spec.ts
@@ -1,6 +1,29 @@
 import { describe, it, expect, vi } from 'vitest';
 
 import { createTransportModule } from '@/features/generation/stores/orchestrator/transportModule';
+import type { GenerationTransportError, GenerationWebSocketStateSnapshot } from '@/features/generation/types/transport';
+
+const baseSnapshot = (
+  overrides: Partial<GenerationWebSocketStateSnapshot> = {},
+): GenerationWebSocketStateSnapshot => ({
+  event: 'disconnect',
+  timestamp: 1,
+  url: 'ws://example.test',
+  connected: false,
+  reconnectAttempt: 1,
+  consecutiveFailures: 1,
+  nextRetryDelayMs: 1_000,
+  lastConnectedAt: 10,
+  lastDisconnectedAt: 20,
+  downtimeMs: 5,
+  error: {
+    message: 'boom',
+    code: 1006,
+    reason: 'closed',
+    wasClean: false,
+  },
+  ...overrides,
+});
 
 describe('transportModule', () => {
   it('throws when ensuring transport before initialization', () => {
@@ -49,5 +72,59 @@ describe('transportModule', () => {
 
     await transportModule.withTransport((instance) => instance.refreshSystemStatus());
     expect(adapter.refreshSystemStatus).toHaveBeenCalled();
+  });
+
+  it('records connection telemetry and exposes metrics', () => {
+    const transportModule = createTransportModule();
+    const disconnect = baseSnapshot();
+    transportModule.recordConnectionSnapshot(disconnect);
+
+    expect(transportModule.phase.value).toBe('disconnected');
+    expect(transportModule.metrics.value.totalDowntimeMs).toBe(0);
+    expect(transportModule.lastError.value).toMatchObject<GenerationTransportError>({
+      source: 'websocket',
+      message: 'boom',
+      statusCode: 1006,
+    });
+
+    const reconnectScheduled = baseSnapshot({
+      event: 'reconnect:scheduled',
+      connected: false,
+      error: null,
+    });
+    transportModule.recordConnectionSnapshot(reconnectScheduled);
+    expect(transportModule.phase.value).toBe('reconnecting');
+
+    const success = baseSnapshot({
+      event: 'connect:success',
+      connected: true,
+      downtimeMs: 5,
+      error: null,
+    });
+    transportModule.recordConnectionSnapshot(success);
+
+    expect(transportModule.phase.value).toBe('connected');
+    expect(transportModule.metrics.value.totalDowntimeMs).toBe(5);
+    expect(transportModule.lastError.value).toMatchObject({ message: 'boom' });
+  });
+
+  it('resets metrics when cleared', () => {
+    const adapter = { clear: vi.fn() } as any;
+    const transportModule = createTransportModule();
+    transportModule.setTransport(adapter);
+    transportModule.recordConnectionSnapshot(baseSnapshot());
+    transportModule.recordTransportError({
+      source: 'http',
+      context: 'refresh',
+      message: 'fail',
+      timestamp: 1,
+    });
+
+    transportModule.clearTransport();
+
+    expect(adapter.clear).toHaveBeenCalled();
+    expect(transportModule.phase.value).toBe('idle');
+    expect(transportModule.lastError.value).toBeNull();
+    expect(transportModule.metrics.value.totalDowntimeMs).toBe(0);
   });
 });

--- a/tests/vue/useGenerationQueueClient.spec.ts
+++ b/tests/vue/useGenerationQueueClient.spec.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 
 import { useGenerationQueueClient } from '@/composables/generation';
 import type { GenerationQueueClient } from '@/services/generation/queueClient';
+import { ApiError } from '@/types';
 import type { GenerationJobStatus, GenerationResult, SystemStatusPayload } from '@/types';
 
 const iso = '2024-01-01T00:00:00Z';
@@ -128,5 +129,45 @@ describe('useGenerationQueueClient validation', () => {
     expect(warnSpy).toHaveBeenCalledTimes(1);
 
     warnSpy.mockRestore();
+  });
+
+  it('reports HTTP transport errors with metadata', async () => {
+    const apiError = new ApiError({
+      message: 'Server exploded',
+      status: 500,
+      statusText: 'Server Error',
+      payload: null,
+      meta: {
+        ok: false,
+        status: 500,
+        statusText: 'Server Error',
+      },
+    });
+
+    const queueClient = createQueueClient({
+      fetchActiveJobs: vi.fn().mockRejectedValue(apiError),
+    });
+
+    const onTransportError = vi.fn();
+    const composable = useGenerationQueueClient(
+      {
+        getBackendUrl: () => null,
+        queueClient,
+      },
+      {
+        onTransportError,
+      },
+    );
+
+    await expect(composable.refreshActiveJobs()).rejects.toThrow(apiError);
+
+    expect(onTransportError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: 'http',
+        context: 'refreshActiveJobs',
+        statusCode: 500,
+        message: 'Server exploded',
+      }),
+    );
   });
 });


### PR DESCRIPTION
## Summary
- add structured telemetry, retry backoff, and error tracking to the generation websocket transport and expose rich metrics through the orchestrator store
- surface HTTP transport failures from the queue client and capture connection lifecycle metadata for downstream consumers
- add focused tests covering websocket reconnect flows, transport metrics, and HTTP error reporting

## Testing
- npx vitest run tests/vue/services/generation/websocketManager.spec.ts tests/vue/useGenerationQueueClient.spec.ts tests/vue/stores/orchestrator/transportModule.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68dd2a2f346c8329884bb57607d96906