### PR TITLE
Pause generation transport when hidden or offline

### DIFF
--- a/app/frontend/src/features/generation/composables/createGenerationTransportAdapter.ts
+++ b/app/frontend/src/features/generation/composables/createGenerationTransportAdapter.ts
@@ -14,6 +14,8 @@ import type {
 } from '@/types';
 import type {
   GenerationTransportError,
+  GenerationTransportPausePayload,
+  GenerationTransportResumePayload,
   GenerationWebSocketStateSnapshot,
 } from '../types/transport';
 
@@ -48,6 +50,12 @@ export interface GenerationTransportAdapter {
   deleteResult: ReturnType<typeof useGenerationTransport>['deleteResult'];
   reconnect: () => void;
   setPollInterval: (interval: number) => void;
+  pause: (payload: GenerationTransportPausePayload) => void;
+  resume: (
+    historyLimit: number,
+    payload: GenerationTransportResumePayload,
+  ) => Promise<void>;
+  isPaused: () => boolean;
   clear: () => void;
 }
 
@@ -114,6 +122,10 @@ export const createGenerationTransportAdapter = (
     deleteResult: transport.deleteResult,
     reconnect: () => transport.reconnectUpdates(),
     setPollInterval: (interval: number) => transport.setPollInterval(interval),
+    pause: (payload: GenerationTransportPausePayload) => transport.pauseUpdates(payload),
+    resume: (historyLimit: number, payload: GenerationTransportResumePayload) =>
+      transport.resumeUpdates(historyLimit, payload),
+    isPaused: () => transport.isPaused(),
     clear: () => {
       transport.clear();
     },

--- a/app/frontend/src/features/generation/composables/useGenerationQueueClient.ts
+++ b/app/frontend/src/features/generation/composables/useGenerationQueueClient.ts
@@ -269,6 +269,7 @@ export const useGenerationQueueClient = (
     pollInterval,
     setPollInterval,
     initialize,
+    startPolling,
     stopPolling,
     refreshSystemStatus,
     refreshActiveJobs,

--- a/app/frontend/src/features/generation/orchestrator/facade.ts
+++ b/app/frontend/src/features/generation/orchestrator/facade.ts
@@ -15,7 +15,10 @@ import type { DeepReadonly } from '@/utils/freezeDeep';
 import type {
   GenerationTransportError,
   GenerationTransportMetricsSnapshot,
+  GenerationTransportPausePayload,
+  GenerationTransportPauseReason,
   GenerationTransportPhase,
+  GenerationTransportResumePayload,
   GenerationWebSocketStateSnapshot,
 } from '../types/transport';
 import { useBackendUrl } from '@/utils/backend';
@@ -65,6 +68,11 @@ export interface GenerationOrchestratorFacadeSelectors {
   readonly transportLastDisconnectedAt: ReadonlyRef<number | null>;
   readonly transportDowntimeMs: ReadonlyRef<number | null>;
   readonly transportTotalDowntimeMs: ReadonlyRef<number>;
+  readonly transportPaused: ReadonlyRef<boolean>;
+  readonly transportPauseReasons: ReadonlyRef<readonly GenerationTransportPauseReason[]>;
+  readonly transportPauseSince: ReadonlyRef<number | null>;
+  readonly transportLastPauseEvent: ReadonlyRef<GenerationTransportPausePayload | null>;
+  readonly transportLastResumeEvent: ReadonlyRef<GenerationTransportResumePayload | null>;
   readonly lastError: ReadonlyRef<GenerationTransportError | null>;
   readonly lastSnapshot: ReadonlyRef<GenerationWebSocketStateSnapshot | null>;
   readonly lastCommandError: ReadonlyRef<Error | null>;
@@ -172,6 +180,11 @@ const createStoreBackedManager = (
     transportLastDisconnectedAt,
     transportDowntimeMs,
     transportTotalDowntimeMs,
+    transportPaused,
+    transportPauseReasons,
+    transportPauseSince,
+    transportLastPauseEvent,
+    transportLastResumeEvent,
     transportLastError,
     transportLastSnapshot,
   } = storeToRefs(store);
@@ -465,6 +478,11 @@ const createStoreBackedManager = (
     transportLastDisconnectedAt,
     transportDowntimeMs,
     transportTotalDowntimeMs,
+    transportPaused,
+    transportPauseReasons,
+    transportPauseSince,
+    transportLastPauseEvent,
+    transportLastResumeEvent,
     lastError: transportLastError,
     lastSnapshot: transportLastSnapshot,
     lastCommandError: lastCommandErrorReadonly,

--- a/app/frontend/src/features/generation/types/transport.ts
+++ b/app/frontend/src/features/generation/types/transport.ts
@@ -3,7 +3,25 @@ export type GenerationTransportPhase =
   | 'connecting'
   | 'connected'
   | 'disconnected'
-  | 'reconnecting';
+  | 'reconnecting'
+  | 'paused';
+
+export type GenerationTransportPauseReason = 'document-hidden' | 'network-offline';
+
+export interface GenerationTransportPausePayload {
+  reasons: readonly GenerationTransportPauseReason[];
+  hidden: boolean;
+  online: boolean;
+  source: string;
+  timestamp: number;
+}
+
+export interface GenerationTransportResumePayload {
+  hidden: boolean;
+  online: boolean;
+  source: string;
+  timestamp: number;
+}
 
 export type GenerationWebSocketEventName =
   | 'connect:start'
@@ -57,4 +75,9 @@ export interface GenerationTransportMetricsSnapshot {
   totalDowntimeMs: number;
   lastError: GenerationTransportError | null;
   lastEvent: GenerationWebSocketStateSnapshot | null;
+  paused: boolean;
+  pauseReasons: readonly GenerationTransportPauseReason[];
+  pauseSince: number | null;
+  lastPauseEvent: GenerationTransportPausePayload | null;
+  lastResumeEvent: GenerationTransportResumePayload | null;
 }


### PR DESCRIPTION
## Summary
- pause generation polling and WebSocket transport when the document is hidden or the browser is offline, resuming with structured lifecycle logs when visibility or connectivity returns
- extend the generation transport adapter and store to expose pause/resume controls and metrics for downstream consumers
- refresh transport data and restart polling deterministically after a resume so queue state stays current

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ddf40fd62883298b3aaed2b1c36367