### PR TITLE
Use feature public barrels for dashboard panels

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -6,6 +6,12 @@ const generationStoreRestriction = {
     'Generation stores are internal. Import `useGenerationOrchestratorFacade` from "@/features/generation/orchestrator" instead.',
 };
 
+const featureUiRestriction = {
+  group: ['@/features/*/ui', '@/features/*/ui/**'],
+  message:
+    'Import feature UI modules via the public surface, e.g. "@/features/<feature>/public".',
+};
+
 const restrictedImportRuleConfig = {
   paths: [
     {
@@ -78,6 +84,7 @@ const restrictedImportRuleConfig = {
         'Import the import/export feature through "@/features/import-export/public" instead of the legacy components path.',
     },
     generationStoreRestriction,
+    featureUiRestriction,
   ],
 };
 

--- a/app/frontend/src/router/index.ts
+++ b/app/frontend/src/router/index.ts
@@ -26,7 +26,7 @@ const router = createRouter({
     {
       path: '/compose',
       name: 'compose',
-      component: () => import('@/features/prompt-composer/ui/ComposeView.vue'),
+      component: () => import('@/features/prompt-composer/public').then((module) => module.ComposeView),
     },
     {
       path: '/generate',

--- a/app/frontend/src/views/DashboardView.vue
+++ b/app/frontend/src/views/DashboardView.vue
@@ -123,7 +123,7 @@ const panelConfigs = [
       'Activate the composer inline to reuse saved prompts or jump directly to the full composition workspace.',
     fallback: 'Loading prompt composer…',
     loader: () =>
-      import('@/features/prompt-composer/ui/PromptComposer.vue').then((module) => module.default),
+      import('@/features/prompt-composer/public').then((module) => module.PromptComposer),
   },
   {
     key: 'studio',
@@ -134,7 +134,7 @@ const panelConfigs = [
     placeholder:
       'Use the inline studio for quick jobs or switch to the dedicated page for the full orchestrator experience.',
     fallback: 'Loading generation studio…',
-    loader: () => import('@/features/generation/ui/GenerationShell.vue').then((module) => module.default),
+    loader: () => import('@/features/generation/public').then((module) => module.GenerationShell),
   },
   {
     key: 'gallery',
@@ -145,7 +145,7 @@ const panelConfigs = [
     placeholder:
       'Quickly browse the gallery inline or open the dedicated gallery for the full management toolkit.',
     fallback: 'Loading LoRA gallery…',
-    loader: () => import('@/features/lora/components/lora-gallery/LoraGallery.vue').then((module) => module.default),
+    loader: () => import('@/features/lora/public').then((module) => module.LoraGallery),
   },
   {
     key: 'history',
@@ -168,7 +168,7 @@ const panelConfigs = [
       'Bring the import/export utilities inline for quick actions or open the dedicated workspace for bulk jobs.',
     fallback: 'Loading import/export tools…',
     loader: () =>
-      import('@/features/import-export/ui/ImportExportContainer').then((module) => module.default),
+      import('@/features/import-export/public').then((module) => module.ImportExportContainer),
   },
 ] satisfies PanelConfig[];
 

--- a/app/frontend/src/views/ImportExportView.vue
+++ b/app/frontend/src/views/ImportExportView.vue
@@ -27,7 +27,7 @@ import PageHeader from '@/components/layout/PageHeader.vue';
 import { ImportExportSkeleton } from '@/features/import-export/public';
 
 const LazyImportExportContainer = defineAsyncComponent({
-  loader: () => import('@/features/import-export/ui/ImportExportContainer'),
+  loader: () => import('@/features/import-export/public').then((module) => module.ImportExportContainer),
   loadingComponent: ImportExportSkeleton,
   delay: 0,
   suspensible: false


### PR DESCRIPTION
## Summary
- update dashboard dashboard and related routes to lazy-load feature panels via their public barrels
- add an ESLint restriction to guard against importing feature UI modules directly

## Testing
- npm run lint *(fails: @typescript-eslint does not support the bundled TypeScript 5.9.2 in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ddc7b101488329a0425ed76b5db54c