### PR TITLE
docs: add orchestrator ADR and effect scope playbook

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,7 +84,11 @@ This document provides a comprehensive assessment of the LoRA Manager project as
 
 ## 🧭 Architecture Orientation (Actionable Notes from Recent PRs)
 
-Multiple late-stage PRs refactored key subsystems (e.g. the orchestrator manager, gallery virtualization, and backend settings overhaul). Use the following map before opening new changes so that we do not regress those integrations.
+Multiple late-stage PRs refactored key subsystems (e.g. the orchestrator manager, gallery virtualization, and backend settings overhaul). Use the following map before opening new changes so that we do not regress those integrations. Keep the most recent documentation at hand:
+
+- **ADR 007 – Generation Orchestrator as Thin Façade** (`docs/architecture/adr-generation-orchestrator-thin-facade.md`) is the contract for how the orchestrator store/composable/helpers divide responsibilities. Stay within that boundary when adding orchestration features.
+- **Effect Scope Ownership Playbook** (`docs/frontend/effect-scope-ownership-playbook.md`) specifies where timers/watchers/event handlers belong. Long-lived effects live in managers or component scopes that dispose them.
+- **Generation Architecture Acceptance Checklist** (`docs/frontend/generation-architecture-acceptance.md`) is the regression list for the refactor. New work must keep those acceptance criteria green.
 
 ### Backend contract map
 

--- a/docs/architecture/adr-generation-orchestrator-thin-facade.md
+++ b/docs/architecture/adr-generation-orchestrator-thin-facade.md
@@ -1,0 +1,55 @@
+# ADR 007: Generation Orchestrator as Thin Façade
+
+- **Status:** Accepted
+- **Date:** 2025-09-XX
+- **Authors:** Frontend platform team
+
+## Context
+
+Recent regressions exposed that different parts of the UI created bespoke generation orchestrators, layered ad-hoc watchers, and mutated shared state. The resulting race conditions and leaked subscriptions made recovery logic brittle, duplicated API handling, and reintroduced the very event-bus patterns that earlier refactors eliminated.
+
+The generation flow now centres on three cooperating pieces:
+
+1. **Generation Orchestrator Store** – a Pinia store that exposes immutable queue, results, transport, and system status state with explicit lifecycle and data-loading methods.
+2. **Generation Orchestrator Manager** – a composable that owns the single orchestrator instance, coordinates initialization/cleanup, and binds watchers to component lifecycles.
+3. **Generation Helpers** – queue/history modules, transport adapters, schema normalizers, and HTTP clients that encapsulate specialised logic.
+
+We need an explicit decision record so future contributors preserve this architecture and avoid the anti-patterns that previously caused bugs.
+
+## Decision
+
+- Treat the orchestrator store as a **thin façade** over helper modules. It wires queue/history modules, the transport adapter, and system status controller together, but holds no long-lived watchers or side-effects beyond the explicit lifecycle methods it exposes.【F:app/frontend/src/features/generation/stores/useGenerationOrchestratorStore.ts†L1-L210】
+- Publish only readonly reactive state (`jobs`, `recentResults`, transport metrics, etc.) and imperative methods (`initialize`, `loadRecentResults`, `startGeneration`, `handleBackendUrlChange`, etc.). Consumers must call methods to trigger work—no hidden behaviour should occur on property access.【F:app/frontend/src/features/generation/stores/useGenerationOrchestratorStore.ts†L74-L210】
+- Keep helper responsibilities isolated:
+  - Queue/history/system-status modules perform data shaping and state updates, including schema enforcement and normalisation.【F:app/frontend/src/features/generation/stores/orchestrator/queueModule.ts†L1-L132】【F:app/frontend/src/features/generation/stores/orchestrator/resultsModule.ts†L1-L214】【F:app/frontend/src/features/generation/stores/orchestrator/systemStatusModule.ts†L1-L200】
+  - Transport modules and adapters encapsulate networking, reconnection, logging, and schema-validated parsing.【F:app/frontend/src/features/generation/stores/orchestrator/transportModule.ts†L1-L129】【F:app/frontend/src/features/generation/composables/createGenerationTransportAdapter.ts†L1-L218】
+  - Managers/composables acquire orchestrator access, manage consumers, and attach watchers for UI-owned behaviour (history size, backend URL changes).【F:app/frontend/src/features/generation/composables/useGenerationOrchestratorManager.ts†L1-L223】
+- Enforce **single-instance** orchestrator ownership. Components and features must obtain access through `useGenerationOrchestratorManager().acquire(...)`, ensuring initialization, teardown, and watchers are coordinated.【F:app/frontend/src/features/generation/composables/useGenerationOrchestrator.ts†L1-L23】【F:app/frontend/src/features/generation/composables/useGenerationOrchestratorManager.ts†L62-L204】
+- All generation-side effects (polling, WebSocket lifecycle, queue refreshes) must run inside explicit orchestrator methods or manager-controlled watchers. No helper should start background work on import or instantiation.
+
+## Consequences
+
+### Positive
+
+- Shared generation state remains deterministic and immutable to consumers.
+- Watchers live only in scopes that can be disposed, preventing resource leaks and phantom updates.
+- Transport and networking policies stay centralised, preserving consistent logging, retry, and schema handling.
+- New integrations can extend helper modules without bloating the façade or breaking the single-instance contract.
+
+### Negative / Trade-offs
+
+- The orchestrator cannot be trivially instantiated in isolation; tests and new features must route through the manager or provide explicit dependency injections.
+- Strict module boundaries require more boilerplate when introducing new side-effects (new helper hooks or manager watchers) but greatly reduce regressions.
+
+### Anti-patterns to Avoid
+
+- Creating new orchestrator instances inside components or composables—always acquire via the manager.
+- Adding `watch`, `setInterval`, or event listeners inside queue/transport helpers. Effects belong to the manager or view-level scopes.
+- Exporting helper internals through barrels that bypass the façade; expose new capabilities via orchestrator methods or typed helper interfaces.
+- Introducing side-effects on property access (e.g., lazy network fetches when reading `recentResults`). Trigger work through explicit methods for traceability.
+
+### Follow-up
+
+- Document manager-owned effect patterns in the Effect Scope Ownership playbook.
+- Keep the orchestrator under ~200 lines by moving new responsibilities into helper modules.
+- Update tests when new helper methods are added to ensure the façade stays side-effect free.

--- a/docs/frontend/effect-scope-ownership-playbook.md
+++ b/docs/frontend/effect-scope-ownership-playbook.md
@@ -1,0 +1,28 @@
+# Effect Scope Ownership Playbook
+
+This guide describes where reactive side-effects (watchers, timers, event handlers) belong inside the frontend codebase. It codifies the conventions introduced during the orchestrator refactor so that new functionality does not leak resources or bypass centralised managers.
+
+## Guiding principles
+
+1. **Managers own long-lived effects.** Acquire generation behaviour through `useGenerationOrchestratorManager().acquire(...)` so backend URL watchers, history limit adjustments, and orchestrator lifecycle are bound to a single shared manager scope.【F:app/frontend/src/features/generation/composables/useGenerationOrchestratorManager.ts†L62-L205】
+2. **Components clean up what they start.** View-specific timers or watchers must live in `onMounted`/`onUnmounted` or `effectScope` blocks that are torn down when the component leaves. Prefer Pinia stores or composables that expose `initialize/cleanup` pairs.
+3. **Helpers stay pure.** Queue modules, transport adapters, and schema normalisers should not register global listeners or timers. They expose methods for managers to call; helpers only mutate their own reactive state.【F:app/frontend/src/features/generation/stores/orchestrator/queueModule.ts†L1-L126】【F:app/frontend/src/features/generation/composables/createGenerationTransportAdapter.ts†L38-L210】
+4. **Unified networking handles retries.** All HTTP calls go through `httpClient` / `apiClient` (or the `useApi` composable) so retry policies, logging, and abort handling stay consistent. Do not spin up bespoke polling loops—reuse the transport adapter or orchestrator methods.【F:app/frontend/src/services/httpClient.ts†L1-L189】【F:app/frontend/src/composables/shared/useApi.ts†L1-L128】
+5. **Reactive settings beats event buses.** To react to runtime configuration (like backend URL changes), watch the relevant Pinia store state instead of emitting custom events. The orchestrator manager’s watchers demonstrate this pattern and automatically tear down when the last consumer leaves.【F:app/frontend/src/features/generation/composables/useGenerationOrchestratorManager.ts†L94-L159】
+
+## Pattern checklist
+
+- Need an interval or retry loop? Add it to a manager/composable that exposes `initialize`/`cleanup`, and register it inside an `effectScope` so `stop()` handles disposal.
+- Need to respond to backend configuration changes? Depend on `useSettingsStore()` and use watchers similar to `ensureWatcherScope()` instead of a standalone emitter.【F:app/frontend/src/features/generation/composables/useGenerationOrchestratorManager.ts†L107-L159】
+- Need to monitor transport metrics? Access the readonly observability fields on the orchestrator store instead of subscribing to the WebSocket directly.【F:app/frontend/src/features/generation/stores/useGenerationOrchestratorStore.ts†L132-L210】
+- Need to observe queue updates? Call orchestrator methods such as `loadActiveJobsData` or rely on manager-provided refs; never call `setInterval(fetchQueue)` inside a view.【F:app/frontend/src/features/generation/composables/useGenerationOrchestratorManager.ts†L169-L206】
+- Need to extend helper behaviour? Add explicit callbacks (e.g., `onTransportError`) that the orchestrator wires up. Helpers should stay synchronous and side-effect free until invoked by the manager.【F:app/frontend/src/features/generation/stores/orchestrator/transportModule.ts†L1-L129】
+
+## Anti-patterns
+
+- Instantiating the orchestrator directly inside a component or composable.
+- Creating `setInterval`, `watch`, or `window` event listeners inside queue/transport helpers.
+- Performing API polling outside the orchestrator/manager, leading to duplicate requests and inconsistent error handling.
+- Relying on global event buses for backend configuration or connection state—stick with reactive stores.
+
+Following these rules keeps effects predictable, prevents leaks, and ensures future refactors remain straightforward.

--- a/docs/frontend/generation-architecture-acceptance.md
+++ b/docs/frontend/generation-architecture-acceptance.md
@@ -1,0 +1,38 @@
+# Generation Architecture Acceptance Criteria Cross-check
+
+This checklist confirms that the post-refactor generation stack satisfies the review criteria. Each section links to the implementation that enforces the requirement.
+
+## Orchestrator Façade
+
+- The orchestrator store is a thin façade composed of queue, results, system-status, and transport modules. It exports readonly state and explicit lifecycle/data-loading methods with no internal watchers.【F:app/frontend/src/features/generation/stores/useGenerationOrchestratorStore.ts†L1-L210】
+- Manager-owned watchers (`showHistory`, backend URL) live in `useGenerationOrchestratorManager`, not inside the store. The orchestrator exposes methods such as `handleBackendUrlChange` that the manager calls explicitly.【F:app/frontend/src/features/generation/composables/useGenerationOrchestratorManager.ts†L94-L206】
+- Store logic is partitioned into helper modules (queue/results/system status/transport) that keep the façade near the 200-line target; orchestration logic itself stays within a single `defineStore` body while helpers encapsulate complex behaviour.【F:app/frontend/src/features/generation/stores/orchestrator/queueModule.ts†L1-L132】【F:app/frontend/src/features/generation/stores/orchestrator/transportModule.ts†L1-L129】
+
+## Unified Networking
+
+- `httpClient` centralises fetch handling, retries, logging hooks, and parsing strategies. Higher-level wrappers (`apiClient`, `useApi`) consume it to provide consistent error handling for all requests.【F:app/frontend/src/services/httpClient.ts†L1-L188】【F:app/frontend/src/services/apiClient.ts†L1-L200】【F:app/frontend/src/composables/shared/useApi.ts†L1-L128】
+- Generation services (`generationService`, queue client, websocket manager) depend on the shared API client or transport adapter rather than bespoke fetch utilities.【F:app/frontend/src/features/generation/services/generationService.ts†L1-L176】【F:app/frontend/src/features/generation/services/queueClient.ts†L1-L148】
+
+## Clean Module Boundaries
+
+- Feature exports route through `features/generation/public.ts`, avoiding global barrels and keeping private helpers internal.【F:app/frontend/src/features/generation/index.ts†L1-L9】【F:app/frontend/src/features/generation/public.ts†L1-L120】
+- Helper modules live alongside their feature (e.g., orchestrator submodules) and expose typed interfaces consumed by the façade, preventing incidental re-exports.【F:app/frontend/src/features/generation/stores/orchestrator/adapterHandlers.ts†L1-L168】
+
+## Manager-Owned Effects
+
+- The orchestrator manager owns the lifecycle scope via `effectScope`, registering watchers for history visibility and backend URL changes, and tearing them down when the last consumer releases the orchestrator.【F:app/frontend/src/features/generation/composables/useGenerationOrchestratorManager.ts†L94-L204】
+- Transport adapters implement retry/polling callbacks but require the manager/store to invoke them—no helper starts background work automatically.【F:app/frontend/src/features/generation/composables/createGenerationTransportAdapter.ts†L1-L218】
+- Components consume orchestrator state through the manager-provided binding (`useGenerationOrchestrator`), ensuring subscriptions tie to component lifecycles.【F:app/frontend/src/features/generation/composables/useGenerationOrchestrator.ts†L1-L23】
+
+## Schema-First Consistency
+
+- All generation payloads/results pass through Zod schemas before entering stores, normalising IDs, statuses, and nullable fields.【F:app/frontend/src/schemas/generation.ts†L1-L160】
+- Queue modules rely on schema-parsed jobs/results and normalisation utilities before storing them in reactive state, ensuring store data matches schema outputs.【F:app/frontend/src/features/generation/stores/orchestrator/queueModule.ts†L1-L70】【F:app/frontend/src/features/generation/stores/orchestrator/resultsModule.ts†L1-L156】
+
+## Robust Observability & Recovery
+
+- The transport module records connection phases, retry counts, downtime, and last errors, exposing immutable metrics for debugging.【F:app/frontend/src/features/generation/stores/orchestrator/transportModule.ts†L1-L123】
+- Tests exercise transport recovery, orchestrator lifecycle, and error handling to guarantee deterministic behaviour (e.g., reconnect scheduling, metrics reset, initialization idempotence).【F:tests/vue/stores/orchestrator/transportModule.spec.ts†L28-L128】【F:tests/vue/stores/useGenerationOrchestratorStore.spec.ts†L51-L196】
+- Queue client tests confirm HTTP error reporting, ensuring logging metadata is preserved for observability.【F:tests/vue/useGenerationQueueClient.spec.ts†L134-L181】
+
+Collectively, these artefacts validate that the refactored architecture remains modular, observable, and resilient, aligning with the review’s expectations.


### PR DESCRIPTION
## Summary
- add an ADR that records the thin façade contract for the generation orchestrator
- document effect scope ownership to keep long-lived watchers inside managers
- capture acceptance-criteria cross-checks for the post-refactor generation architecture

## Testing
- not run (documentation only)

------
https://chatgpt.com/codex/tasks/task_e_68dd2f47db6083298752aeac1dfe1ab5