### PR TITLE
feat: enforce readonly generation facade usage

### DIFF
--- a/app/frontend/src/components/dashboard/DashboardGenerationSummary.vue
+++ b/app/frontend/src/components/dashboard/DashboardGenerationSummary.vue
@@ -99,9 +99,9 @@ import { RouterLink } from 'vue-router';
 
 import { useBackendClient } from '@/services/backendClient';
 import { listResults as listHistoryResults } from '@/features/history/services';
-import { useGenerationResultsStore } from '@/features/generation/public';
+import { useGenerationOrchestratorFacade } from '@/features/generation/orchestrator';
 import { formatFileSize, formatRelativeTime } from '@/utils/format';
-import { mapGenerationResultsToHistory, mapHistoryResultsToGeneration } from '@/utils/generationHistory';
+import { mapGenerationResultsToHistory } from '@/utils/generationHistory';
 import type {
   GenerationHistoryResult,
   GenerationHistoryStats,
@@ -113,8 +113,8 @@ const SUMMARY_QUERY = Object.freeze({ page_size: 4, sort: 'created_at_desc' as c
 const backendClient = useBackendClient();
 const settingsStore = useSettingsStore();
 const { backendUrl } = storeToRefs(settingsStore);
-const resultsStore = useGenerationResultsStore();
-const { recentResults: storeResults } = storeToRefs(resultsStore);
+const generationFacade = useGenerationOrchestratorFacade();
+const storeResults = generationFacade.results;
 
 const stats = ref<GenerationHistoryStats>({
   total_results: 0,
@@ -171,9 +171,6 @@ const refresh = async () => {
     const output = await listHistoryResults({ ...SUMMARY_QUERY }, {}, backendClient);
     stats.value = output.stats;
     fetchedResults.value = output.results;
-    if (!storeResults.value.length && output.results.length) {
-      resultsStore.setResults(mapHistoryResultsToGeneration(output.results));
-    }
   } catch (err) {
     error.value = err instanceof Error ? err : new Error('Failed to load generation summary');
     console.error('Failed to refresh generation summary', err);

--- a/app/frontend/src/features/generation/components/GenerationResultsGallery.vue
+++ b/app/frontend/src/features/generation/components/GenerationResultsGallery.vue
@@ -76,19 +76,19 @@
 import { toRefs } from 'vue'
 
 import type { UseGenerationStudioReturn } from '../composables/useGenerationStudio'
-import type { GenerationResult } from '@/types'
+import type { ResultItemView, ReadonlyResults } from '@/features/generation/orchestrator'
 
 const props = defineProps<{
-  recentResults: GenerationResult[]
+  recentResults: ReadonlyResults
   showHistory: boolean
   formatTime: UseGenerationStudioReturn['formatTime']
 }>()
 
 const emit = defineEmits<{
   (event: 'refresh-results'): void
-  (event: 'reuse-parameters', result: GenerationResult): void
+  (event: 'reuse-parameters', result: ResultItemView): void
   (event: 'delete-result', resultId: string | number): void
-  (event: 'show-image-modal', result: GenerationResult): void
+  (event: 'show-image-modal', result: ResultItemView): void
 }>()
 
 const { recentResults, showHistory, formatTime } = toRefs(props)

--- a/app/frontend/src/features/generation/composables/useJobQueueActions.ts
+++ b/app/frontend/src/features/generation/composables/useJobQueueActions.ts
@@ -1,14 +1,14 @@
 import { getCurrentScope, onScopeDispose, ref, shallowRef } from 'vue';
 
 import { useGenerationOrchestratorManager, type GenerationOrchestratorBinding } from './useGenerationOrchestratorManager';
-import { useGenerationQueueStore } from '../stores/queue';
+import { useGenerationOrchestratorFacade } from '@/features/generation/orchestrator';
 import { useNotifications } from '@/composables/shared';
 import type { NotificationType } from '@/types';
 
 export interface UseJobQueueActionsOptions {}
 
 export const useJobQueueActions = (_options: UseJobQueueActionsOptions = {}) => {
-  const queueStore = useGenerationQueueStore();
+  const generationFacade = useGenerationOrchestratorFacade();
   const orchestratorManager = useGenerationOrchestratorManager();
   const notifications = useNotifications();
 
@@ -82,7 +82,7 @@ export const useJobQueueActions = (_options: UseJobQueueActionsOptions = {}) => 
   };
 
   const clearCompletedJobs = (): void => {
-    queueStore.clearCompletedJobs();
+    generationFacade.clearCompletedJobs();
   };
 
   return {

--- a/app/frontend/src/features/generation/index.ts
+++ b/app/frontend/src/features/generation/index.ts
@@ -4,6 +4,4 @@ export {
   SystemAdminStatusCard,
   SystemStatusCard,
   SystemStatusPanel,
-  useGenerationResultsStore,
 } from './public';
-export type { GenerationResultsStore } from './public';

--- a/app/frontend/src/features/generation/orchestrator/facade.readonly.test-d.ts
+++ b/app/frontend/src/features/generation/orchestrator/facade.readonly.test-d.ts
@@ -1,0 +1,10 @@
+import type { GenerationOrchestratorFacade } from '@/features/generation/orchestrator';
+
+declare const facade: GenerationOrchestratorFacade;
+
+// @ts-expect-error Generation queue is read-only.
+facade.queue.value[0] = undefined;
+// @ts-expect-error Generation results are read-only.
+facade.results.value[0] = undefined;
+
+export {};

--- a/app/frontend/src/features/generation/public.ts
+++ b/app/frontend/src/features/generation/public.ts
@@ -3,6 +3,3 @@ export { default as JobQueue } from './components/JobQueue.vue';
 export { default as SystemAdminStatusCard } from './components/system/SystemAdminStatusCard.vue';
 export { default as SystemStatusCard } from './components/system/SystemStatusCard.vue';
 export { default as SystemStatusPanel } from './components/system/SystemStatusPanel.vue';
-
-export { useGenerationResultsStore } from './stores/results';
-export type { GenerationResultsStore } from './stores/results';

--- a/app/frontend/src/utils/generationHistory.ts
+++ b/app/frontend/src/utils/generationHistory.ts
@@ -1,4 +1,5 @@
 import type { GenerationHistoryResult, GenerationResult } from '@/types';
+import type { DeepReadonly } from '@/utils/freezeDeep';
 
 const ensureCreatedAt = (timestamp?: string): string => {
   if (typeof timestamp === 'string' && timestamp.trim()) {
@@ -7,7 +8,9 @@ const ensureCreatedAt = (timestamp?: string): string => {
   return new Date().toISOString();
 };
 
-export const toHistoryResult = (result: GenerationResult): GenerationHistoryResult => ({
+export const toHistoryResult = (
+  result: DeepReadonly<GenerationResult> | GenerationResult,
+): GenerationHistoryResult => ({
   id: result.id,
   job_id: result.job_id ?? undefined,
   prompt: result.prompt ?? null,
@@ -44,7 +47,7 @@ export const toGenerationResult = (result: GenerationHistoryResult): GenerationR
 });
 
 export const mapGenerationResultsToHistory = (
-  results: readonly GenerationResult[],
+  results: readonly (DeepReadonly<GenerationResult> | GenerationResult)[],
 ): GenerationHistoryResult[] => results.map((result) => toHistoryResult(result));
 
 export const mapHistoryResultsToGeneration = (

--- a/docs/frontend/generation-orchestrator-facade.md
+++ b/docs/frontend/generation-orchestrator-facade.md
@@ -18,8 +18,8 @@ only public entry-point for orchestration capabilities. Raw Pinia stores (for ex
 
 All selectors are reactive Vue references that expose immutable snapshots:
 
-- `jobs`, `activeJobs`, `sortedActiveJobs`, `hasActiveJobs` – queue state, frozen per job.
-- `recentResults`, `historyLimit` – history summaries constrained by the configured limit.
+- `queue`, `jobs`, `activeJobs`, `sortedActiveJobs`, `hasActiveJobs` – queue state, frozen per job.
+- `results`, `recentResults`, `historyLimit` – history summaries constrained by the configured limit.
 - `systemStatus`, `systemStatusReady`, `systemStatusLastUpdated`, `systemStatusApiAvailable`,
   `queueManagerActive` – backend availability and health snapshots.
 - `isActive`, `isConnected`, `pollIntervalMs` – lifecycle markers for the orchestrator and
@@ -30,8 +30,9 @@ All selectors are reactive Vue references that expose immutable snapshots:
   transport telemetry.
 - `lastError`, `lastSnapshot` – the most recent transport error and websocket event snapshot.
 
-Each selector is typed as a `ComputedRef` or `ReadonlyRef`, guaranteeing that consumers cannot
-mutate orchestrator internals directly.
+Each selector is typed as a `ComputedRef` or `ReadonlyRef` that resolves to deeply immutable
+snapshots. Attempting to assign to `facade.queue.value` or `facade.results.value` fails at
+compile-time, preventing accidental mutations of orchestrator internals.
 
 ## Command methods
 


### PR DESCRIPTION
## Summary
- expose deeply readonly queue/results selectors on the generation orchestrator façade and cover them with a TS-only mutation test
- migrate generation UI utilities and the dashboard summary to consume façade selectors/commands instead of public stores
- drop store exports from the generation public barrel and refresh documentation for the façade contract

## Testing
- npm run type-check *(fails: existing Vue TSC issues in the repo)*

------
https://chatgpt.com/codex/tasks/task_e_68dda0bca73c83299413efafb4395195