### PR TITLE
feat: centralize generation orchestrator consumption in shell

### DIFF
--- a/app/frontend/src/features/generation/components/GenerationStudio.vue
+++ b/app/frontend/src/features/generation/components/GenerationStudio.vue
@@ -126,13 +126,29 @@
 </template>
 
 <script setup lang="ts">
+import { storeToRefs } from 'pinia';
+
 import GenerationActiveJobsList from './GenerationActiveJobsList.vue';
 import GenerationParameterForm from './GenerationParameterForm.vue';
 import GenerationResultsGallery from './GenerationResultsGallery.vue';
 import GenerationSystemStatusCard from './GenerationSystemStatusCard.vue';
 import { useGenerationStudio } from '../composables/useGenerationStudio';
+import { HISTORY_LIMIT_WHEN_SHOWING } from '../composables/useGenerationOrchestratorManager';
+import { useGenerationStudioUiStore } from '../stores/ui';
+import { DEFAULT_HISTORY_LIMIT } from '../stores/useGenerationOrchestratorStore';
+import { useBackendUrl } from '@/utils/backend';
 
-const generationStudio = useGenerationStudio()
+/** @deprecated Use GenerationShell instead. */
+const uiStore = useGenerationStudioUiStore();
+const { showHistory: showHistoryState } = storeToRefs(uiStore);
+
+const backendBaseUrl = useBackendUrl('/')
+
+const generationStudio = useGenerationStudio({
+  getHistoryLimit: () =>
+    showHistoryState.value ? HISTORY_LIMIT_WHEN_SHOWING : DEFAULT_HISTORY_LIMIT,
+  getBackendUrl: () => backendBaseUrl.value || null,
+})
 
 const {
   params,

--- a/app/frontend/src/features/generation/composables/useGenerationStudio.ts
+++ b/app/frontend/src/features/generation/composables/useGenerationStudio.ts
@@ -8,7 +8,15 @@ import { useGenerationFormStore } from '../stores/form'
 import { useAsyncLifecycleTask } from '@/composables/shared'
 import type { GenerationFormState } from '@/types'
 
-export const useGenerationStudio = () => {
+export interface UseGenerationStudioOptions {
+  getHistoryLimit: () => number
+  getBackendUrl: () => string | null
+}
+
+export const useGenerationStudio = ({
+  getHistoryLimit,
+  getBackendUrl,
+}: UseGenerationStudioOptions) => {
   const formStore = useGenerationFormStore()
 
   const { notify, confirm: requestConfirmation, prompt: requestPrompt, logDebug } =
@@ -49,6 +57,8 @@ export const useGenerationStudio = () => {
     debug: logDebug,
     onAfterStart: persistParams,
     onAfterInitialize: loadParams,
+    getHistoryLimit,
+    getBackendUrl,
   })
 
   const params = computed(() => uiParams.value)
@@ -100,8 +110,8 @@ export const useGenerationStudio = () => {
     await controller.deleteResult(resultId)
   }
 
-  const refreshResults = async (): Promise<void> => {
-    await controller.refreshResults(true)
+  const refreshResults = async (notifySuccess = true): Promise<void> => {
+    await controller.refreshResults(notifySuccess)
   }
 
   const updateParams = (value: GenerationFormState): void => {
@@ -154,6 +164,9 @@ export const useGenerationStudio = () => {
     getSystemStatusClasses,
     updateParams,
     toggleHistory,
+    setHistoryLimit: controller.setHistoryLimit,
+    handleBackendUrlChange: controller.handleBackendUrlChange,
+    isManagerInitialized: controller.isManagerInitialized,
   }
 }
 

--- a/app/frontend/src/features/generation/composables/useGenerationStudioController.ts
+++ b/app/frontend/src/features/generation/composables/useGenerationStudioController.ts
@@ -14,6 +14,8 @@ export interface UseGenerationStudioControllerOptions {
   debug?: (...args: unknown[]) => void
   onAfterStart?: (params: GenerationFormState) => void
   onAfterInitialize?: () => void | Promise<void>
+  getHistoryLimit: () => number
+  getBackendUrl: () => string | null
 }
 
 export const useGenerationStudioController = ({
@@ -22,6 +24,8 @@ export const useGenerationStudioController = ({
   debug,
   onAfterStart,
   onAfterInitialize,
+  getHistoryLimit,
+  getBackendUrl,
 }: UseGenerationStudioControllerOptions) => {
   const formStore = useGenerationFormStore()
   const orchestratorManager = useGenerationOrchestratorManager()
@@ -32,6 +36,8 @@ export const useGenerationStudioController = ({
       orchestratorBinding.value = orchestratorManager.acquire({
         notify,
         debug,
+        historyLimit: getHistoryLimit(),
+        getBackendUrl,
       })
     }
 
@@ -93,12 +99,21 @@ export const useGenerationStudioController = ({
   const canCancelJob = (job: GenerationJob): boolean =>
     orchestratorBinding.value?.canCancelJob(job) ?? false
 
+  const setHistoryLimit = (limit: number): void => {
+    ensureBinding().setHistoryLimit(limit)
+  }
+
+  const handleBackendUrlChange = async (): Promise<void> => {
+    await ensureBinding().handleBackendUrlChange()
+  }
+
   return {
     activeJobs: orchestratorManager.activeJobs,
     sortedActiveJobs: orchestratorManager.sortedActiveJobs,
     recentResults: orchestratorManager.recentResults,
     systemStatus: orchestratorManager.systemStatus,
     isConnected: orchestratorManager.isConnected,
+    isManagerInitialized: orchestratorManager.isInitialized,
     initialize,
     startGeneration,
     cancelJob,
@@ -106,6 +121,8 @@ export const useGenerationStudioController = ({
     refreshResults,
     deleteResult,
     canCancelJob,
+    setHistoryLimit,
+    handleBackendUrlChange,
   }
 }
 

--- a/app/frontend/src/features/generation/index.ts
+++ b/app/frontend/src/features/generation/index.ts
@@ -1,4 +1,5 @@
 export {
+  GenerationShell,
   GenerationStudio,
   JobQueue,
   SystemAdminStatusCard,

--- a/app/frontend/src/features/generation/public.ts
+++ b/app/frontend/src/features/generation/public.ts
@@ -1,4 +1,6 @@
+/** @deprecated Use GenerationShell instead. */
 export { default as GenerationStudio } from './components/GenerationStudio.vue';
+export { default as GenerationShell } from './ui/GenerationShell.vue';
 export { default as JobQueue } from './components/JobQueue.vue';
 export { default as SystemAdminStatusCard } from './components/system/SystemAdminStatusCard.vue';
 export { default as SystemStatusCard } from './components/system/SystemStatusCard.vue';

--- a/app/frontend/src/features/generation/ui/GenerationShell.vue
+++ b/app/frontend/src/features/generation/ui/GenerationShell.vue
@@ -1,0 +1,220 @@
+<template>
+  <div class="generation-shell grid gap-6 xl:grid-cols-[3fr_2fr]">
+    <div class="generation-page-container flex flex-col gap-6">
+      <div class="page-header">
+        <div class="flex justify-between items-center">
+          <div>
+            <h1 class="page-title">Generation Studio</h1>
+            <p class="page-subtitle">Generate images with AI-powered LoRA integration</p>
+            <div class="mt-2 flex items-center text-sm text-gray-500 gap-2">
+              <span
+                class="inline-flex h-2 w-2 rounded-full"
+                :class="isConnected ? 'bg-green-500' : 'bg-red-500'"
+              ></span>
+              <span v-if="isConnected">Live updates connected</span>
+              <span v-else>Reconnecting to updates…</span>
+            </div>
+          </div>
+          <div class="header-actions flex gap-2">
+            <button
+              @click="toggleHistory()"
+              class="btn btn-secondary btn-sm"
+              :class="{ 'btn-primary': showHistory }"
+              type="button"
+            >
+              <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 01180z"></path>
+              </svg>
+              History
+            </button>
+            <button
+              @click="clearQueue"
+              class="btn btn-secondary btn-sm"
+              :disabled="activeJobs.length === 0"
+              type="button"
+            >
+              <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                  d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
+                ></path>
+              </svg>
+              Clear Queue
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <div class="grid grid-cols-1 lg:grid-cols-3 gap-6">
+        <div class="lg:col-span-1">
+          <GenerationParameterForm
+            :params="params"
+            :is-generating="isGenerating"
+            @update:params="updateParams"
+            @start-generation="startGeneration"
+            @load-from-composer="loadFromComposer"
+            @use-random-prompt="useRandomPrompt"
+            @save-preset="savePreset"
+          />
+        </div>
+
+        <div class="lg:col-span-1">
+          <div class="space-y-6">
+            <GenerationActiveJobsList
+              :active-jobs="activeJobs"
+              :sorted-active-jobs="sortedActiveJobs"
+              :format-time="formatTime"
+              :get-job-status-classes="getJobStatusClasses"
+              :get-job-status-text="getJobStatusText"
+              :can-cancel-job="canCancelJob"
+              @cancel-job="cancelJob"
+            />
+
+            <GenerationSystemStatusCard
+              :system-status="systemStatus"
+              :get-system-status-classes="getSystemStatusClasses"
+            />
+          </div>
+        </div>
+
+        <div class="lg:col-span-1">
+          <GenerationResultsGallery
+            :recent-results="recentResults"
+            :show-history="showHistory"
+            :format-time="formatTime"
+            @refresh-results="refreshResults"
+            @reuse-parameters="reuseParameters"
+            @delete-result="deleteResult"
+            @show-image-modal="showImageModal"
+          />
+        </div>
+      </div>
+    </div>
+
+    <div class="flex flex-col gap-6">
+      <SystemStatusCard variant="detailed" />
+      <JobQueue :show-clear-completed="true" />
+    </div>
+  </div>
+
+  <div v-if="showModal && selectedResult" class="fixed inset-0 z-50 overflow-y-auto" @click.self="hideImageModal">
+    <div class="flex items-center justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:block sm:p-0">
+      <div class="fixed inset-0 bg-gray-500 bg-opacity-75" @click="hideImageModal"></div>
+
+      <div class="inline-block align-bottom bg-white rounded-lg text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-lg sm:w-full">
+        <img
+          v-if="selectedResult?.image_url"
+          :src="selectedResult.image_url"
+          :alt="selectedResult?.prompt ?? 'Generated image'"
+          class="w-full"
+        >
+        <div class="p-4">
+          <h3 class="text-lg font-medium text-gray-900 mb-2">Generation Details</h3>
+          <div class="space-y-1 text-sm text-gray-600">
+            <div><strong>Prompt:</strong> {{ selectedResult?.prompt ?? 'Unknown prompt' }}</div>
+            <div>
+              <strong>Size:</strong>
+              {{ selectedResult?.width ?? '—' }}×{{ selectedResult?.height ?? '—' }}
+            </div>
+            <div><strong>Steps:</strong> {{ selectedResult?.steps ?? '—' }}</div>
+            <div><strong>CFG Scale:</strong> {{ selectedResult?.cfg_scale ?? '—' }}</div>
+            <div><strong>Seed:</strong> {{ selectedResult?.seed ?? '—' }}</div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, watch } from 'vue';
+import { storeToRefs } from 'pinia';
+
+import GenerationActiveJobsList from '../components/GenerationActiveJobsList.vue';
+import GenerationParameterForm from '../components/GenerationParameterForm.vue';
+import GenerationResultsGallery from '../components/GenerationResultsGallery.vue';
+import GenerationSystemStatusCard from '../components/GenerationSystemStatusCard.vue';
+import JobQueue from '../components/JobQueue.vue';
+import SystemStatusCard from '../components/system/SystemStatusCard.vue';
+import { useGenerationStudio } from '../composables/useGenerationStudio';
+import { HISTORY_LIMIT_WHEN_SHOWING } from '../composables/useGenerationOrchestratorManager';
+import { useGenerationStudioUiStore } from '../stores/ui';
+import { DEFAULT_HISTORY_LIMIT } from '../stores/useGenerationOrchestratorStore';
+import { useBackendUrl } from '@/utils/backend';
+
+const uiStore = useGenerationStudioUiStore();
+const { showHistory: uiShowHistory } = storeToRefs(uiStore);
+
+const backendBaseUrl = useBackendUrl('/');
+
+const getHistoryLimit = () =>
+  uiShowHistory.value ? HISTORY_LIMIT_WHEN_SHOWING : DEFAULT_HISTORY_LIMIT;
+
+const generationStudio = useGenerationStudio({
+  getHistoryLimit,
+  getBackendUrl: () => backendBaseUrl.value || null,
+});
+
+const historyLimit = computed(getHistoryLimit);
+
+const {
+  params,
+  systemStatus,
+  isGenerating,
+  showHistory: showHistoryComputed,
+  showModal,
+  selectedResult,
+  activeJobs,
+  recentResults,
+  sortedActiveJobs,
+  isConnected,
+  startGeneration,
+  cancelJob,
+  clearQueue,
+  refreshResults,
+  loadFromComposer,
+  useRandomPrompt,
+  savePreset,
+  showImageModal,
+  hideImageModal,
+  reuseParameters,
+  deleteResult,
+  formatTime,
+  getJobStatusClasses,
+  getJobStatusText,
+  canCancelJob,
+  getSystemStatusClasses,
+  updateParams,
+  toggleHistory,
+  setHistoryLimit,
+  handleBackendUrlChange,
+  isManagerInitialized,
+} = generationStudio;
+
+watch(
+  historyLimit,
+  (next, previous) => {
+    if (!isManagerInitialized.value || previous === undefined || next === previous) {
+      return;
+    }
+
+    setHistoryLimit(next);
+    void refreshResults(false);
+  },
+);
+
+watch(
+  () => backendBaseUrl.value,
+  (next, previous) => {
+    if (!isManagerInitialized.value || next === previous) {
+      return;
+    }
+
+    void handleBackendUrlChange();
+  },
+);
+
+const showHistory = computed(() => showHistoryComputed.value);
+</script>

--- a/app/frontend/src/views/DashboardView.vue
+++ b/app/frontend/src/views/DashboardView.vue
@@ -134,7 +134,7 @@ const panelConfigs = [
     placeholder:
       'Use the inline studio for quick jobs or switch to the dedicated page for the full orchestrator experience.',
     fallback: 'Loading generation studio…',
-    loader: () => import('@/features/generation/components/GenerationStudio.vue').then((module) => module.default),
+    loader: () => import('@/features/generation/ui/GenerationShell.vue').then((module) => module.default),
   },
   {
     key: 'gallery',

--- a/app/frontend/src/views/GenerateView.vue
+++ b/app/frontend/src/views/GenerateView.vue
@@ -11,10 +11,8 @@
       </template>
     </PageHeader>
     <div class="grid gap-6 xl:grid-cols-[3fr_2fr]">
-      <GenerationStudio />
+      <GenerationShell />
       <div class="flex flex-col gap-6">
-        <SystemStatusCard variant="detailed" />
-        <JobQueue :show-clear-completed="true" />
         <RecommendationsPanel />
       </div>
     </div>
@@ -24,7 +22,7 @@
 <script setup lang="ts">
 import { RouterLink } from 'vue-router';
 
-import { GenerationStudio, JobQueue, SystemStatusCard } from '@/features/generation/public';
+import { GenerationShell } from '@/features/generation/public';
 import PageHeader from '@/components/layout/PageHeader.vue';
 import { RecommendationsPanel } from '@/features/recommendations';
 </script>


### PR DESCRIPTION
## Summary
- add a GenerationShell component that acquires the orchestrator manager, handles history/backend effects, and composes the queue, status, and result panels
- extend the generation studio composables to accept history/backend hooks and expose façade methods for the shell to drive lifecycle updates
- simplify the orchestrator manager so the shell owns watchers, and update views/exports to load the new shell while marking the legacy studio as deprecated

## Testing
- npm run lint *(fails: repository-wide restricted-import rules outside the touched files)*

------
https://chatgpt.com/codex/tasks/task_e_68dd38edcf008329a5a3b69d180fcf3e