### PR TITLE
Ensure generation facade snapshots are immutable and translate job identifiers

### DIFF
--- a/app/frontend/src/features/generation/orchestrator/utils/immutableSnapshots.ts
+++ b/app/frontend/src/features/generation/orchestrator/utils/immutableSnapshots.ts
@@ -1,0 +1,117 @@
+import type { DeepReadonly } from '@/utils/freezeDeep';
+
+interface ImmutableSnapshotOptions {
+  readonly depth?: number;
+}
+
+const DEFAULT_DEPTH = 2;
+
+const resolveBooleanFlag = (value: unknown): boolean => {
+  if (typeof value === 'boolean') {
+    return value;
+  }
+
+  if (typeof value === 'string') {
+    const normalized = value.trim().toLowerCase();
+    if (normalized === 'false' || normalized === '0' || normalized === '') {
+      return false;
+    }
+    return true;
+  }
+
+  return Boolean(value);
+};
+
+const isDevEnvironment = (): boolean => {
+  try {
+    const env = import.meta.env ?? {};
+    if (resolveBooleanFlag(env.PROD ?? false)) {
+      return false;
+    }
+    return resolveBooleanFlag(env.DEV ?? false);
+  } catch (_error) {
+    return false;
+  }
+};
+
+const cloneValue = <T>(value: T, depth: number): T => {
+  if (Array.isArray(value)) {
+    const cloned = (value as unknown[]).map((item) =>
+      depth > 0 ? cloneValue(item, depth - 1) : item,
+    );
+    return cloned as unknown as T;
+  }
+
+  if (value instanceof Date) {
+    return new Date(value.getTime()) as unknown as T;
+  }
+
+  if (value && typeof value === 'object') {
+    const clonedObject: Record<PropertyKey, unknown> = {};
+    for (const [key, entry] of Object.entries(value as Record<string, unknown>)) {
+      clonedObject[key] = depth > 0 ? cloneValue(entry, depth - 1) : entry;
+    }
+    return clonedObject as unknown as T;
+  }
+
+  return value;
+};
+
+const trapMutations = <T>(value: T, label: string, depth: number): T => {
+  if (!isDevEnvironment()) {
+    return value;
+  }
+
+  if (Array.isArray(value)) {
+    const arrayValue = value as unknown as unknown[];
+    if (depth > 0) {
+      arrayValue.forEach((item, index) => {
+        arrayValue[index] = trapMutations(item, `${label}[${index}]`, depth - 1);
+      });
+    }
+    return Object.freeze(arrayValue) as unknown as T;
+  }
+
+  if (value instanceof Date || value === null || typeof value !== 'object') {
+    return value;
+  }
+
+  const recordValue = value as Record<string, unknown>;
+  if (depth > 0) {
+    Object.entries(recordValue).forEach(([key, entry]) => {
+      recordValue[key] = trapMutations(entry, `${label}.${key}`, depth - 1);
+    });
+  }
+
+  return Object.freeze(recordValue) as unknown as T;
+};
+
+const createImmutableSnapshotInternal = <T>(
+  value: T,
+  label: string,
+  { depth = DEFAULT_DEPTH }: ImmutableSnapshotOptions = {},
+): T => {
+  const cloned = cloneValue(value, depth);
+  return trapMutations(cloned, label, depth);
+};
+
+export const createImmutableArraySnapshot = <T>(
+  source: readonly T[],
+  label: string,
+  options?: ImmutableSnapshotOptions,
+): readonly DeepReadonly<T>[] =>
+  createImmutableSnapshotInternal(source, label, options) as readonly DeepReadonly<T>[];
+
+export const createImmutableObjectSnapshot = <T extends Record<string, unknown>>(
+  source: T,
+  label: string,
+  options?: ImmutableSnapshotOptions,
+): DeepReadonly<T> =>
+  createImmutableSnapshotInternal(source, label, options) as DeepReadonly<T>;
+
+export const createImmutableValueSnapshot = <T>(
+  value: T,
+  label: string,
+  options?: ImmutableSnapshotOptions,
+): T => createImmutableSnapshotInternal(value, label, options);
+

--- a/app/frontend/src/features/generation/stores/useGenerationOrchestratorStore.ts
+++ b/app/frontend/src/features/generation/stores/useGenerationOrchestratorStore.ts
@@ -20,7 +20,8 @@ import type {
   GenerationTransportResumePayload,
   GenerationWebSocketStateSnapshot,
 } from '../types/transport';
-import { freezeDeep, type DeepReadonly } from '@/utils/freezeDeep';
+import type { DeepReadonly } from '@/utils/freezeDeep';
+import { createImmutableArraySnapshot, createImmutableObjectSnapshot } from '../orchestrator/utils/immutableSnapshots';
 
 export type { GenerationJobInput } from './orchestrator/queueModule';
 export { MAX_RESULTS, DEFAULT_HISTORY_LIMIT } from './orchestrator/resultsModule';
@@ -126,20 +127,32 @@ export const useGenerationOrchestratorStore = defineStore('generation-orchestrat
     const transportLastPauseEvent = transportModule.lastPauseEvent;
     const transportLastResumeEvent = transportModule.lastResumeEvent;
 
-    const jobs = computed(() => freezeDeep(queue.jobs.value as GenerationJob[]) as ImmutableJobs);
+    const jobs = computed(() =>
+      createImmutableArraySnapshot(queue.jobs.value as GenerationJob[], 'generation-orchestrator.jobs') as ImmutableJobs,
+    );
     const jobsByUiId = computed(() => queue.jobsByUiId.value);
     const jobsByBackendId = computed(() => queue.jobsByBackendId.value);
-    const activeJobs = computed(
-      () => freezeDeep(queue.activeJobs.value as GenerationJob[]) as ImmutableJobs,
+    const activeJobs = computed(() =>
+      createImmutableArraySnapshot(queue.activeJobs.value as GenerationJob[], 'generation-orchestrator.activeJobs') as ImmutableJobs,
     );
-    const sortedActiveJobs = computed(
-      () => freezeDeep(queue.sortedActiveJobs.value as GenerationJob[]) as ImmutableJobs,
+    const sortedActiveJobs = computed(() =>
+      createImmutableArraySnapshot(
+        queue.sortedActiveJobs.value as GenerationJob[],
+        'generation-orchestrator.sortedActiveJobs',
+      ) as ImmutableJobs,
     );
     const recentResults = computed(() =>
-      freezeDeep(resultsPublic.recentResults.value as GenerationResult[]) as ImmutableResults,
+      createImmutableArraySnapshot(
+        resultsPublic.recentResults.value as GenerationResult[],
+        'generation-orchestrator.recentResults',
+      ) as ImmutableResults,
     );
     const systemStatus = computed(
-      () => freezeDeep(systemStatusModule.systemStatus) as ImmutableSystemStatus,
+      () =>
+        createImmutableObjectSnapshot(
+          systemStatusModule.systemStatus as SystemStatusState,
+          'generation-orchestrator.systemStatus',
+        ) as ImmutableSystemStatus,
     );
 
     const isActiveState = readonly(isActive);


### PR DESCRIPTION
## Summary
- add reusable immutable snapshot utilities that clone facade data shallowly and trap mutations in development
- expose generation store selectors through snapshot helpers to deliver read-only queue, result, and status views
- extend orchestrator store tests to cover backend ID translation and immutable snapshots across dev and production environments

## Testing
- npm run test -- --run tests/vue/stores/useGenerationOrchestratorStore.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68ddf831e71883298c5b29bdb862b4c3