### PR TITLE
Delay backend environment readiness until settings load

### DIFF
--- a/app/frontend/src/features/recommendations/composables/useRecommendations.ts
+++ b/app/frontend/src/features/recommendations/composables/useRecommendations.ts
@@ -90,7 +90,7 @@ export const useRecommendations = (options: UseRecommendationsOptions = {}) => {
   const weights = ref<WeightState>({ ...DEFAULT_WEIGHTS, ...(options.initialWeights ?? {}) });
 
   const hydrationReady = ref(false);
-  void backendEnvironment.readyPromise.then(() => {
+  void backendEnvironment.ensureReady().then(() => {
     hydrationReady.value = true;
   });
 


### PR DESCRIPTION
## Summary
- gate the backend environment readiness promise on the first settings load and expose an ensureReady helper
- update useBackendEnvironment and the recommendations composable to use the helper
- expand the recommendations composable tests to cover readiness gating and mock the recommendations service

## Testing
- npm run test -- useRecommendations

------
https://chatgpt.com/codex/tasks/task_e_68ddc827e8508329985a75ea91e95284