### PR TITLE
Move generation lifecycle watchers into orchestrator manager

### DIFF
--- a/app/frontend/src/features/generation/components/GenerationStudio.vue
+++ b/app/frontend/src/features/generation/components/GenerationStudio.vue
@@ -133,22 +133,13 @@ import GenerationParameterForm from './GenerationParameterForm.vue';
 import GenerationResultsGallery from './GenerationResultsGallery.vue';
 import GenerationSystemStatusCard from './GenerationSystemStatusCard.vue';
 import { useGenerationStudio } from '../composables/useGenerationStudio';
-import { HISTORY_LIMIT_WHEN_SHOWING } from '../composables/useGenerationOrchestratorManager';
 import { useGenerationStudioUiStore } from '../stores/ui';
-import { DEFAULT_HISTORY_LIMIT } from '../stores/useGenerationOrchestratorStore';
-import { useBackendUrl } from '@/utils/backend';
 
 /** @deprecated Use GenerationShell instead. */
 const uiStore = useGenerationStudioUiStore();
 const { showHistory: showHistoryState } = storeToRefs(uiStore);
 
-const backendBaseUrl = useBackendUrl('/')
-
-const generationStudio = useGenerationStudio({
-  getHistoryLimit: () =>
-    showHistoryState.value ? HISTORY_LIMIT_WHEN_SHOWING : DEFAULT_HISTORY_LIMIT,
-  getBackendUrl: () => backendBaseUrl.value || null,
-})
+const generationStudio = useGenerationStudio()
 
 const {
   params,

--- a/app/frontend/src/features/generation/composables/useGenerationStudio.ts
+++ b/app/frontend/src/features/generation/composables/useGenerationStudio.ts
@@ -8,15 +8,7 @@ import { useGenerationFormStore } from '../stores/form'
 import { useAsyncLifecycleTask } from '@/composables/shared'
 import type { GenerationFormState } from '@/types'
 
-export interface UseGenerationStudioOptions {
-  getHistoryLimit: () => number
-  getBackendUrl: () => string | null
-}
-
-export const useGenerationStudio = ({
-  getHistoryLimit,
-  getBackendUrl,
-}: UseGenerationStudioOptions) => {
+export const useGenerationStudio = () => {
   const formStore = useGenerationFormStore()
 
   const { notify, confirm: requestConfirmation, prompt: requestPrompt, logDebug } =
@@ -57,8 +49,6 @@ export const useGenerationStudio = ({
     debug: logDebug,
     onAfterStart: persistParams,
     onAfterInitialize: loadParams,
-    getHistoryLimit,
-    getBackendUrl,
   })
 
   const params = computed(() => uiParams.value)

--- a/app/frontend/src/features/generation/composables/useGenerationStudioController.ts
+++ b/app/frontend/src/features/generation/composables/useGenerationStudioController.ts
@@ -14,8 +14,6 @@ export interface UseGenerationStudioControllerOptions {
   debug?: (...args: unknown[]) => void
   onAfterStart?: (params: GenerationFormState) => void
   onAfterInitialize?: () => void | Promise<void>
-  getHistoryLimit: () => number
-  getBackendUrl: () => string | null
 }
 
 export const useGenerationStudioController = ({
@@ -24,8 +22,6 @@ export const useGenerationStudioController = ({
   debug,
   onAfterStart,
   onAfterInitialize,
-  getHistoryLimit,
-  getBackendUrl,
 }: UseGenerationStudioControllerOptions) => {
   const formStore = useGenerationFormStore()
   const orchestratorManager = useGenerationOrchestratorManager()
@@ -36,8 +32,6 @@ export const useGenerationStudioController = ({
       orchestratorBinding.value = orchestratorManager.acquire({
         notify,
         debug,
-        historyLimit: getHistoryLimit(),
-        getBackendUrl,
       })
     }
 

--- a/app/frontend/src/features/generation/ui/GenerationShell.vue
+++ b/app/frontend/src/features/generation/ui/GenerationShell.vue
@@ -129,8 +129,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, watch } from 'vue';
-import { storeToRefs } from 'pinia';
+import { computed } from 'vue';
 
 import GenerationActiveJobsList from '../components/GenerationActiveJobsList.vue';
 import GenerationParameterForm from '../components/GenerationParameterForm.vue';
@@ -139,25 +138,8 @@ import GenerationSystemStatusCard from '../components/GenerationSystemStatusCard
 import JobQueue from '../components/JobQueue.vue';
 import SystemStatusCard from '../components/system/SystemStatusCard.vue';
 import { useGenerationStudio } from '../composables/useGenerationStudio';
-import { HISTORY_LIMIT_WHEN_SHOWING } from '../composables/useGenerationOrchestratorManager';
-import { useGenerationStudioUiStore } from '../stores/ui';
-import { DEFAULT_HISTORY_LIMIT } from '../stores/useGenerationOrchestratorStore';
-import { useBackendUrl } from '@/utils/backend';
 
-const uiStore = useGenerationStudioUiStore();
-const { showHistory: uiShowHistory } = storeToRefs(uiStore);
-
-const backendBaseUrl = useBackendUrl('/');
-
-const getHistoryLimit = () =>
-  uiShowHistory.value ? HISTORY_LIMIT_WHEN_SHOWING : DEFAULT_HISTORY_LIMIT;
-
-const generationStudio = useGenerationStudio({
-  getHistoryLimit,
-  getBackendUrl: () => backendBaseUrl.value || null,
-});
-
-const historyLimit = computed(getHistoryLimit);
+const generationStudio = useGenerationStudio();
 
 const {
   params,
@@ -188,33 +170,7 @@ const {
   getSystemStatusClasses,
   updateParams,
   toggleHistory,
-  setHistoryLimit,
-  handleBackendUrlChange,
-  isManagerInitialized,
 } = generationStudio;
-
-watch(
-  historyLimit,
-  (next, previous) => {
-    if (!isManagerInitialized.value || previous === undefined || next === previous) {
-      return;
-    }
-
-    setHistoryLimit(next);
-    void refreshResults(false);
-  },
-);
-
-watch(
-  () => backendBaseUrl.value,
-  (next, previous) => {
-    if (!isManagerInitialized.value || next === previous) {
-      return;
-    }
-
-    void handleBackendUrlChange();
-  },
-);
 
 const showHistory = computed(() => showHistoryComputed.value);
 </script>

--- a/tests/vue/composables/useGenerationOrchestratorManager.integration.spec.ts
+++ b/tests/vue/composables/useGenerationOrchestratorManager.integration.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { createPinia, setActivePinia, defineStore } from 'pinia';
-import { nextTick, ref } from 'vue';
+import { computed, nextTick, ref } from 'vue';
 
 vi.mock('@/features/generation/composables/createGenerationTransportAdapter', () => ({
   createGenerationTransportAdapter: vi.fn(),
@@ -11,6 +11,7 @@ import { createUseGenerationOrchestratorManager, HISTORY_LIMIT_WHEN_SHOWING } fr
 import { useGenerationOrchestratorStore, DEFAULT_HISTORY_LIMIT } from '@/features/generation/stores/useGenerationOrchestratorStore';
 import { useGenerationOrchestratorManagerStore } from '@/features/generation/stores/orchestratorManagerStore';
 import { useGenerationStudioUiStore } from '@/features/generation/stores/ui';
+import { useBackendUrl } from '@/utils/backend';
 
 const useStubSettingsStore = defineStore('stub-settings', () => {
   const backendUrl = ref('http://localhost');
@@ -48,11 +49,13 @@ describe('useGenerationOrchestratorManager integration', () => {
     const uiStore = useGenerationStudioUiStore();
     const settingsStore = useStubSettingsStore();
 
+    const backendUrlRef = computed(() => settingsStore.backendUrl as string);
+
     const useManager = createUseGenerationOrchestratorManager({
       useGenerationOrchestratorManagerStore: () => managerStore,
       useGenerationOrchestratorStore: () => orchestratorStore,
       useGenerationStudioUiStore: () => uiStore,
-      useSettingsStore: () => settingsStore as any,
+      useBackendUrl: (() => backendUrlRef) as unknown as typeof useBackendUrl,
     });
 
     const manager = useManager();

--- a/tests/vue/composables/useGenerationOrchestratorManager.spec.ts
+++ b/tests/vue/composables/useGenerationOrchestratorManager.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { ref, shallowRef, type Ref } from 'vue';
+import { computed, ref, shallowRef, type Ref } from 'vue';
 
 import {
   createUseGenerationOrchestratorManager,
@@ -11,7 +11,7 @@ import type {
   GenerationOrchestratorStore,
   GenerationStudioUiStore,
 } from '@/features/generation/stores';
-import type { SettingsStore } from '@/stores';
+import { useBackendUrl } from '@/utils/backend';
 import type {
   GenerationJob,
   GenerationRequestPayload,
@@ -98,18 +98,17 @@ const createDependencies = () => {
     showHistory: ref(false),
   } satisfies Partial<GenerationStudioUiStore> & { showHistory: Ref<boolean> };
 
-  const settingsStore = {
-    backendUrl: ref<string | null>('http://localhost'),
-  } satisfies Partial<SettingsStore> & { backendUrl: Ref<string | null> };
+  const backendUrl = ref('http://localhost');
+  const backendUrlComputed = computed(() => backendUrl.value);
 
   const dependencies: UseGenerationOrchestratorManagerDependencies = {
     useGenerationOrchestratorManagerStore: () => orchestratorManagerStore as GenerationOrchestratorManagerStore,
     useGenerationOrchestratorStore: () => orchestratorStore as unknown as GenerationOrchestratorStore,
     useGenerationStudioUiStore: () => uiStore as GenerationStudioUiStore,
-    useSettingsStore: () => settingsStore as SettingsStore,
+    useBackendUrl: (() => backendUrlComputed) as unknown as typeof useBackendUrl,
   };
 
-  return { orchestratorStore, orchestratorManagerStore, uiStore, settingsStore, dependencies };
+  return { orchestratorStore, orchestratorManagerStore, uiStore, backendUrl, dependencies };
 };
 
 describe('createUseGenerationOrchestratorManager', () => {


### PR DESCRIPTION
## Summary
- shift backend URL and history limit watchers into `useGenerationOrchestratorManager` using a managed effect scope
- simplify `GenerationShell` and legacy `GenerationStudio` to rely on the manager without local watchers
- update related composables and tests to reflect the centralized lifecycle logic

## Testing
- npm run test -- --run tests/vue/composables/useGenerationOrchestratorManager

------
https://chatgpt.com/codex/tasks/task_e_68dd4151e1708329a71a2c26361267f4