### PR TITLE
Add frontend guardrails and bundle budget checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,13 @@ jobs:
         run: npm ci
       - name: Run unified quality workflow
         run: npm run ci:check
+      - name: Upload dashboard bundle report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: dashboard-bundle-report
+          path: app/dist/bundle-inspector.json
+          if-no-files-found: ignore
 
   node-modules-sanity:
     name: Ensure node_modules directory is absent

--- a/app/frontend/src/components/dashboard/DashboardGenerationSummary.vue
+++ b/app/frontend/src/components/dashboard/DashboardGenerationSummary.vue
@@ -98,7 +98,7 @@ import { storeToRefs } from 'pinia';
 import { RouterLink } from 'vue-router';
 
 import { useBackendClient } from '@/services/backendClient';
-import { listResults as listHistoryResults } from '@/features/history/services';
+import { listResults as listHistoryResults } from '@/features/history/public';
 import { useGenerationOrchestratorFacade } from '@/features/generation/public';
 import { formatFileSize, formatRelativeTime } from '@/utils/format';
 import { mapGenerationResultsToHistory } from '@/utils/generationHistory';

--- a/app/frontend/src/services/system/systemService.ts
+++ b/app/frontend/src/services/system/systemService.ts
@@ -7,35 +7,31 @@ import type {
   SystemMetricsSnapshot,
   SystemStatusPayload,
 } from '@/types';
-import { requestConfiguredJson, type ApiRequestConfig } from '@/services/apiClient';
+import { performConfiguredRequest, type ApiRequestConfig } from '@/services/apiClient';
 
 const createRequestConfig = (path: string, client?: BackendClient | null): ApiRequestConfig => ({
   target: resolveBackendPath(path, client ?? undefined),
   init: withSameOrigin(),
 });
 
-export const loadFrontendSettings = async (): Promise<FrontendRuntimeSettings | null> => {
-  const result = await requestConfiguredJson<FrontendRuntimeSettings>(createRequestConfig('/frontend/settings'));
-  return (result.data as FrontendRuntimeSettings | null) ?? null;
+const requestBackendJson = async <TPayload>(
+  path: string,
+  client?: BackendClient | null,
+): Promise<TPayload | null> => {
+  const result = await performConfiguredRequest<TPayload>(createRequestConfig(path, client));
+  return (result.data as TPayload | null) ?? null;
 };
+
+export const loadFrontendSettings = async (): Promise<FrontendRuntimeSettings | null> =>
+  requestBackendJson<FrontendRuntimeSettings>('/frontend/settings');
 
 export const fetchDashboardStats = async (
   client?: BackendClient | null,
-): Promise<DashboardStatsSummary | null> => {
-  const result = await requestConfiguredJson<DashboardStatsSummary>(
-    createRequestConfig('/dashboard/stats', client),
-  );
-  return (result.data as DashboardStatsSummary | null) ?? null;
-};
+): Promise<DashboardStatsSummary | null> => requestBackendJson<DashboardStatsSummary>('/dashboard/stats', client);
 
 export const fetchSystemStatus = async (
   client?: BackendClient | null,
-): Promise<SystemStatusPayload | null> => {
-  const result = await requestConfiguredJson<SystemStatusPayload>(
-    createRequestConfig('/system/status', client),
-  );
-  return (result.data as SystemStatusPayload | null) ?? null;
-};
+): Promise<SystemStatusPayload | null> => requestBackendJson<SystemStatusPayload>('/system/status', client);
 
 export const emptyMetricsSnapshot = (): SystemMetricsSnapshot => ({
   cpu_percent: 0,

--- a/tests/guardrails/forbidden_backend_client.ts
+++ b/tests/guardrails/forbidden_backend_client.ts
@@ -1,0 +1,4 @@
+// This file intentionally exercises the BackendClient restriction guardrail.
+import { useBackendClient } from '@/services/backendClient';
+
+void useBackendClient;

--- a/tests/guardrails/forbidden_feature_internal.ts
+++ b/tests/guardrails/forbidden_feature_internal.ts
@@ -1,0 +1,2 @@
+// This file intentionally violates the feature encapsulation guardrail.
+import '@/features/history/services/historyService';

--- a/tests/guardrails/forbidden_request_configured_json.ts
+++ b/tests/guardrails/forbidden_request_configured_json.ts
@@ -1,0 +1,4 @@
+// This file intentionally exercises the requestConfiguredJson restriction guardrail.
+import { requestConfiguredJson } from '@/services/apiClient';
+
+void requestConfiguredJson;


### PR DESCRIPTION
## Summary
- extend the ESLint configuration with dynamic feature-boundary enforcement, backend client restrictions, and guardrail fixtures
- harden the consolidated CI check script with legacy import greps and fitness tests, and update system services to avoid deprecated helpers
- publish the dashboard bundle inspector artifact during CI and ensure dashboard imports use public feature surfaces

## Testing
- python scripts/ci_check.py

------
https://chatgpt.com/codex/tasks/task_e_68ddeff154cc832987eaa219ea24847b