### PR TITLE
Centralize backend config normalization and readiness updates

### DIFF
--- a/app/frontend/src/config/backendSettings.ts
+++ b/app/frontend/src/config/backendSettings.ts
@@ -1,10 +1,8 @@
-const normaliseApiKey = (value?: string | null): string | null => {
-  if (value == null) {
-    return null;
-  }
+import { normalizeBackendConfig } from '@/shared/config/backendConfig';
 
-  const trimmed = `${value}`.trim();
-  return trimmed.length > 0 ? trimmed : null;
+const normaliseApiKey = (value?: string | null): string | null => {
+  const { apiKey } = normalizeBackendConfig({ apiKey: value });
+  return apiKey;
 };
 
 let backendApiKey: string | null = null;

--- a/app/frontend/src/shared/config/backendConfig.ts
+++ b/app/frontend/src/shared/config/backendConfig.ts
@@ -1,0 +1,58 @@
+import { z } from 'zod';
+
+import { sanitizeBackendBaseUrl } from '@/utils/backend/helpers';
+
+const RawBackendConfigSchema = z
+  .union([
+    z
+      .object({
+        baseURL: z.unknown().optional(),
+        backendUrl: z.unknown().optional(),
+        apiKey: z.unknown().optional(),
+        backendApiKey: z.unknown().optional(),
+      })
+      .passthrough(),
+    z.null(),
+    z.undefined(),
+  ])
+  .optional()
+  .default({});
+
+const NormalizedBackendConfigSchema = z.object({
+  baseURL: z.string(),
+  apiKey: z.string().nullable(),
+});
+
+const toNullableString = (value: unknown): string | null => {
+  if (value == null) {
+    return null;
+  }
+
+  const trimmed = String(value).trim();
+  return trimmed.length > 0 ? trimmed : null;
+};
+
+export const normalizeBackendConfig = (
+  raw: unknown,
+): z.infer<typeof NormalizedBackendConfigSchema> => {
+  const parsed = RawBackendConfigSchema.parse(raw) as {
+    baseURL?: unknown;
+    backendUrl?: unknown;
+    apiKey?: unknown;
+    backendApiKey?: unknown;
+  };
+
+  const baseCandidate = parsed.baseURL ?? parsed.backendUrl;
+  const baseURL = sanitizeBackendBaseUrl(
+    baseCandidate == null ? undefined : String(baseCandidate),
+  );
+
+  const apiKey = toNullableString(parsed.apiKey ?? parsed.backendApiKey ?? null);
+
+  return NormalizedBackendConfigSchema.parse({
+    baseURL,
+    apiKey,
+  });
+};
+
+export type NormalizedBackendConfig = z.infer<typeof NormalizedBackendConfigSchema>;


### PR DESCRIPTION
## Summary
- add a shared Zod-backed normalizer for backend base URLs and API keys
- refactor the backend environment service and settings store to use the shared normalizer and epoch-based readiness promises
- extend the settings store test suite to cover stale readiness rejection

## Testing
- npm run test:unit -- tests/vue/stores/settingsStore.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68ddf40a56508329b8e68dc644b2b4a4