### PR TITLE
Add guardrails for generation feature imports

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -32,6 +32,23 @@ module.exports = {
     'no-restricted-imports': [
       'error',
       {
+        paths: [
+          {
+            name: '@/components/compose',
+            message:
+              'Import compose helpers from the prompt composer feature barrels instead of the legacy components path.',
+          },
+          {
+            name: '@/stores/generationQueue',
+            message:
+              'Import generation queue state via the orchestrator manager barrels rather than the legacy store entry.',
+          },
+          {
+            name: '@/stores/generationResults',
+            message:
+              'Import generation results state via the orchestrator manager barrels rather than the legacy store entry.',
+          },
+        ],
         patterns: [
           {
             group: ['@/composables/*/*', '@/composables/*/**'],

--- a/scripts/ci_check.py
+++ b/scripts/ci_check.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import subprocess
+from pathlib import Path
 from typing import Sequence
 
 COMMANDS: Sequence[Sequence[str]] = (
@@ -15,6 +16,113 @@ COMMANDS: Sequence[Sequence[str]] = (
 )
 
 
+def _parse_rg_output(output: str) -> list[tuple[Path, str, str]]:
+    """Parse ripgrep output into structured tuples."""
+
+    matches: list[tuple[Path, str, str]] = []
+    for line in output.splitlines():
+        if not line:
+            continue
+        parts = line.split(":", 2)
+        if len(parts) != 3:
+            continue
+        path_str, line_no, content = parts
+        matches.append((Path(path_str), line_no, content))
+    return matches
+
+
+def _ensure_generation_studio_imports_are_scoped() -> None:
+    """Fail if GenerationStudio.vue is imported outside the public barrels."""
+
+    allowed_files = {
+        Path("app/frontend/src/features/generation/components/index.ts"),
+        Path("app/frontend/src/features/generation/public.ts"),
+    }
+
+    result = subprocess.run(
+        (
+            "rg",
+            "--with-filename",
+            "--line-number",
+            "--no-heading",
+            "GenerationStudio\\.vue",
+            "app/frontend/src",
+        ),
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    if result.returncode not in (0, 1):
+        raise RuntimeError("Failed to scan for GenerationStudio.vue imports")
+
+    matches = _parse_rg_output(result.stdout)
+    violations = [
+        (path, line_no, content)
+        for path, line_no, content in matches
+        if path not in allowed_files
+    ]
+
+    if violations:
+        formatted = "\n".join(
+            f"- {path}:{line_no}: {content.strip()}" for path, line_no, content in violations
+        )
+        raise SystemExit(
+            "GenerationStudio.vue may only be imported via the feature barrel.\n"
+            f"Remove the direct import(s):\n{formatted}"
+        )
+
+
+def _ensure_cancel_job_usage_is_guarded() -> None:
+    """Ensure cancelGenerationJob is only used within the orchestrator manager surface."""
+
+    allowed_files = {
+        Path("app/frontend/src/features/generation/services/generationService.ts"),
+        Path("app/frontend/src/features/generation/services/queueClient.ts"),
+        Path("app/frontend/src/features/generation/composables/useJobQueueActions.ts"),
+    }
+
+    result = subprocess.run(
+        (
+            "rg",
+            "--with-filename",
+            "--line-number",
+            "--no-heading",
+            "cancelGenerationJob",
+            "app/frontend/src",
+        ),
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    if result.returncode not in (0, 1):
+        raise RuntimeError("Failed to scan for cancelGenerationJob usage")
+
+    matches = _parse_rg_output(result.stdout)
+    violations = [
+        (path, line_no, content)
+        for path, line_no, content in matches
+        if path not in allowed_files
+    ]
+
+    if violations:
+        formatted = "\n".join(
+            f"- {path}:{line_no}: {content.strip()}" for path, line_no, content in violations
+        )
+        raise SystemExit(
+            "cancelGenerationJob should only be invoked through the orchestrator manager surface.\n"
+            f"Update the following file(s) to delegate through the manager:\n{formatted}"
+        )
+
+
+def run_guardrail_checks() -> None:
+    """Run repository guardrail validations prior to full CI checks."""
+
+    _ensure_generation_studio_imports_are_scoped()
+    _ensure_cancel_job_usage_is_guarded()
+
+
 def run_command(command: Sequence[str]) -> None:
     """Execute a single command and stream its output."""
     print(f"\n→ {' '.join(command)}", flush=True)
@@ -23,6 +131,7 @@ def run_command(command: Sequence[str]) -> None:
 
 def main() -> int:
     """Run the CI-equivalent workflow and return the exit code."""
+    run_guardrail_checks()
     for command in COMMANDS:
         run_command(command)
     return 0

--- a/tests/recommendations/test_service_lifecycle.py
+++ b/tests/recommendations/test_service_lifecycle.py
@@ -1,0 +1,14 @@
+"""Placeholder tests for exercising the recommendation service lifecycle."""
+
+import pytest
+
+pytestmark = pytest.mark.skip(reason="TODO: cover recommendation service lifecycle scenarios")
+
+
+class TestRecommendationServiceLifecycle:
+    """Reserved for future recommendation service lifecycle coverage."""
+
+    def test_placeholder(self) -> None:
+        """Ensure pytest registers this module for future implementation."""
+
+        pytest.skip("TODO: implement recommendation service lifecycle tests")

--- a/tests/services/test_service_registry_read_only_facade.py
+++ b/tests/services/test_service_registry_read_only_facade.py
@@ -1,0 +1,11 @@
+"""Placeholder coverage for the read-only service registry facade."""
+
+import pytest
+
+pytestmark = pytest.mark.skip(reason="TODO: validate read-only service registry facade behaviour")
+
+
+def test_service_registry_read_only_facade_placeholder() -> None:
+    """Mark the module for future read-only facade coverage."""
+
+    pytest.skip("TODO: assert service registry exposes read-only facades")

--- a/tests/vue/composables/useGenerationOrchestratorManager.lifecycle.spec.ts
+++ b/tests/vue/composables/useGenerationOrchestratorManager.lifecycle.spec.ts
@@ -1,0 +1,7 @@
+import { describe, it } from 'vitest';
+
+describe('useGenerationOrchestratorManager lifecycle', () => {
+  it.todo('initializes the orchestrator when the first consumer acquires a binding');
+  it.todo('destroys the orchestrator when the last consumer releases its binding');
+  it.todo('retries initialization when setup fails and a new consumer subscribes');
+});

--- a/tests/vue/stores/performanceAnalyticsStore.autoRefresh.spec.ts
+++ b/tests/vue/stores/performanceAnalyticsStore.autoRefresh.spec.ts
@@ -1,0 +1,7 @@
+import { describe, it } from 'vitest';
+
+describe('performance analytics auto-refresh', () => {
+  it.todo('schedules analytics polling when the dashboard becomes visible');
+  it.todo('cancels analytics polling when the dashboard is hidden or destroyed');
+  it.todo('throttles refresh frequency according to configuration settings');
+});


### PR DESCRIPTION
## Summary
- extend the shared ESLint configuration to block legacy compose and generation store imports
- add CI guardrail scans to prevent direct GenerationStudio.vue imports and cancelGenerationJob usage outside the approved surface
- introduce placeholder test specs for manager lifecycle, recommendation service lifecycle, read-only facade, and analytics auto-refresh coverage

## Testing
- python -c "from scripts.ci_check import run_guardrail_checks; run_guardrail_checks()"
- pytest tests/recommendations/test_service_lifecycle.py

------
https://chatgpt.com/codex/tasks/task_e_68dd412cb5388329b38f8f83a80d38f1