### PR TITLE
feat(generation): centralize auto sync options for studio manager

### DIFF
--- a/app/frontend/src/features/generation/composables/useGenerationStudio.ts
+++ b/app/frontend/src/features/generation/composables/useGenerationStudio.ts
@@ -3,12 +3,17 @@ import { computed } from 'vue'
 import { useGenerationPersistence } from './useGenerationPersistence'
 import { useGenerationUI } from './useGenerationUI'
 import { useGenerationStudioController } from './useGenerationStudioController'
+import type { GenerationOrchestratorAutoSyncOptions } from './useGenerationOrchestratorManager'
 import { useGenerationStudioNotifications } from './useGenerationStudioNotifications'
 import { useGenerationFormStore } from '../stores/form'
 import { useAsyncLifecycleTask } from '@/composables/shared'
 import type { GenerationFormState } from '@/types'
 
-export const useGenerationStudio = () => {
+export interface UseGenerationStudioOptions {
+  autoSync?: boolean | GenerationOrchestratorAutoSyncOptions
+}
+
+export const useGenerationStudio = ({ autoSync = true }: UseGenerationStudioOptions = {}) => {
   const formStore = useGenerationFormStore()
 
   const { notify, confirm: requestConfirmation, prompt: requestPrompt, logDebug } =
@@ -49,6 +54,7 @@ export const useGenerationStudio = () => {
     debug: logDebug,
     onAfterStart: persistParams,
     onAfterInitialize: loadParams,
+    autoSync,
   })
 
   const params = computed(() => uiParams.value)

--- a/app/frontend/src/features/generation/composables/useGenerationStudioController.ts
+++ b/app/frontend/src/features/generation/composables/useGenerationStudioController.ts
@@ -4,6 +4,7 @@ import { toGenerationRequestPayload } from '../services/generationService'
 import {
   useGenerationOrchestratorManager,
   type GenerationOrchestratorBinding,
+  type GenerationOrchestratorAutoSyncOptions,
 } from './useGenerationOrchestratorManager'
 import { useGenerationFormStore } from '../stores/form'
 import type { GenerationFormState, NotificationType, GenerationJob } from '@/types'
@@ -14,6 +15,7 @@ export interface UseGenerationStudioControllerOptions {
   debug?: (...args: unknown[]) => void
   onAfterStart?: (params: GenerationFormState) => void
   onAfterInitialize?: () => void | Promise<void>
+  autoSync?: boolean | GenerationOrchestratorAutoSyncOptions
 }
 
 export const useGenerationStudioController = ({
@@ -22,6 +24,7 @@ export const useGenerationStudioController = ({
   debug,
   onAfterStart,
   onAfterInitialize,
+  autoSync = true,
 }: UseGenerationStudioControllerOptions) => {
   const formStore = useGenerationFormStore()
   const orchestratorManager = useGenerationOrchestratorManager()
@@ -32,6 +35,7 @@ export const useGenerationStudioController = ({
       orchestratorBinding.value = orchestratorManager.acquire({
         notify,
         debug,
+        autoSync,
       })
     }
 

--- a/app/frontend/src/features/generation/stores/orchestratorManagerStore.ts
+++ b/app/frontend/src/features/generation/stores/orchestratorManagerStore.ts
@@ -9,6 +9,8 @@ export interface GenerationOrchestratorConsumer {
   id: symbol;
   notify: GenerationNotificationAdapter['notify'];
   debug?: GenerationNotificationAdapter['debug'];
+  autoSyncHistory: boolean;
+  autoSyncBackend: boolean;
 }
 
 export const useGenerationOrchestratorManagerStore = defineStore('generation-orchestrator-manager', () => {

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -14,6 +14,10 @@ export default defineConfig({
         replacement: resolve(frontendSrc, 'features/generation/composables'),
       },
       {
+        find: '@/features/generation/orchestrator',
+        replacement: resolve(frontendSrc, 'features/generation/orchestrator/facade.ts'),
+      },
+      {
         find: '@',
         replacement: frontendSrc,
       },


### PR DESCRIPTION
## Summary
- add auto-sync option handling to the generation orchestrator manager and controller, deduplicating history/backend watchers across consumers
- extend useGenerationStudio to accept auto-sync configuration flags that default to enabled for shared behaviour
- update unit/integration tests and Vitest config to cover multi-consumer scenarios and new options

## Testing
- npx vitest run tests/vue/composables/useGenerationStudioController.spec.ts tests/vue/composables/useGenerationStudio.integration.spec.ts tests/vue/composables/useGenerationOrchestratorManager.integration.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68ddb6267c58832987432408800e9957