### PR TITLE
Refactor generation queue access to façade

### DIFF
--- a/app/frontend/src/features/generation/components/JobQueue.vue
+++ b/app/frontend/src/features/generation/components/JobQueue.vue
@@ -81,7 +81,7 @@ import { useJobQueue } from '../composables/useJobQueue';
 import { useJobQueueActions } from '../composables/useJobQueueActions';
 import { formatElapsedTime } from '@/utils/format';
 
-import type { GenerationJob } from '@/types';
+import type { QueueItemView } from '@/features/generation/orchestrator';
 
 interface Props {
   title?: string;
@@ -143,7 +143,7 @@ const getStatusColorClass = (status: string) => {
   }
 };
 
-const getJobDetailsText = (job: GenerationJob) => {
+const getJobDetailsText = (job: QueueItemView) => {
   if (job.params && typeof job.params === 'object') {
     const width = job.params.width ?? '—';
     const height = job.params.height ?? '—';
@@ -153,7 +153,7 @@ const getJobDetailsText = (job: GenerationJob) => {
   return 'Processing…';
 };
 
-const canCancelJob = (job: GenerationJob) => {
+const canCancelJob = (job: QueueItemView) => {
   return job.status === 'queued' || job.status === 'processing';
 };
 

--- a/app/frontend/src/features/generation/composables/useGenerationQueueClient.ts
+++ b/app/frontend/src/features/generation/composables/useGenerationQueueClient.ts
@@ -3,7 +3,7 @@ import { ref, shallowRef } from 'vue';
 import { createGenerationQueueClient, type GenerationQueueClient } from '../services/queueClient';
 import { generationPollingConfig } from '../config/polling';
 import { parseGenerationJobStatuses, parseGenerationResults } from '../services/validation';
-import type { GenerationJobInput } from '../stores/queue';
+import type { GenerationJobInput } from '../stores/useGenerationOrchestratorStore';
 import type {
   GenerationJobStatus,
   GenerationRequestPayload,

--- a/app/frontend/src/features/generation/composables/useGenerationSocketBridge.ts
+++ b/app/frontend/src/features/generation/composables/useGenerationSocketBridge.ts
@@ -2,7 +2,7 @@ import { shallowRef } from 'vue';
 
 import { createGenerationWebSocketManager, type GenerationWebSocketManager } from '../services/websocketManager';
 import { ensureArray } from '../services/validation';
-import type { GenerationJobInput } from '../stores/queue';
+import type { GenerationJobInput } from '../stores/useGenerationOrchestratorStore';
 import type {
   GenerationCompleteMessage,
   GenerationErrorMessage,

--- a/app/frontend/src/features/generation/composables/useGenerationTransport.ts
+++ b/app/frontend/src/features/generation/composables/useGenerationTransport.ts
@@ -1,7 +1,7 @@
 import { extractGenerationErrorMessage } from '../services/updates';
 import type { GenerationQueueClient } from '../services/queueClient';
 import type { GenerationWebSocketManager } from '../services/websocketManager';
-import type { GenerationJobInput } from '../stores/queue';
+import type { GenerationJobInput } from '../stores/useGenerationOrchestratorStore';
 import type {
   GenerationCompleteMessage,
   GenerationErrorMessage,

--- a/app/frontend/src/features/generation/composables/useJobQueue.ts
+++ b/app/frontend/src/features/generation/composables/useJobQueue.ts
@@ -1,14 +1,14 @@
 import { computed } from 'vue';
 
-import { useGenerationOrchestratorManager } from './useGenerationOrchestratorManager';
+import { useGenerationOrchestratorFacade } from '@/features/generation/orchestrator';
 
 export const useJobQueue = () => {
-  const manager = useGenerationOrchestratorManager();
+  const facade = useGenerationOrchestratorFacade();
 
   return {
-    jobs: manager.sortedActiveJobs,
+    jobs: facade.sortedActiveJobs,
     isReady: computed(() => true),
-    queueManagerActive: manager.queueManagerActive,
+    queueManagerActive: facade.queueManagerActive,
   } as const;
 };
 

--- a/app/frontend/src/features/generation/stores/queue.ts
+++ b/app/frontend/src/features/generation/stores/queue.ts
@@ -1,8 +1,2 @@
 /** @internal */
-import { useGenerationOrchestratorStore } from './useGenerationOrchestratorStore';
-
 export type { GenerationJobInput } from './useGenerationOrchestratorStore';
-
-export type GenerationQueueStore = ReturnType<typeof useGenerationOrchestratorStore>;
-
-export const useGenerationQueueStore = (): GenerationQueueStore => useGenerationOrchestratorStore();

--- a/app/frontend/src/features/generation/stores/results.ts
+++ b/app/frontend/src/features/generation/stores/results.ts
@@ -1,8 +1,2 @@
 /** @internal */
-import { useGenerationOrchestratorStore } from './useGenerationOrchestratorStore';
-
 export { MAX_RESULTS, DEFAULT_HISTORY_LIMIT } from './useGenerationOrchestratorStore';
-
-export type GenerationResultsStore = ReturnType<typeof useGenerationOrchestratorStore>;
-
-export const useGenerationResultsStore = (): GenerationResultsStore => useGenerationOrchestratorStore();

--- a/tests/vue/GenerationShell.spec.js
+++ b/tests/vue/GenerationShell.spec.js
@@ -8,8 +8,7 @@ import { mount } from '@vue/test-utils'
 import GenerationShell from '@/features/generation/ui/GenerationShell.vue'
 import { useAppStore } from '../../app/frontend/src/stores/app'
 import { useGenerationFormStore } from '@/features/generation/stores/form'
-import { useGenerationQueueStore } from '@/features/generation/stores/queue'
-import { useGenerationResultsStore } from '@/features/generation/stores/results'
+import { useGenerationOrchestratorStore } from '@/features/generation/stores/useGenerationOrchestratorStore'
 import { useGenerationStudioUiStore } from '@/features/generation/stores/ui'
 import { useGenerationConnectionStore } from '@/features/generation/stores/connection'
 import { PERSISTENCE_KEYS } from '../../app/frontend/src/composables/shared/usePersistence'
@@ -138,8 +137,6 @@ global.fetch = vi.fn()
 describe('GenerationShell.vue', () => {
   let wrapper
   let appStore
-  let queueStore
-  let resultsStore
   let connectionStore
   let formStore
   let uiStore
@@ -148,13 +145,11 @@ describe('GenerationShell.vue', () => {
     vi.clearAllMocks()
     appStore = useAppStore()
     appStore.$reset()
-    queueStore = useGenerationQueueStore()
-    resultsStore = useGenerationResultsStore()
+    const orchestratorStore = useGenerationOrchestratorStore()
     connectionStore = useGenerationConnectionStore()
     formStore = useGenerationFormStore()
     uiStore = useGenerationStudioUiStore()
-    queueStore.resetState()
-    resultsStore.resetState()
+    orchestratorStore.resetState()
     connectionStore.resetState()
     formStore.reset()
     uiStore.reset()

--- a/tests/vue/progressUtils.spec.ts
+++ b/tests/vue/progressUtils.spec.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it } from 'vitest'
 import { createPinia, setActivePinia } from 'pinia'
 
 import { normalizeGenerationProgress } from '../../app/frontend/src/utils/progress.ts'
-import { useGenerationQueueStore } from '../../app/frontend/src/stores/generation/queue.ts'
+import { useGenerationOrchestratorStore } from '../../app/frontend/src/features/generation/stores/useGenerationOrchestratorStore'
 
 describe('normalizeGenerationProgress', () => {
   it('returns 0 for undefined and null values', () => {
@@ -39,7 +39,7 @@ describe('useGenerationQueueStore progress normalization', () => {
   })
 
   it('clamps progress values above 100 received from progress messages', () => {
-    const store = useGenerationQueueStore()
+    const store = useGenerationOrchestratorStore()
 
     store.handleProgressMessage({
       job_id: 'job-1',
@@ -52,7 +52,7 @@ describe('useGenerationQueueStore progress normalization', () => {
   })
 
   it('clamps progress values below 0 received from progress messages', () => {
-    const store = useGenerationQueueStore()
+    const store = useGenerationOrchestratorStore()
 
     store.enqueueJob({ id: 'job-2', status: 'processing', progress: 25 })
 

--- a/tests/vue/useGenerationUI.spec.ts
+++ b/tests/vue/useGenerationUI.spec.ts
@@ -3,7 +3,7 @@ import { createPinia, setActivePinia, storeToRefs } from 'pinia'
 
 import { useGenerationUI } from '@/composables/generation/useGenerationUI'
 import { useGenerationFormStore } from '@/features/generation/stores/form'
-import { useGenerationResultsStore } from '@/features/generation/stores/results'
+import { useGenerationOrchestratorStore } from '@/features/generation/stores/useGenerationOrchestratorStore'
 import { useGenerationStudioUiStore } from '@/features/generation/stores/ui'
 import type { GenerationResult } from '@/types'
 
@@ -12,7 +12,7 @@ describe('useGenerationUI', () => {
     setActivePinia(createPinia())
     useGenerationFormStore().reset()
     useGenerationStudioUiStore().reset()
-    useGenerationResultsStore().reset()
+    useGenerationOrchestratorStore().resetState()
   })
 
   it('applies parameters through the store when reusing results', () => {

--- a/tests/vue/useHistoryShortcuts.spec.ts
+++ b/tests/vue/useHistoryShortcuts.spec.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { computed, ref } from 'vue';
 import { createPinia, setActivePinia } from 'pinia';
 
-import { useGenerationResultsStore } from '../../app/frontend/src/stores/generation/results';
+import { useGenerationOrchestratorStore } from '../../app/frontend/src/features/generation/stores/useGenerationOrchestratorStore';
 import { useHistoryShortcuts } from '../../app/frontend/src/composables/history/useHistoryShortcuts';
 
 describe('useHistoryShortcuts', () => {
@@ -11,7 +11,7 @@ describe('useHistoryShortcuts', () => {
   });
 
   it('selects all items when ctrl+a is pressed for large result sets', () => {
-    const store = useGenerationResultsStore();
+    const store = useGenerationOrchestratorStore();
     const results = Array.from({ length: 1000 }, (_, index) => ({
       id: index + 1,
       prompt: `item-${index + 1}`,


### PR DESCRIPTION
## Summary
- route job queue state and actions through the generation orchestrator façade so queue interactions are immutable and centralized
- remove the exported queue/results store helpers in favour of façade types and adjust JobQueue UI to consume read-only queue items
- update generation tests to work with the façade-backed orchestrator store helpers

## Testing
- npm run type-check *(fails: pre-existing TypeScript errors across unrelated modules)*
- npx vitest run tests/vue/useJobQueueActions.spec.ts *(fails: Vite alias resolution issue for @/features/generation/orchestrator during isolated test run)*

------
https://chatgpt.com/codex/tasks/task_e_68ddb2be0efc8329921f5d2fc49d31e3