### PR TITLE
Add manager-backed generation orchestrator façade

### DIFF
--- a/app/frontend/src/features/generation/orchestrator/facade.ts
+++ b/app/frontend/src/features/generation/orchestrator/facade.ts
@@ -1,5 +1,8 @@
 import type { ComputedRef, Ref } from 'vue';
 
+import { useGenerationOrchestratorStore } from '../stores/useGenerationOrchestratorStore';
+import type { GenerationOrchestratorStore } from '../stores/useGenerationOrchestratorStore';
+
 import type { GenerationJob, GenerationResult, SystemStatusState } from '@/types';
 import type { DeepReadonly } from '@/utils/freezeDeep';
 import type {
@@ -61,3 +64,107 @@ export interface GenerationOrchestratorFacade
     GenerationOrchestratorFacadeCommands {}
 
 export type GenerationOrchestratorFacadeFactory = () => GenerationOrchestratorFacade;
+
+export interface GenerationManager extends GenerationOrchestratorFacadeSelectors {
+  cancelJob(jobId: string): Promise<void>;
+  removeJob(jobId: string | number): void;
+  refreshHistory(options?: GenerationHistoryRefreshOptions): Promise<void>;
+  reconnect(): void | Promise<void>;
+  setHistoryLimit(limit: GenerationHistoryLimit): void;
+}
+
+const normalizeJobId = (jobId: string | number): string => String(jobId);
+
+const createStoreBackedManager = (
+  store: GenerationOrchestratorStore,
+): GenerationManager => ({
+  jobs: store.jobs,
+  activeJobs: store.activeJobs,
+  sortedActiveJobs: store.sortedActiveJobs,
+  hasActiveJobs: store.hasActiveJobs,
+  recentResults: store.recentResults,
+  historyLimit: store.historyLimit,
+  systemStatus: store.systemStatus,
+  systemStatusReady: store.systemStatusReady,
+  systemStatusLastUpdated: store.systemStatusLastUpdated,
+  systemStatusApiAvailable: store.systemStatusApiAvailable,
+  queueManagerActive: store.queueManagerActive,
+  isActive: store.isActive,
+  isConnected: store.isConnected,
+  pollIntervalMs: store.pollIntervalMs,
+  transportMetrics: store.transportMetrics,
+  transportPhase: store.transportPhase,
+  transportReconnectAttempt: store.transportReconnectAttempt,
+  transportConsecutiveFailures: store.transportConsecutiveFailures,
+  transportNextRetryDelayMs: store.transportNextRetryDelayMs,
+  transportLastConnectedAt: store.transportLastConnectedAt,
+  transportLastDisconnectedAt: store.transportLastDisconnectedAt,
+  transportDowntimeMs: store.transportDowntimeMs,
+  transportTotalDowntimeMs: store.transportTotalDowntimeMs,
+  lastError: store.transportLastError,
+  lastSnapshot: store.transportLastSnapshot,
+  cancelJob: async (jobId: string): Promise<void> => {
+    await store.cancelJob(jobId);
+  },
+  removeJob: (jobId: string | number): void => {
+    store.removeJob(normalizeJobId(jobId));
+  },
+  refreshHistory: async (options?: GenerationHistoryRefreshOptions): Promise<void> => {
+    await store.loadRecentResults(options?.notifySuccess ?? false);
+  },
+  reconnect: () => store.reconnect(),
+  setHistoryLimit: (limit: GenerationHistoryLimit): void => {
+    store.setHistoryLimit(limit);
+    if (store.isActive.value) {
+      void store.loadRecentResults(false);
+    }
+  },
+});
+
+export interface CreateGenerationFacadeOptions {
+  manager: GenerationManager;
+}
+
+export const createGenerationFacade = ({
+  manager,
+}: CreateGenerationFacadeOptions): GenerationOrchestratorFacade => ({
+  jobs: manager.jobs,
+  activeJobs: manager.activeJobs,
+  sortedActiveJobs: manager.sortedActiveJobs,
+  hasActiveJobs: manager.hasActiveJobs,
+  recentResults: manager.recentResults,
+  historyLimit: manager.historyLimit,
+  systemStatus: manager.systemStatus,
+  systemStatusReady: manager.systemStatusReady,
+  systemStatusLastUpdated: manager.systemStatusLastUpdated,
+  systemStatusApiAvailable: manager.systemStatusApiAvailable,
+  queueManagerActive: manager.queueManagerActive,
+  isActive: manager.isActive,
+  isConnected: manager.isConnected,
+  pollIntervalMs: manager.pollIntervalMs,
+  transportMetrics: manager.transportMetrics,
+  transportPhase: manager.transportPhase,
+  transportReconnectAttempt: manager.transportReconnectAttempt,
+  transportConsecutiveFailures: manager.transportConsecutiveFailures,
+  transportNextRetryDelayMs: manager.transportNextRetryDelayMs,
+  transportLastConnectedAt: manager.transportLastConnectedAt,
+  transportLastDisconnectedAt: manager.transportLastDisconnectedAt,
+  transportDowntimeMs: manager.transportDowntimeMs,
+  transportTotalDowntimeMs: manager.transportTotalDowntimeMs,
+  lastError: manager.lastError,
+  lastSnapshot: manager.lastSnapshot,
+  cancelJob: (jobId: string): Promise<void> => manager.cancelJob(jobId),
+  removeJob: (jobId: string | number): void => manager.removeJob(jobId),
+  refreshHistory: (options?: GenerationHistoryRefreshOptions): Promise<void> =>
+    manager.refreshHistory(options),
+  reconnect: (): void | Promise<void> => manager.reconnect(),
+  setHistoryLimit: (limit: GenerationHistoryLimit): void => manager.setHistoryLimit(limit),
+});
+
+export const useGenerationOrchestratorFacade: GenerationOrchestratorFacadeFactory = () => {
+  const store = useGenerationOrchestratorStore();
+  const manager = createStoreBackedManager(store);
+  return createGenerationFacade({ manager });
+};
+
+export default useGenerationOrchestratorFacade;

--- a/app/frontend/src/features/generation/stores/orchestrator/transportActions.ts
+++ b/app/frontend/src/features/generation/stores/orchestrator/transportActions.ts
@@ -44,6 +44,10 @@ export const createTransportActions = ({
     await refreshAllData();
   };
 
+  const reconnect = (): void => {
+    transport.reconnect();
+  };
+
   const startGeneration = async (
     payload: GenerationRequestPayload,
   ): Promise<GenerationStartResponse> => {
@@ -105,6 +109,7 @@ export const createTransportActions = ({
     loadRecentResults,
     refreshAllData,
     handleBackendUrlChange,
+    reconnect,
     startGeneration,
     cancelJob,
     clearQueue,

--- a/tests/vue/orchestrator/facade.spec.ts
+++ b/tests/vue/orchestrator/facade.spec.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it, vi } from 'vitest';
+import { computed } from 'vue';
+
+import {
+  createGenerationFacade,
+  type GenerationHistoryRefreshOptions,
+  type GenerationManager,
+  type GenerationHistoryLimit,
+  type ImmutableGenerationJob,
+  type ImmutableGenerationResult,
+} from '@/features/generation/orchestrator/facade';
+import type { DeepReadonly } from '@/utils/freezeDeep';
+import type { SystemStatusState } from '@/types';
+import type {
+  GenerationTransportError,
+  GenerationTransportMetricsSnapshot,
+  GenerationTransportPhase,
+  GenerationWebSocketStateSnapshot,
+} from '@/features/generation/types/transport';
+
+const systemStatus: DeepReadonly<SystemStatusState> = Object.freeze({
+  gpu_available: false,
+  queue_length: 0,
+  status: 'unknown',
+  gpu_status: 'Unknown',
+  memory_used: 0,
+  memory_total: 0,
+});
+
+const transportMetrics: GenerationTransportMetricsSnapshot = {
+  phase: 'idle',
+  reconnectAttempt: 0,
+  consecutiveFailures: 0,
+  nextRetryDelayMs: null,
+  lastConnectedAt: null,
+  lastDisconnectedAt: null,
+  downtimeMs: null,
+  totalDowntimeMs: 0,
+  lastError: null,
+  lastEvent: null,
+};
+
+const createManagerStub = () => {
+  const cancelJob = vi.fn(async (_jobId: string) => {});
+  const removeJob = vi.fn((_jobId: string | number) => {});
+  const refreshHistory = vi.fn(async (_options?: GenerationHistoryRefreshOptions) => {});
+  const setHistoryLimit = vi.fn((_limit: GenerationHistoryLimit) => {});
+  const reconnect = vi.fn(() => {});
+
+  const manager: GenerationManager = {
+    jobs: computed<readonly ImmutableGenerationJob[]>(() => []),
+    activeJobs: computed<readonly ImmutableGenerationJob[]>(() => []),
+    sortedActiveJobs: computed<readonly ImmutableGenerationJob[]>(() => []),
+    hasActiveJobs: computed(() => false),
+    recentResults: computed<readonly ImmutableGenerationResult[]>(() => []),
+    historyLimit: computed<GenerationHistoryLimit>(() => 10),
+    systemStatus: computed(() => systemStatus),
+    systemStatusReady: computed(() => true),
+    systemStatusLastUpdated: computed(() => null),
+    systemStatusApiAvailable: computed(() => true),
+    queueManagerActive: computed(() => true),
+    isActive: computed(() => true),
+    isConnected: computed(() => true),
+    pollIntervalMs: computed(() => 1_000),
+    transportMetrics: computed(() => transportMetrics),
+    transportPhase: computed<GenerationTransportPhase>(() => transportMetrics.phase),
+    transportReconnectAttempt: computed(() => transportMetrics.reconnectAttempt),
+    transportConsecutiveFailures: computed(() => transportMetrics.consecutiveFailures),
+    transportNextRetryDelayMs: computed(() => transportMetrics.nextRetryDelayMs),
+    transportLastConnectedAt: computed(() => transportMetrics.lastConnectedAt),
+    transportLastDisconnectedAt: computed(() => transportMetrics.lastDisconnectedAt),
+    transportDowntimeMs: computed(() => transportMetrics.downtimeMs),
+    transportTotalDowntimeMs: computed(() => transportMetrics.totalDowntimeMs),
+    lastError: computed<GenerationTransportError | null>(() => transportMetrics.lastError),
+    lastSnapshot: computed<GenerationWebSocketStateSnapshot | null>(
+      () => transportMetrics.lastEvent,
+    ),
+    cancelJob,
+    removeJob,
+    refreshHistory,
+    reconnect,
+    setHistoryLimit,
+  };
+
+  return {
+    manager,
+    cancelJob,
+    removeJob,
+    refreshHistory,
+    reconnect,
+    setHistoryLimit,
+  };
+};
+
+describe('createGenerationFacade', () => {
+  it('forwards cancelJob to the manager', async () => {
+    const { manager, cancelJob } = createManagerStub();
+    const facade = createGenerationFacade({ manager });
+
+    await facade.cancelJob('job-1');
+
+    expect(cancelJob).toHaveBeenCalledWith('job-1');
+  });
+
+  it('forwards removeJob to the manager', () => {
+    const { manager, removeJob } = createManagerStub();
+    const facade = createGenerationFacade({ manager });
+
+    facade.removeJob(42);
+
+    expect(removeJob).toHaveBeenCalledWith(42);
+  });
+
+  it('forwards refreshHistory options to the manager', async () => {
+    const { manager, refreshHistory } = createManagerStub();
+    const facade = createGenerationFacade({ manager });
+    const options: GenerationHistoryRefreshOptions = { notifySuccess: true };
+
+    await facade.refreshHistory(options);
+
+    expect(refreshHistory).toHaveBeenCalledWith(options);
+  });
+
+  it('forwards reconnect to the manager', () => {
+    const { manager, reconnect } = createManagerStub();
+    const facade = createGenerationFacade({ manager });
+
+    facade.reconnect();
+
+    expect(reconnect).toHaveBeenCalledTimes(1);
+  });
+
+  it('forwards setHistoryLimit to the manager', () => {
+    const { manager, setHistoryLimit } = createManagerStub();
+    const facade = createGenerationFacade({ manager });
+
+    facade.setHistoryLimit(25);
+
+    expect(setHistoryLimit).toHaveBeenCalledWith(25);
+  });
+});


### PR DESCRIPTION
## Summary
- wrap the generation orchestrator façade in a manager-backed implementation and expose a default composable
- surface the transport reconnect action through the orchestrator store for façade commands
- add unit coverage ensuring façade commands delegate to the manager contract

## Testing
- npm run test:unit -- tests/vue/orchestrator/facade.spec.ts
- npm run type-check *(fails: existing TypeScript issues in unrelated modules)*

------
https://chatgpt.com/codex/tasks/task_e_68dd5443fae48329a5be83cd6c21365f