### PR TITLE
Refactor generation orchestrator manager into modular composables

### DIFF
--- a/app/frontend/src/features/generation/composables/useGenerationOrchestratorManager.ts
+++ b/app/frontend/src/features/generation/composables/useGenerationOrchestratorManager.ts
@@ -1,54 +1,18 @@
-/** @internal */
-import {
-  computed,
-  effectScope,
-  shallowRef,
-  watch,
-  type ComputedRef,
-  type EffectScope,
-  type Ref,
-  type WatchStopHandle,
-} from 'vue';
 import { storeToRefs } from 'pinia';
+import { type ComputedRef } from 'vue';
 
-import type { GenerationNotificationAdapter } from './useGenerationTransport';
-import type { GenerationQueueClient } from '../services/queueClient';
-import type { GenerationWebSocketManager } from '../services/websocketManager';
+import { useOrchestratorConsumers } from './useOrchestratorConsumers';
+import { useOrchestratorEffects } from './useOrchestratorEffects';
+import { useOrchestratorLifecycle } from './useOrchestratorLifecycle';
+import { useOrchestratorCommands } from './useOrchestratorCommands';
 import {
-  useGenerationOrchestratorManagerStore,
-  type GenerationOrchestratorConsumer,
-} from '../stores/orchestratorManagerStore';
-import {
-  useGenerationOrchestratorStore,
-  DEFAULT_HISTORY_LIMIT,
-} from '../stores/useGenerationOrchestratorStore';
+  type GenerationOrchestratorAcquireOptions,
+  type GenerationOrchestratorAutoSyncOptions,
+  type GenerationOrchestratorBinding,
+} from './useGenerationOrchestratorManager.types';
+import { useGenerationOrchestratorManagerStore } from '../stores/orchestratorManagerStore';
+import { useGenerationOrchestratorStore } from '../stores/useGenerationOrchestratorStore';
 import { useBackendUrl } from '@/utils/backend';
-import type {
-  GenerationRequestPayload,
-  GenerationStartResponse,
-  SystemStatusState,
-} from '@/types';
-import type { DeepReadonly } from '@/utils/freezeDeep';
-import type { GenerationJobView, GenerationResultView } from '../orchestrator/facade';
-import type {
-  GenerationTransportPausePayload,
-  GenerationTransportPauseReason,
-  GenerationTransportResumePayload,
-} from '../types/transport';
-
-export interface GenerationOrchestratorAcquireOptions {
-  notify: GenerationNotificationAdapter['notify'];
-  debug?: GenerationNotificationAdapter['debug'];
-  queueClient?: GenerationQueueClient;
-  websocketManager?: GenerationWebSocketManager;
-  autoSync?: boolean | GenerationOrchestratorAutoSyncOptions;
-  historyVisibility?: Readonly<Ref<boolean>>;
-}
-
-export interface GenerationOrchestratorAutoSyncOptions {
-  historyLimit?: boolean;
-  backendUrl?: boolean;
-}
 
 const normalizeAutoSyncOptions = (
   value: GenerationOrchestratorAcquireOptions['autoSync'],
@@ -81,75 +45,53 @@ const defaultDependencies: UseGenerationOrchestratorManagerDependencies = {
   useBackendUrl,
 };
 
-export interface GenerationOrchestratorBinding {
-  activeJobs: Ref<ReadonlyArray<GenerationJobView>>;
-  sortedActiveJobs: Ref<ReadonlyArray<GenerationJobView>>;
-  recentResults: Ref<ReadonlyArray<GenerationResultView>>;
-  systemStatus: Ref<DeepReadonly<SystemStatusState>>;
-  isConnected: Ref<boolean>;
-  initialize: () => Promise<void>;
-  cleanup: () => void;
-  loadSystemStatusData: () => Promise<void>;
-  loadActiveJobsData: () => Promise<void>;
-  loadRecentResultsData: (notifySuccess?: boolean) => Promise<void>;
-  startGeneration: (payload: GenerationRequestPayload) => Promise<GenerationStartResponse>;
-  cancelJob: (jobId: string) => Promise<void>;
-  clearQueue: () => Promise<void>;
-  deleteResult: (resultId: string | number) => Promise<void>;
-  refreshResults: (notifySuccess?: boolean) => Promise<void>;
-  canCancelJob: (job: GenerationJobView) => boolean;
-  setHistoryLimit: (limit: number) => void;
-  handleBackendUrlChange: () => Promise<void>;
-  release: () => void;
-}
-
-export const HISTORY_LIMIT_WHEN_SHOWING = 50;
-
 export const createUseGenerationOrchestratorManager = (
   dependencies: UseGenerationOrchestratorManagerDependencies = defaultDependencies,
 ) => () => {
   const orchestratorManagerStore = dependencies.useGenerationOrchestratorManagerStore();
   const orchestratorStore = dependencies.useGenerationOrchestratorStore();
-  const { initializationPromise, isInitialized, consumers } = storeToRefs(orchestratorManagerStore);
-  const historyVisibilityRefs = shallowRef(new Map<symbol, Readonly<Ref<boolean>>>());
-
-  const registerHistoryVisibilityRef = (
-    consumerId: symbol,
-    visibility: Readonly<Ref<boolean>> | undefined,
-  ): void => {
-    if (!visibility) {
-      return;
-    }
-
-    const next = new Map(historyVisibilityRefs.value);
-    next.set(consumerId, visibility);
-    historyVisibilityRefs.value = next;
-  };
-
-  const unregisterHistoryVisibilityRef = (consumerId: symbol): void => {
-    if (!historyVisibilityRefs.value.has(consumerId)) {
-      return;
-    }
-
-    const next = new Map(historyVisibilityRefs.value);
-    next.delete(consumerId);
-    historyVisibilityRefs.value = next;
-  };
-
   const backendUrl = dependencies.useBackendUrl('/') as ComputedRef<string>;
-  const getBackendUrl = (): string | null => backendUrl.value || null;
 
-  const historyLimit = computed<number>(() => {
-    for (const visibility of historyVisibilityRefs.value.values()) {
-      if (visibility.value) {
-        return HISTORY_LIMIT_WHEN_SHOWING;
-      }
-    }
+  const { isInitialized } = storeToRefs(orchestratorManagerStore);
 
-    return DEFAULT_HISTORY_LIMIT;
+  const ensureOrchestrator = () =>
+    orchestratorManagerStore.ensureOrchestrator(() => orchestratorStore);
+
+  const consumersApi = useOrchestratorConsumers({ managerStore: orchestratorManagerStore });
+
+  const notifyAll: GenerationOrchestratorAcquireOptions['notify'] = (
+    message,
+    type: Parameters<GenerationOrchestratorAcquireOptions['notify']>[1] = 'info',
+  ) => {
+    consumersApi.consumers.value.forEach((consumer) => {
+      consumer.notify(message, type);
+    });
+  };
+
+  const debugAll: NonNullable<GenerationOrchestratorAcquireOptions['debug']> = (
+    ...args: unknown[]
+  ) => {
+    consumersApi.consumers.value.forEach((consumer) => {
+      consumer.debug?.(...args);
+    });
+  };
+
+  const lifecycle = useOrchestratorLifecycle({
+    managerStore: orchestratorManagerStore,
+    historyLimit: consumersApi.historyLimit,
+    getBackendUrl: () => backendUrl.value || null,
+    ensureOrchestrator,
+    notifyAll,
+    debugAll,
   });
 
-  let lifecycleScope: EffectScope | null = null;
+  const commands = useOrchestratorCommands({ getOrchestrator: ensureOrchestrator });
+  const effects = useOrchestratorEffects({
+    historyLimit: consumersApi.historyLimit,
+    backendUrl,
+    isInitialized,
+    ensureOrchestrator,
+  });
 
   const {
     recentResults,
@@ -163,387 +105,47 @@ export const createUseGenerationOrchestratorManager = (
     transportPauseSince,
   } = storeToRefs(orchestratorStore);
 
-  const notifyAll: GenerationNotificationAdapter['notify'] = (
-    message,
-    type: Parameters<GenerationNotificationAdapter['notify']>[1] = 'info',
-  ) => {
-    consumers.value.forEach((consumer) => {
-      consumer.notify(message, type);
-    });
-  };
-
-  const debugAll: GenerationNotificationAdapter['debug'] = (...args: unknown[]) => {
-    consumers.value.forEach((consumer) => {
-      consumer.debug?.(...args);
-    });
-  };
-
-  const ensureOrchestrator = (): ReturnType<typeof useGenerationOrchestratorStore> =>
-    orchestratorManagerStore.ensureOrchestrator(() => orchestratorStore);
-
-  let historyWatcherStop: WatchStopHandle | null = null;
-  let backendWatcherStop: WatchStopHandle | null = null;
-
-  const ensureLifecycleScope = (): EffectScope => {
-    if (!lifecycleScope) {
-      lifecycleScope = effectScope();
-    }
-
-    return lifecycleScope;
-  };
-
-  const stopLifecycleScope = (): void => {
-    if (!lifecycleScope) {
-      return;
-    }
-
-    historyWatcherStop?.();
-    backendWatcherStop?.();
-    historyWatcherStop = null;
-    backendWatcherStop = null;
-    lifecycleScope.stop();
-    lifecycleScope = null;
-  };
-
-  let environmentCleanup: (() => void) | null = null;
-  let lastEnvironmentKey = '';
-  let lastPauseActive = false;
-
-  const logLifecycleEvent = (
-    event: 'pause' | 'resume',
-    payload: GenerationTransportPausePayload | GenerationTransportResumePayload,
-  ): void => {
-    const entry: Record<string, unknown> = {
-      event,
-      timestamp: new Date(payload.timestamp).toISOString(),
-      source: payload.source,
-      hidden: payload.hidden,
-      online: payload.online,
-    };
-
-    if ('reasons' in payload) {
-      entry.reasons = [...payload.reasons];
-    }
-
-    console.info('[GenerationOrchestratorLifecycle]', entry);
-  };
-
-  const getEnvironmentState = () => {
-    const hidden = typeof document !== 'undefined' ? document.hidden === true : false;
-    const online = typeof navigator === 'undefined' ? true : navigator.onLine !== false;
-    const reasons: GenerationTransportPauseReason[] = [];
-
-    if (hidden) {
-      reasons.push('document-hidden');
-    }
-
-    if (!online) {
-      reasons.push('network-offline');
-    }
-
-    return { hidden, online, reasons } as const;
-  };
-
-  const applyEnvironmentPauseState = (
-    source: string,
-    options: { force?: boolean } = {},
-  ): void => {
-    if (typeof window === 'undefined') {
-      return;
-    }
-
-    const state = getEnvironmentState();
-    const key = `${state.reasons.join('|')}|hidden:${state.hidden}|online:${state.online}`;
-    const previousKey = lastEnvironmentKey;
-    const wasPaused = lastPauseActive;
-
-    if (!options.force && key === previousKey) {
-      return;
-    }
-
-    lastEnvironmentKey = key;
-    lastPauseActive = state.reasons.length > 0;
-
-    if (!isInitialized.value) {
-      return;
-    }
-
-    const orchestratorInstance = orchestratorManagerStore.orchestrator.value;
-    if (!orchestratorInstance) {
-      return;
-    }
-
-    const timestamp = Date.now();
-
-    if (state.reasons.length > 0) {
-      const payload: GenerationTransportPausePayload = {
-        reasons: state.reasons,
-        hidden: state.hidden,
-        online: state.online,
-        source,
-        timestamp,
-      };
-      orchestratorInstance.pauseTransport(payload);
-      logLifecycleEvent('pause', payload);
-      return;
-    }
-
-    if (!options.force && !wasPaused) {
-      return;
-    }
-
-    const resumePayload: GenerationTransportResumePayload = {
-      hidden: state.hidden,
-      online: state.online,
-      source,
-      timestamp,
-    };
-
-    void orchestratorInstance
-      .resumeTransport(resumePayload)
-      .catch((error) => {
-        console.error('Failed to resume generation transport after environment change:', error);
-      });
-    logLifecycleEvent('resume', resumePayload);
-  };
-
-  const startEnvironmentListeners = (): void => {
-    if (environmentCleanup || typeof window === 'undefined' || typeof document === 'undefined') {
-      return;
-    }
-
-    const handleVisibilityChange = (): void => {
-      applyEnvironmentPauseState('visibilitychange');
-    };
-    const handleOnline = (): void => {
-      applyEnvironmentPauseState('online');
-    };
-    const handleOffline = (): void => {
-      applyEnvironmentPauseState('offline');
-    };
-
-    document.addEventListener('visibilitychange', handleVisibilityChange);
-    window.addEventListener('online', handleOnline);
-    window.addEventListener('offline', handleOffline);
-
-    environmentCleanup = () => {
-      document.removeEventListener('visibilitychange', handleVisibilityChange);
-      window.removeEventListener('online', handleOnline);
-      window.removeEventListener('offline', handleOffline);
-    };
-
-    applyEnvironmentPauseState('environment:init', { force: true });
-  };
-
-  const stopEnvironmentListeners = (): void => {
-    if (!environmentCleanup) {
-      return;
-    }
-
-    environmentCleanup();
-    environmentCleanup = null;
-    lastEnvironmentKey = '';
-    lastPauseActive = false;
-  };
-
-  const hasHistoryAutoSync = (): boolean => {
-    for (const consumer of consumers.value.values()) {
-      if (consumer.autoSyncHistory) {
-        return true;
-      }
-    }
-    return false;
-  };
-
-  const hasBackendAutoSync = (): boolean => {
-    for (const consumer of consumers.value.values()) {
-      if (consumer.autoSyncBackend) {
-        return true;
-      }
-    }
-    return false;
-  };
-
-  const startHistoryWatcher = (): void => {
-    if (historyWatcherStop || !hasHistoryAutoSync()) {
-      return;
-    }
-
-    const scope = ensureLifecycleScope();
-    historyWatcherStop =
-      scope.run(
-        () =>
-          watch(historyLimit, (next, previous) => {
-            if (!isInitialized.value || previous === next) {
-              return;
-            }
-
-            const orchestrator = ensureOrchestrator();
-            orchestrator.setHistoryLimit(next);
-            void orchestrator.loadRecentResults(false);
-          }),
-      ) ?? null;
-  };
-
-  const stopHistoryWatcher = (): void => {
-    if (!historyWatcherStop) {
-      return;
-    }
-
-    historyWatcherStop();
-    historyWatcherStop = null;
-  };
-
-  const startBackendWatcher = (): void => {
-    if (backendWatcherStop || !hasBackendAutoSync()) {
-      return;
-    }
-
-    const scope = ensureLifecycleScope();
-    backendWatcherStop =
-      scope.run(
-        () =>
-          watch(backendUrl, (next, previous) => {
-            if (!isInitialized.value || next === previous) {
-              return;
-            }
-
-            const orchestrator = ensureOrchestrator();
-            void orchestrator.handleBackendUrlChange();
-          }),
-      ) ?? null;
-  };
-
-  const stopBackendWatcher = (): void => {
-    if (!backendWatcherStop) {
-      return;
-    }
-
-    backendWatcherStop();
-    backendWatcherStop = null;
-  };
-
   const updateAutoSyncWatchers = (): void => {
-    if (hasHistoryAutoSync()) {
-      startHistoryWatcher();
-    } else {
-      stopHistoryWatcher();
-    }
-
-    if (hasBackendAutoSync()) {
-      startBackendWatcher();
-    } else {
-      stopBackendWatcher();
-    }
-
-    if (!historyWatcherStop && !backendWatcherStop && consumers.value.size === 0) {
-      stopLifecycleScope();
-    }
+    effects.updateAutoSyncWatchers({
+      history: consumersApi.hasHistoryAutoSync(),
+      backend: consumersApi.hasBackendAutoSync(),
+    });
   };
 
-  const ensureInitialized = async (
-    options: GenerationOrchestratorAcquireOptions,
-  ): Promise<void> => {
-    if (isInitialized.value) {
-      return;
-    }
-
-    if (!initializationPromise.value) {
-      const orchestrator = ensureOrchestrator();
-      ensureLifecycleScope();
-      const promise = orchestrator
-        .initialize({
-          historyLimit: historyLimit.value,
-          getBackendUrl,
-          notificationAdapter: {
-            notify: notifyAll,
-            debug: debugAll,
-          },
-          queueClient: options.queueClient,
-          websocketManager: options.websocketManager,
-        })
-        .then(() => {
-          isInitialized.value = true;
-        })
-        .catch((error) => {
-          isInitialized.value = false;
-          throw error;
-        })
-        .finally(() => {
-          initializationPromise.value = null;
-        });
-
-      initializationPromise.value = promise;
-    }
-
-    await initializationPromise.value;
-    applyEnvironmentPauseState('environment:sync', { force: true });
-  };
-
-  const releaseConsumer = (id: symbol): void => {
-    if (!consumers.value.has(id)) {
-      return;
-    }
-
-    orchestratorManagerStore.unregisterConsumer(id);
-    unregisterHistoryVisibilityRef(id);
+  const releaseConsumer = (releaseFn: () => void): void => {
+    releaseFn();
 
     if (!orchestratorManagerStore.hasActiveConsumers()) {
-      stopHistoryWatcher();
-      stopBackendWatcher();
-      stopEnvironmentListeners();
-      orchestratorManagerStore.destroyOrchestrator();
-      stopLifecycleScope();
+      effects.stopAllWatchers();
+      lifecycle.destroy();
       return;
     }
 
     updateAutoSyncWatchers();
-
   };
 
-  const acquire = (
-    options: GenerationOrchestratorAcquireOptions,
-  ): GenerationOrchestratorBinding => {
+  const acquire = (options: GenerationOrchestratorAcquireOptions): GenerationOrchestratorBinding => {
     const autoSync = normalizeAutoSyncOptions(options.autoSync);
 
-    const consumer: GenerationOrchestratorConsumer = {
-      id: Symbol('generation-orchestrator-consumer'),
+    const consumer = consumersApi.acquireConsumer({
       notify: options.notify,
       debug: options.debug,
-      autoSyncHistory: autoSync.historyLimit,
-      autoSyncBackend: autoSync.backendUrl,
-    };
-
-    const orchestrator = ensureOrchestrator();
-    orchestratorManagerStore.registerConsumer(consumer);
-    registerHistoryVisibilityRef(consumer.id, options.historyVisibility);
+      historyVisibility: options.historyVisibility,
+      autoSync,
+    });
 
     updateAutoSyncWatchers();
-    startEnvironmentListeners();
-
-    const loadSystemStatusData = (): Promise<void> => orchestrator.loadSystemStatusData();
-    const loadActiveJobsData = (): Promise<void> => orchestrator.loadActiveJobsData();
-    const loadRecentResultsData = (notifySuccess?: boolean): Promise<void> =>
-      orchestrator.loadRecentResults(notifySuccess);
-    const startGeneration = (payload: GenerationRequestPayload): Promise<GenerationStartResponse> =>
-      orchestrator.startGeneration(payload);
-    const cancelJob = (jobId: string): Promise<void> => orchestrator.cancelJob(jobId);
-    const clearQueue = (): Promise<void> => orchestrator.clearQueue();
-    const deleteResult = (resultId: string | number): Promise<void> =>
-      orchestrator.deleteResult(resultId);
-    const refreshResults = (notifySuccess = false): Promise<void> =>
-      orchestrator.loadRecentResults(notifySuccess);
-    const setHistoryLimit = (limit: number): void => {
-      orchestrator.setHistoryLimit(limit);
-    };
-    const handleBackendUrlChange = (): Promise<void> => orchestrator.handleBackendUrlChange();
+    lifecycle.startEnvironmentListeners();
 
     const initialize = async (): Promise<void> => {
-      await ensureInitialized(options);
+      await lifecycle.ensureInitialized({
+        queueClient: options.queueClient,
+        websocketManager: options.websocketManager,
+      });
     };
 
-    const cleanup = (): void => {
-      releaseConsumer(consumer.id);
+    const release = (): void => {
+      releaseConsumer(consumer.release);
     };
 
     const binding: GenerationOrchestratorBinding = {
@@ -553,21 +155,21 @@ export const createUseGenerationOrchestratorManager = (
       systemStatus,
       isConnected,
       initialize,
-      cleanup,
-      loadSystemStatusData,
-      loadActiveJobsData,
-      loadRecentResultsData,
-      startGeneration,
-      cancelJob,
-      clearQueue,
-      deleteResult,
-      refreshResults,
-      setHistoryLimit,
-      handleBackendUrlChange,
-      canCancelJob: (job) => orchestrator.isJobCancellable(job),
-      release: () => {
-        releaseConsumer(consumer.id);
+      cleanup: release,
+      loadSystemStatusData: () => commands.loadSystemStatusData(),
+      loadActiveJobsData: () => commands.loadActiveJobsData(),
+      loadRecentResultsData: (notifySuccess?: boolean) => commands.loadRecentResultsData(notifySuccess),
+      startGeneration: (payload: GenerationRequestPayload) => commands.startGeneration(payload),
+      cancelJob: (jobId: string) => commands.cancelJob(jobId),
+      clearQueue: () => commands.clearQueue(),
+      deleteResult: (resultId: string | number) => commands.deleteResult(resultId),
+      refreshResults: (notifySuccess?: boolean) => commands.refreshResults(notifySuccess),
+      setHistoryLimit: (limit: number) => {
+        commands.setHistoryLimit(limit);
       },
+      handleBackendUrlChange: () => commands.handleBackendUrlChange(),
+      canCancelJob: (job) => commands.canCancelJob(job),
+      release,
     };
 
     return binding;
@@ -593,3 +195,6 @@ export const useGenerationOrchestratorManager = createUseGenerationOrchestratorM
 export type UseGenerationOrchestratorManagerReturn = ReturnType<
   typeof useGenerationOrchestratorManager
 >;
+
+export type { GenerationOrchestratorAcquireOptions, GenerationOrchestratorAutoSyncOptions, GenerationOrchestratorBinding } from './useGenerationOrchestratorManager.types';
+

--- a/app/frontend/src/features/generation/composables/useGenerationOrchestratorManager.types.ts
+++ b/app/frontend/src/features/generation/composables/useGenerationOrchestratorManager.types.ts
@@ -1,0 +1,45 @@
+import type { Ref } from 'vue';
+
+import type { GenerationNotificationAdapter } from './useGenerationTransport';
+import type { GenerationQueueClient } from '../services/queueClient';
+import type { GenerationWebSocketManager } from '../services/websocketManager';
+import type { GenerationRequestPayload, GenerationStartResponse, SystemStatusState } from '@/types';
+import type { DeepReadonly } from '@/utils/freezeDeep';
+import type { GenerationJobView, GenerationResultView } from '../orchestrator/facade';
+
+export interface GenerationOrchestratorAutoSyncOptions {
+  historyLimit?: boolean;
+  backendUrl?: boolean;
+}
+
+export interface GenerationOrchestratorAcquireOptions {
+  notify: GenerationNotificationAdapter['notify'];
+  debug?: GenerationNotificationAdapter['debug'];
+  queueClient?: GenerationQueueClient;
+  websocketManager?: GenerationWebSocketManager;
+  autoSync?: boolean | GenerationOrchestratorAutoSyncOptions;
+  historyVisibility?: Readonly<Ref<boolean>>;
+}
+
+export interface GenerationOrchestratorBinding {
+  activeJobs: Ref<ReadonlyArray<GenerationJobView>>;
+  sortedActiveJobs: Ref<ReadonlyArray<GenerationJobView>>;
+  recentResults: Ref<ReadonlyArray<GenerationResultView>>;
+  systemStatus: Ref<DeepReadonly<SystemStatusState>>;
+  isConnected: Ref<boolean>;
+  initialize: () => Promise<void>;
+  cleanup: () => void;
+  loadSystemStatusData: () => Promise<void>;
+  loadActiveJobsData: () => Promise<void>;
+  loadRecentResultsData: (notifySuccess?: boolean) => Promise<void>;
+  startGeneration: (payload: GenerationRequestPayload) => Promise<GenerationStartResponse>;
+  cancelJob: (jobId: string) => Promise<void>;
+  clearQueue: () => Promise<void>;
+  deleteResult: (resultId: string | number) => Promise<void>;
+  refreshResults: (notifySuccess?: boolean) => Promise<void>;
+  canCancelJob: (job: GenerationJobView) => boolean;
+  setHistoryLimit: (limit: number) => void;
+  handleBackendUrlChange: () => Promise<void>;
+  release: () => void;
+}
+

--- a/app/frontend/src/features/generation/composables/useOrchestratorCommands.ts
+++ b/app/frontend/src/features/generation/composables/useOrchestratorCommands.ts
@@ -1,0 +1,92 @@
+import type { GenerationRequestPayload, GenerationStartResponse } from '@/types';
+
+import type { GenerationJobView } from '../orchestrator/facade';
+import type { GenerationOrchestratorStore } from '../stores/useGenerationOrchestratorStore';
+
+const normalizeCommandError = (error: unknown): Error => {
+  if (error instanceof Error) {
+    return error;
+  }
+
+  if (typeof error === 'string' && error.trim()) {
+    return new Error(error);
+  }
+
+  return new Error('Generation orchestrator command failed');
+};
+
+const wrapCommand = <Args extends unknown[], Result>(
+  handler: (...args: Args) => Promise<Result> | Result,
+): ((...args: Args) => Promise<Result>) => {
+  return async (...args: Args): Promise<Result> => {
+    try {
+      return await Promise.resolve(handler(...args));
+    } catch (error) {
+      throw normalizeCommandError(error);
+    }
+  };
+};
+
+export interface OrchestratorCommandsOptions {
+  getOrchestrator: () => GenerationOrchestratorStore;
+}
+
+export interface OrchestratorCommandsApi {
+  loadSystemStatusData: () => Promise<void>;
+  loadActiveJobsData: () => Promise<void>;
+  loadRecentResultsData: (notifySuccess?: boolean) => Promise<void>;
+  startGeneration: (payload: GenerationRequestPayload) => Promise<GenerationStartResponse>;
+  cancelJob: (jobId: string) => Promise<void>;
+  clearQueue: () => Promise<void>;
+  deleteResult: (resultId: string | number) => Promise<void>;
+  refreshResults: (notifySuccess?: boolean) => Promise<void>;
+  canCancelJob: (job: GenerationJobView) => boolean;
+  setHistoryLimit: (limit: number) => void;
+  handleBackendUrlChange: () => Promise<void>;
+}
+
+export const useOrchestratorCommands = (
+  options: OrchestratorCommandsOptions,
+): OrchestratorCommandsApi => {
+  const loadSystemStatusData = (): Promise<void> =>
+    options.getOrchestrator().loadSystemStatusData();
+  const loadActiveJobsData = (): Promise<void> => options.getOrchestrator().loadActiveJobsData();
+  const loadRecentResultsData = (notifySuccess = false): Promise<void> =>
+    options.getOrchestrator().loadRecentResults(notifySuccess);
+  const startGeneration = (payload: GenerationRequestPayload): Promise<GenerationStartResponse> =>
+    options.getOrchestrator().startGeneration(payload);
+
+  const cancelJob = wrapCommand((jobId: string) => options.getOrchestrator().cancelJob(jobId));
+  const clearQueue = wrapCommand(() => options.getOrchestrator().clearQueue());
+  const deleteResult = wrapCommand((resultId: string | number) =>
+    options.getOrchestrator().deleteResult(resultId),
+  );
+  const refreshResults = wrapCommand((notifySuccess = false) =>
+    options.getOrchestrator().loadRecentResults(notifySuccess),
+  );
+
+  const canCancelJob = (job: GenerationJobView): boolean =>
+    options.getOrchestrator().isJobCancellable(job);
+
+  const setHistoryLimit = (limit: number): void => {
+    options.getOrchestrator().setHistoryLimit(limit);
+  };
+
+  const handleBackendUrlChange = (): Promise<void> =>
+    options.getOrchestrator().handleBackendUrlChange();
+
+  return {
+    loadSystemStatusData,
+    loadActiveJobsData,
+    loadRecentResultsData,
+    startGeneration,
+    cancelJob,
+    clearQueue,
+    deleteResult,
+    refreshResults,
+    canCancelJob,
+    setHistoryLimit,
+    handleBackendUrlChange,
+  };
+};
+

--- a/app/frontend/src/features/generation/composables/useOrchestratorConsumers.ts
+++ b/app/frontend/src/features/generation/composables/useOrchestratorConsumers.ts
@@ -1,0 +1,124 @@
+import { storeToRefs } from 'pinia';
+import { computed, shallowRef, type ComputedRef, type Ref } from 'vue';
+
+import type {
+  GenerationOrchestratorAcquireOptions,
+  GenerationOrchestratorAutoSyncOptions,
+} from './useGenerationOrchestratorManager.types';
+import type {
+  GenerationOrchestratorConsumer,
+  GenerationOrchestratorManagerStore,
+} from '../stores/orchestratorManagerStore';
+import { DEFAULT_HISTORY_LIMIT } from '../stores/useGenerationOrchestratorStore';
+
+export interface OrchestratorConsumersOptions {
+  managerStore: GenerationOrchestratorManagerStore;
+}
+
+export interface AcquireConsumerOptions
+  extends Pick<GenerationOrchestratorAcquireOptions, 'notify' | 'debug' | 'historyVisibility'> {
+  autoSync: Required<GenerationOrchestratorAutoSyncOptions>;
+}
+
+export interface OrchestratorConsumersApi {
+  consumers: Ref<Map<symbol, GenerationOrchestratorConsumer>>;
+  historyLimit: ComputedRef<number>;
+  acquireConsumer: (options: AcquireConsumerOptions) => { id: symbol; release: () => void };
+  hasHistoryAutoSync: () => boolean;
+  hasBackendAutoSync: () => boolean;
+}
+
+const HISTORY_LIMIT_WHEN_SHOWING = 50;
+
+export const useOrchestratorConsumers = (
+  options: OrchestratorConsumersOptions,
+): OrchestratorConsumersApi => {
+  const { consumers } = storeToRefs(options.managerStore);
+  const historyVisibilityRefs = shallowRef(
+    new Map<symbol, Readonly<Ref<boolean>> | undefined>(),
+  );
+
+  const registerHistoryVisibilityRef = (
+    consumerId: symbol,
+    visibility: Readonly<Ref<boolean>> | undefined,
+  ): void => {
+    if (!visibility) {
+      return;
+    }
+
+    const next = new Map(historyVisibilityRefs.value);
+    next.set(consumerId, visibility);
+    historyVisibilityRefs.value = next;
+  };
+
+  const unregisterHistoryVisibilityRef = (consumerId: symbol): void => {
+    if (!historyVisibilityRefs.value.has(consumerId)) {
+      return;
+    }
+
+    const next = new Map(historyVisibilityRefs.value);
+    next.delete(consumerId);
+    historyVisibilityRefs.value = next;
+  };
+
+  const historyLimit = computed<number>(() => {
+    for (const visibility of historyVisibilityRefs.value.values()) {
+      if (visibility?.value) {
+        return HISTORY_LIMIT_WHEN_SHOWING;
+      }
+    }
+
+    return DEFAULT_HISTORY_LIMIT;
+  });
+
+  const acquireConsumer = (
+    acquireOptions: AcquireConsumerOptions,
+  ): { id: symbol; release: () => void } => {
+    const consumer: GenerationOrchestratorConsumer = {
+      id: Symbol('generation-orchestrator-consumer'),
+      notify: acquireOptions.notify,
+      debug: acquireOptions.debug,
+      autoSyncHistory: acquireOptions.autoSync.historyLimit,
+      autoSyncBackend: acquireOptions.autoSync.backendUrl,
+    };
+
+    options.managerStore.registerConsumer(consumer);
+    registerHistoryVisibilityRef(consumer.id, acquireOptions.historyVisibility);
+
+    const release = (): void => {
+      options.managerStore.unregisterConsumer(consumer.id);
+      unregisterHistoryVisibilityRef(consumer.id);
+    };
+
+    return { id: consumer.id, release };
+  };
+
+  const hasHistoryAutoSync = (): boolean => {
+    for (const consumer of consumers.value.values()) {
+      if (consumer.autoSyncHistory) {
+        return true;
+      }
+    }
+    return false;
+  };
+
+  const hasBackendAutoSync = (): boolean => {
+    for (const consumer of consumers.value.values()) {
+      if (consumer.autoSyncBackend) {
+        return true;
+      }
+    }
+    return false;
+  };
+
+  return {
+    consumers,
+    historyLimit,
+    acquireConsumer,
+    hasHistoryAutoSync,
+    hasBackendAutoSync,
+  };
+};
+
+export { HISTORY_LIMIT_WHEN_SHOWING };
+

--- a/app/frontend/src/features/generation/composables/useOrchestratorEffects.ts
+++ b/app/frontend/src/features/generation/composables/useOrchestratorEffects.ts
@@ -1,0 +1,129 @@
+import { effectScope, watch, type ComputedRef, type EffectScope, type Ref, type WatchStopHandle } from 'vue';
+
+import type { GenerationOrchestratorStore } from '../stores/useGenerationOrchestratorStore';
+
+export interface OrchestratorEffectsOptions {
+  historyLimit: ComputedRef<number>;
+  backendUrl: ComputedRef<string>;
+  isInitialized: Ref<boolean>;
+  ensureOrchestrator: () => GenerationOrchestratorStore;
+  onHistoryLimitChange?: (next: number, previous: number | undefined) => void;
+  onBackendUrlChange?: (next: string, previous: string | undefined) => void;
+}
+
+export interface OrchestratorEffectsApi {
+  updateAutoSyncWatchers: (state: { history: boolean; backend: boolean }) => void;
+  stopAllWatchers: () => void;
+}
+
+export const useOrchestratorEffects = (
+  options: OrchestratorEffectsOptions,
+): OrchestratorEffectsApi => {
+  let lifecycleScope: EffectScope | null = null;
+  let historyWatcherStop: WatchStopHandle | null = null;
+  let backendWatcherStop: WatchStopHandle | null = null;
+
+  const ensureLifecycleScope = (): EffectScope => {
+    if (!lifecycleScope) {
+      lifecycleScope = effectScope();
+    }
+
+    return lifecycleScope;
+  };
+
+  const stopLifecycleScope = (): void => {
+    if (!lifecycleScope) {
+      return;
+    }
+
+    historyWatcherStop?.();
+    backendWatcherStop?.();
+    historyWatcherStop = null;
+    backendWatcherStop = null;
+    lifecycleScope.stop();
+    lifecycleScope = null;
+  };
+
+  const startHistoryWatcher = (): void => {
+    if (historyWatcherStop) {
+      return;
+    }
+
+    const scope = ensureLifecycleScope();
+    historyWatcherStop =
+      scope.run(
+        () =>
+          watch(options.historyLimit, (next, previous) => {
+            if (!options.isInitialized.value || previous === next) {
+              return;
+            }
+
+            const orchestrator = options.ensureOrchestrator();
+            orchestrator.setHistoryLimit(next);
+            void orchestrator.loadRecentResults(false);
+            options.onHistoryLimitChange?.(next, previous);
+          }),
+      ) ?? null;
+  };
+
+  const stopHistoryWatcher = (): void => {
+    historyWatcherStop?.();
+    historyWatcherStop = null;
+  };
+
+  const startBackendWatcher = (): void => {
+    if (backendWatcherStop) {
+      return;
+    }
+
+    const scope = ensureLifecycleScope();
+    backendWatcherStop =
+      scope.run(
+        () =>
+          watch(options.backendUrl, (next, previous) => {
+            if (!options.isInitialized.value || next === previous) {
+              return;
+            }
+
+            const orchestrator = options.ensureOrchestrator();
+            void orchestrator.handleBackendUrlChange();
+            options.onBackendUrlChange?.(next, previous);
+          }),
+      ) ?? null;
+  };
+
+  const stopBackendWatcher = (): void => {
+    backendWatcherStop?.();
+    backendWatcherStop = null;
+  };
+
+  const updateAutoSyncWatchers = (state: { history: boolean; backend: boolean }): void => {
+    if (state.history) {
+      startHistoryWatcher();
+    } else {
+      stopHistoryWatcher();
+    }
+
+    if (state.backend) {
+      startBackendWatcher();
+    } else {
+      stopBackendWatcher();
+    }
+
+    if (!historyWatcherStop && !backendWatcherStop) {
+      stopLifecycleScope();
+    }
+  };
+
+  const stopAllWatchers = (): void => {
+    stopHistoryWatcher();
+    stopBackendWatcher();
+    stopLifecycleScope();
+  };
+
+  return {
+    updateAutoSyncWatchers,
+    stopAllWatchers,
+  };
+};
+

--- a/app/frontend/src/features/generation/composables/useOrchestratorLifecycle.ts
+++ b/app/frontend/src/features/generation/composables/useOrchestratorLifecycle.ts
@@ -1,0 +1,230 @@
+import { storeToRefs } from 'pinia';
+import type { ComputedRef } from 'vue';
+
+import type { GenerationOrchestratorAcquireOptions } from './useGenerationOrchestratorManager.types';
+import type { GenerationNotificationAdapter } from './useGenerationTransport';
+import type { GenerationOrchestratorManagerStore } from '../stores/orchestratorManagerStore';
+import type { GenerationOrchestratorStore } from '../stores/useGenerationOrchestratorStore';
+import type {
+  GenerationTransportPausePayload,
+  GenerationTransportResumePayload,
+  GenerationTransportPauseReason,
+} from '../types/transport';
+
+export interface OrchestratorLifecycleOptions {
+  managerStore: GenerationOrchestratorManagerStore;
+  historyLimit: ComputedRef<number>;
+  getBackendUrl: () => string | null;
+  ensureOrchestrator: () => GenerationOrchestratorStore;
+  notifyAll: GenerationNotificationAdapter['notify'];
+  debugAll: GenerationNotificationAdapter['debug'];
+}
+
+export interface OrchestratorLifecycleApi {
+  ensureInitialized: (
+    options: Pick<GenerationOrchestratorAcquireOptions, 'queueClient' | 'websocketManager'>,
+  ) => Promise<void>;
+  startEnvironmentListeners: () => void;
+  stopEnvironmentListeners: () => void;
+  destroy: () => void;
+  applyEnvironmentStateForTests?: () => void;
+}
+
+const logLifecycleEvent = (
+  event: 'pause' | 'resume',
+  payload: GenerationTransportPausePayload | GenerationTransportResumePayload,
+): void => {
+  const entry: Record<string, unknown> = {
+    event,
+    timestamp: new Date(payload.timestamp).toISOString(),
+    source: payload.source,
+    hidden: payload.hidden,
+    online: payload.online,
+  };
+
+  if ('reasons' in payload) {
+    entry.reasons = [...payload.reasons];
+  }
+
+  console.info('[GenerationOrchestratorLifecycle]', entry);
+};
+
+const getEnvironmentState = () => {
+  const hidden = typeof document !== 'undefined' ? document.hidden === true : false;
+  const online = typeof navigator === 'undefined' ? true : navigator.onLine !== false;
+  const reasons: GenerationTransportPauseReason[] = [];
+
+  if (hidden) {
+    reasons.push('document-hidden');
+  }
+
+  if (!online) {
+    reasons.push('network-offline');
+  }
+
+  return { hidden, online, reasons } as const;
+};
+
+export const useOrchestratorLifecycle = (
+  options: OrchestratorLifecycleOptions,
+): OrchestratorLifecycleApi => {
+  const { orchestrator, initializationPromise, isInitialized } = storeToRefs(options.managerStore);
+  let environmentCleanup: (() => void) | null = null;
+  let lastEnvironmentKey = '';
+  let lastPauseActive = false;
+
+  const applyEnvironmentPauseState = (
+    source: string,
+    applyOptions: { force?: boolean } = {},
+  ): void => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    const state = getEnvironmentState();
+    const key = `${state.reasons.join('|')}|hidden:${state.hidden}|online:${state.online}`;
+    const previousKey = lastEnvironmentKey;
+    const wasPaused = lastPauseActive;
+
+    if (!applyOptions.force && key === previousKey) {
+      return;
+    }
+
+    lastEnvironmentKey = key;
+    lastPauseActive = state.reasons.length > 0;
+
+    if (!isInitialized.value) {
+      return;
+    }
+
+    const orchestratorInstance = orchestrator.value;
+    if (!orchestratorInstance) {
+      return;
+    }
+
+    const timestamp = Date.now();
+
+    if (state.reasons.length > 0) {
+      const payload: GenerationTransportPausePayload = {
+        reasons: state.reasons,
+        hidden: state.hidden,
+        online: state.online,
+        source,
+        timestamp,
+      };
+      orchestratorInstance.pauseTransport(payload);
+      logLifecycleEvent('pause', payload);
+      return;
+    }
+
+    if (!applyOptions.force && !wasPaused) {
+      return;
+    }
+
+    const resumePayload: GenerationTransportResumePayload = {
+      hidden: state.hidden,
+      online: state.online,
+      source,
+      timestamp,
+    };
+
+    void orchestratorInstance.resumeTransport(resumePayload).catch((error) => {
+      console.error('Failed to resume generation transport after environment change:', error);
+    });
+    logLifecycleEvent('resume', resumePayload);
+  };
+
+  const startEnvironmentListeners = (): void => {
+    if (environmentCleanup || typeof window === 'undefined' || typeof document === 'undefined') {
+      return;
+    }
+
+    const handleVisibilityChange = (): void => {
+      applyEnvironmentPauseState('visibilitychange');
+    };
+    const handleOnline = (): void => {
+      applyEnvironmentPauseState('online');
+    };
+    const handleOffline = (): void => {
+      applyEnvironmentPauseState('offline');
+    };
+
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+    window.addEventListener('online', handleOnline);
+    window.addEventListener('offline', handleOffline);
+
+    environmentCleanup = () => {
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
+      window.removeEventListener('online', handleOnline);
+      window.removeEventListener('offline', handleOffline);
+    };
+
+    applyEnvironmentPauseState('environment:init', { force: true });
+  };
+
+  const stopEnvironmentListeners = (): void => {
+    if (!environmentCleanup) {
+      return;
+    }
+
+    environmentCleanup();
+    environmentCleanup = null;
+    lastEnvironmentKey = '';
+    lastPauseActive = false;
+  };
+
+  const ensureInitialized = async (
+    initializeOptions: Pick<GenerationOrchestratorAcquireOptions, 'queueClient' | 'websocketManager'>,
+  ): Promise<void> => {
+    if (isInitialized.value) {
+      return;
+    }
+
+    if (!initializationPromise.value) {
+      const orchestratorInstance = options.ensureOrchestrator();
+
+      const promise = orchestratorInstance
+        .initialize({
+          historyLimit: options.historyLimit.value,
+          getBackendUrl: options.getBackendUrl,
+          notificationAdapter: {
+            notify: options.notifyAll,
+            debug: options.debugAll,
+          },
+          queueClient: initializeOptions.queueClient,
+          websocketManager: initializeOptions.websocketManager,
+        })
+        .then(() => {
+          isInitialized.value = true;
+        })
+        .catch((error) => {
+          isInitialized.value = false;
+          throw error;
+        })
+        .finally(() => {
+          initializationPromise.value = null;
+        });
+
+      initializationPromise.value = promise;
+    }
+
+    await initializationPromise.value;
+    applyEnvironmentPauseState('environment:sync', { force: true });
+  };
+
+  const destroy = (): void => {
+    stopEnvironmentListeners();
+    options.managerStore.destroyOrchestrator();
+  };
+
+  return {
+    ensureInitialized,
+    startEnvironmentListeners,
+    stopEnvironmentListeners,
+    destroy,
+    applyEnvironmentStateForTests: () => {
+      applyEnvironmentPauseState('test', { force: true });
+    },
+  };
+};
+

--- a/app/frontend/src/utils/freezeDeep.ts
+++ b/app/frontend/src/utils/freezeDeep.ts
@@ -122,72 +122,13 @@ const freezeDeepInternal = <T>(value: T, seen = new WeakSet<object>()): DeepRead
   return Object.freeze(value) as DeepReadonly<T>;
 };
 
-const formatMutationPath = (segments: readonly PropertyKey[]): string => {
-  if (segments.length === 0) {
-    return '<root>';
-  }
-
-  return segments
-    .map((segment) =>
-      typeof segment === 'symbol' ? segment.toString() : String(segment),
-    )
-    .join('.');
-};
-
-const createDevMutationGuard = <T>(
-  value: T,
-  seen = new WeakMap<object, unknown>(),
-  path: readonly PropertyKey[] = [],
-): T => {
-  if (value === null || typeof value !== 'object') {
-    return value;
-  }
-
-  const existing = seen.get(value as object);
-  if (existing) {
-    return existing as T;
-  }
-
-  const guard = new Proxy(value as object, {
-    set(): never {
-      throw new Error(
-        `Attempted to mutate immutable snapshot at ${formatMutationPath(path)}`,
-      );
-    },
-    deleteProperty(): never {
-      throw new Error(
-        `Attempted to mutate immutable snapshot at ${formatMutationPath(path)}`,
-      );
-    },
-    defineProperty(): never {
-      throw new Error(
-        `Attempted to mutate immutable snapshot at ${formatMutationPath(path)}`,
-      );
-    },
-    get(target, property, receiver) {
-      const result = Reflect.get(target, property, receiver);
-      if (result === null || typeof result !== 'object') {
-        return result;
-      }
-
-      return createDevMutationGuard(result, seen, [...path, property]);
-    },
-  });
-
-  seen.set(value as object, guard);
-  return guard as T;
-};
-
 export const freezeDeep = <T>(value: T): DeepReadonly<T> => {
   if (value === null || typeof value !== 'object') {
     return value as DeepReadonly<T>;
   }
 
   const cloned = cloneDeep(value);
+  const frozen = freezeDeepInternal(cloned);
 
-  if (!import.meta.env.DEV) {
-    return cloned as DeepReadonly<T>;
-  }
-
-  return createDevMutationGuard(cloned) as DeepReadonly<T>;
+  return frozen;
 };

--- a/tests/vue/composables/useGenerationOrchestratorManager.integration.spec.ts
+++ b/tests/vue/composables/useGenerationOrchestratorManager.integration.spec.ts
@@ -7,7 +7,8 @@ vi.mock('@/features/generation/composables/createGenerationTransportAdapter', ()
 }));
 
 import { createGenerationTransportAdapter } from '@/features/generation/composables/createGenerationTransportAdapter';
-import { createUseGenerationOrchestratorManager, HISTORY_LIMIT_WHEN_SHOWING } from '@/features/generation/composables/useGenerationOrchestratorManager';
+import { createUseGenerationOrchestratorManager } from '@/features/generation/composables/useGenerationOrchestratorManager';
+import { HISTORY_LIMIT_WHEN_SHOWING } from '@/features/generation/composables/useOrchestratorConsumers';
 import { useGenerationOrchestratorStore, DEFAULT_HISTORY_LIMIT } from '@/features/generation/stores/useGenerationOrchestratorStore';
 import { useGenerationOrchestratorManagerStore } from '@/features/generation/stores/orchestratorManagerStore';
 import { useBackendUrl } from '@/utils/backend';
@@ -26,6 +27,8 @@ const createTransportMock = () => ({
   startGeneration: vi.fn().mockResolvedValue({ job_id: 'job-1' } as any),
   cancelJob: vi.fn().mockResolvedValue(undefined),
   deleteResult: vi.fn().mockResolvedValue(undefined),
+  pause: vi.fn(),
+  resume: vi.fn().mockResolvedValue(undefined),
   reconnect: vi.fn(),
   setPollInterval: vi.fn(),
   clear: vi.fn(),

--- a/tests/vue/composables/useOrchestratorCommands.spec.ts
+++ b/tests/vue/composables/useOrchestratorCommands.spec.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi } from 'vitest';
+
+import { useOrchestratorCommands } from '@/features/generation/composables/useOrchestratorCommands';
+import type { GenerationOrchestratorStore } from '@/features/generation/stores/useGenerationOrchestratorStore';
+import type { GenerationRequestPayload, GenerationStartResponse } from '@/types';
+import type { GenerationJobView } from '@/features/generation/orchestrator';
+
+const createOrchestrator = () => ({
+  loadSystemStatusData: vi.fn().mockResolvedValue(undefined),
+  loadActiveJobsData: vi.fn().mockResolvedValue(undefined),
+  loadRecentResults: vi.fn().mockResolvedValue(undefined),
+  startGeneration: vi
+    .fn<[GenerationRequestPayload], Promise<GenerationStartResponse>>()
+    .mockResolvedValue({} as GenerationStartResponse),
+  cancelJob: vi.fn<[string], Promise<void>>().mockResolvedValue(undefined),
+  clearQueue: vi.fn<[], Promise<void>>().mockResolvedValue(undefined),
+  deleteResult: vi.fn<[string | number], Promise<void>>().mockResolvedValue(undefined),
+  isJobCancellable: vi.fn().mockReturnValue(true),
+  setHistoryLimit: vi.fn(),
+  handleBackendUrlChange: vi.fn().mockResolvedValue(undefined),
+} as unknown as Pick<
+  GenerationOrchestratorStore,
+  | 'loadSystemStatusData'
+  | 'loadActiveJobsData'
+  | 'loadRecentResults'
+  | 'startGeneration'
+  | 'cancelJob'
+  | 'clearQueue'
+  | 'deleteResult'
+  | 'isJobCancellable'
+  | 'setHistoryLimit'
+  | 'handleBackendUrlChange'
+>);
+
+describe('useOrchestratorCommands', () => {
+  it('wraps orchestrator commands and normalizes errors', async () => {
+    const orchestrator = createOrchestrator();
+    const commands = useOrchestratorCommands({
+      getOrchestrator: () => orchestrator as GenerationOrchestratorStore,
+    });
+
+    await commands.loadSystemStatusData();
+    await commands.loadActiveJobsData();
+    await commands.loadRecentResultsData();
+    await commands.startGeneration({} as GenerationRequestPayload);
+
+    await commands.cancelJob('job-1');
+    await commands.clearQueue();
+    await commands.deleteResult('result-1');
+    await commands.refreshResults();
+    commands.setHistoryLimit(25);
+    await commands.handleBackendUrlChange();
+
+    expect(orchestrator.cancelJob).toHaveBeenCalledWith('job-1');
+    expect(orchestrator.setHistoryLimit).toHaveBeenCalledWith(25);
+    expect(commands.canCancelJob({} as GenerationJobView)).toBe(true);
+
+    orchestrator.cancelJob.mockRejectedValueOnce('boom');
+    await expect(commands.cancelJob('bad-job')).rejects.toThrow('boom');
+
+    orchestrator.clearQueue.mockRejectedValueOnce({});
+    await expect(commands.clearQueue()).rejects.toThrow('Generation orchestrator command failed');
+  });
+});
+

--- a/tests/vue/composables/useOrchestratorConsumers.spec.ts
+++ b/tests/vue/composables/useOrchestratorConsumers.spec.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi } from 'vitest';
+import { ref, shallowRef } from 'vue';
+
+import {
+  useOrchestratorConsumers,
+  HISTORY_LIMIT_WHEN_SHOWING,
+} from '@/features/generation/composables/useOrchestratorConsumers';
+import { DEFAULT_HISTORY_LIMIT } from '@/features/generation/stores/useGenerationOrchestratorStore';
+import type { GenerationOrchestratorManagerStore } from '@/features/generation/stores/orchestratorManagerStore';
+
+const createManagerStore = () => {
+  const consumers = shallowRef(new Map());
+
+  const managerStore = {
+    consumers,
+    registerConsumer: vi.fn((consumer) => {
+      consumers.value.set(consumer.id, consumer);
+    }),
+    unregisterConsumer: vi.fn((id: symbol) => {
+      consumers.value.delete(id);
+    }),
+  } as unknown as Pick<
+    GenerationOrchestratorManagerStore,
+    'consumers' | 'registerConsumer' | 'unregisterConsumer'
+  >;
+
+  return managerStore;
+};
+
+describe('useOrchestratorConsumers', () => {
+  it('registers and unregisters consumers while tracking history visibility', () => {
+    const managerStore = createManagerStore();
+    const historyVisibility = ref(false);
+
+    const consumers = useOrchestratorConsumers({ managerStore });
+
+    expect(consumers.historyLimit.value).toBe(DEFAULT_HISTORY_LIMIT);
+
+    const { release, id } = consumers.acquireConsumer({
+      notify: vi.fn(),
+      debug: vi.fn(),
+      historyVisibility,
+      autoSync: { backendUrl: true, historyLimit: true },
+    });
+
+    expect(managerStore.registerConsumer).toHaveBeenCalled();
+    expect(managerStore.consumers.value.has(id)).toBe(true);
+
+    historyVisibility.value = true;
+    expect(consumers.historyLimit.value).toBe(HISTORY_LIMIT_WHEN_SHOWING);
+
+    release();
+
+    expect(managerStore.unregisterConsumer).toHaveBeenCalledWith(id);
+    expect(consumers.historyLimit.value).toBe(DEFAULT_HISTORY_LIMIT);
+  });
+
+  it('reports auto-sync capabilities from registered consumers', () => {
+    const managerStore = createManagerStore();
+    const consumers = useOrchestratorConsumers({ managerStore });
+
+    expect(consumers.hasHistoryAutoSync()).toBe(false);
+    expect(consumers.hasBackendAutoSync()).toBe(false);
+
+    const first = consumers.acquireConsumer({
+      notify: vi.fn(),
+      autoSync: { historyLimit: true, backendUrl: false },
+    });
+
+    expect(consumers.hasHistoryAutoSync()).toBe(true);
+    expect(consumers.hasBackendAutoSync()).toBe(false);
+
+    const second = consumers.acquireConsumer({
+      notify: vi.fn(),
+      autoSync: { historyLimit: false, backendUrl: true },
+    });
+
+    expect(consumers.hasHistoryAutoSync()).toBe(true);
+    expect(consumers.hasBackendAutoSync()).toBe(true);
+
+    first.release();
+    expect(consumers.hasHistoryAutoSync()).toBe(false);
+    expect(consumers.hasBackendAutoSync()).toBe(true);
+
+    second.release();
+    expect(consumers.hasBackendAutoSync()).toBe(false);
+  });
+});
+

--- a/tests/vue/composables/useOrchestratorEffects.spec.ts
+++ b/tests/vue/composables/useOrchestratorEffects.spec.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi } from 'vitest';
+import { computed, ref, nextTick } from 'vue';
+
+import { useOrchestratorEffects } from '@/features/generation/composables/useOrchestratorEffects';
+import type { GenerationOrchestratorStore } from '@/features/generation/stores/useGenerationOrchestratorStore';
+
+const createOrchestrator = () => ({
+  setHistoryLimit: vi.fn(),
+  loadRecentResults: vi.fn().mockResolvedValue(undefined),
+  handleBackendUrlChange: vi.fn().mockResolvedValue(undefined),
+} as unknown as Pick<
+  GenerationOrchestratorStore,
+  'setHistoryLimit' | 'loadRecentResults' | 'handleBackendUrlChange'
+>);
+
+describe('useOrchestratorEffects', () => {
+  it('reacts to history limit changes when auto-sync is enabled', async () => {
+    const historyLimit = ref(10);
+    const backendUrl = ref('http://localhost');
+    const isInitialized = ref(false);
+    const orchestrator = createOrchestrator();
+    const ensureOrchestrator = vi.fn(() => orchestrator as GenerationOrchestratorStore);
+
+    const effects = useOrchestratorEffects({
+      historyLimit: computed(() => historyLimit.value),
+      backendUrl: computed(() => backendUrl.value),
+      isInitialized,
+      ensureOrchestrator,
+    });
+
+    effects.updateAutoSyncWatchers({ history: true, backend: false });
+
+    historyLimit.value = 20;
+    await nextTick();
+
+    expect(orchestrator.setHistoryLimit).not.toHaveBeenCalled();
+
+    isInitialized.value = true;
+    historyLimit.value = 30;
+    await nextTick();
+
+    expect(orchestrator.setHistoryLimit).toHaveBeenCalledWith(30);
+    expect(orchestrator.loadRecentResults).toHaveBeenCalledWith(false);
+
+    effects.stopAllWatchers();
+    historyLimit.value = 40;
+    await nextTick();
+    expect(orchestrator.setHistoryLimit).toHaveBeenCalledTimes(1);
+  });
+
+  it('reacts to backend URL changes when auto-sync is enabled', async () => {
+    const historyLimit = ref(10);
+    const backendUrl = ref('http://one');
+    const isInitialized = ref(true);
+    const orchestrator = createOrchestrator();
+    const ensureOrchestrator = vi.fn(() => orchestrator as GenerationOrchestratorStore);
+
+    const effects = useOrchestratorEffects({
+      historyLimit: computed(() => historyLimit.value),
+      backendUrl: computed(() => backendUrl.value),
+      isInitialized,
+      ensureOrchestrator,
+    });
+
+    effects.updateAutoSyncWatchers({ history: false, backend: true });
+
+    backendUrl.value = 'http://two';
+    await nextTick();
+
+    expect(orchestrator.handleBackendUrlChange).toHaveBeenCalledTimes(1);
+
+    effects.updateAutoSyncWatchers({ history: false, backend: false });
+    backendUrl.value = 'http://three';
+    await nextTick();
+    expect(orchestrator.handleBackendUrlChange).toHaveBeenCalledTimes(1);
+  });
+});
+

--- a/tests/vue/composables/useOrchestratorLifecycle.spec.ts
+++ b/tests/vue/composables/useOrchestratorLifecycle.spec.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { computed, ref, shallowRef } from 'vue';
+
+import { useOrchestratorLifecycle } from '@/features/generation/composables/useOrchestratorLifecycle';
+import type { GenerationOrchestratorManagerStore } from '@/features/generation/stores/orchestratorManagerStore';
+import type { GenerationOrchestratorStore } from '@/features/generation/stores/useGenerationOrchestratorStore';
+
+const createManagerStore = (orchestrator: GenerationOrchestratorStore) => {
+  const store = {
+    orchestrator: shallowRef(orchestrator),
+    initializationPromise: ref<Promise<void> | null>(null),
+    isInitialized: ref(false),
+    destroyOrchestrator: vi.fn(() => {
+      store.orchestrator.value = null;
+    }),
+  } as unknown as Pick<
+    GenerationOrchestratorManagerStore,
+    'orchestrator' | 'initializationPromise' | 'isInitialized' | 'destroyOrchestrator'
+  >;
+
+  return store;
+};
+
+describe('useOrchestratorLifecycle', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('initializes the orchestrator and synchronizes environment state', async () => {
+    const orchestrator = {
+      initialize: vi.fn().mockResolvedValue(undefined),
+      pauseTransport: vi.fn(),
+      resumeTransport: vi.fn().mockResolvedValue(undefined),
+    } as unknown as Pick<
+      GenerationOrchestratorStore,
+      'initialize' | 'pauseTransport' | 'resumeTransport'
+    >;
+
+    const managerStore = createManagerStore(orchestrator as GenerationOrchestratorStore);
+
+    const lifecycle = useOrchestratorLifecycle({
+      managerStore: managerStore as GenerationOrchestratorManagerStore,
+      historyLimit: computed(() => 10),
+      getBackendUrl: () => 'http://localhost',
+      ensureOrchestrator: () => orchestrator as GenerationOrchestratorStore,
+      notifyAll: vi.fn(),
+      debugAll: vi.fn(),
+    });
+
+    await lifecycle.ensureInitialized({});
+
+    expect(orchestrator.initialize).toHaveBeenCalledTimes(1);
+    const args = vi.mocked(orchestrator.initialize).mock.calls[0][0];
+    expect(args.historyLimit).toBe(10);
+    expect(args.getBackendUrl()).toBe('http://localhost');
+    expect(managerStore.isInitialized.value).toBe(true);
+    expect(orchestrator.resumeTransport).toHaveBeenCalled();
+    expect(managerStore.initializationPromise.value).toBeNull();
+  });
+
+  it('stops environment listeners on destroy', () => {
+    const orchestrator = {
+      initialize: vi.fn(),
+      pauseTransport: vi.fn(),
+      resumeTransport: vi.fn().mockResolvedValue(undefined),
+    } as unknown as Pick<
+      GenerationOrchestratorStore,
+      'initialize' | 'pauseTransport' | 'resumeTransport'
+    >;
+
+    const managerStore = createManagerStore(orchestrator as GenerationOrchestratorStore);
+
+    const addSpy = vi.spyOn(document, 'addEventListener');
+    const removeSpy = vi.spyOn(document, 'removeEventListener');
+    const windowAddSpy = vi.spyOn(window, 'addEventListener');
+    const windowRemoveSpy = vi.spyOn(window, 'removeEventListener');
+
+    const lifecycle = useOrchestratorLifecycle({
+      managerStore: managerStore as GenerationOrchestratorManagerStore,
+      historyLimit: computed(() => 10),
+      getBackendUrl: () => 'http://localhost',
+      ensureOrchestrator: () => orchestrator as GenerationOrchestratorStore,
+      notifyAll: vi.fn(),
+      debugAll: vi.fn(),
+    });
+
+    lifecycle.startEnvironmentListeners();
+    lifecycle.destroy();
+
+    expect(addSpy).toHaveBeenCalled();
+    expect(windowAddSpy).toHaveBeenCalled();
+    expect(removeSpy).toHaveBeenCalled();
+    expect(windowRemoveSpy).toHaveBeenCalled();
+    expect(managerStore.destroyOrchestrator).toHaveBeenCalled();
+  });
+
+  it('resets initialization state when initialization fails', async () => {
+    const error = new Error('fail');
+    const orchestrator = {
+      initialize: vi.fn().mockRejectedValue(error),
+      pauseTransport: vi.fn(),
+      resumeTransport: vi.fn().mockResolvedValue(undefined),
+    } as unknown as Pick<
+      GenerationOrchestratorStore,
+      'initialize' | 'pauseTransport' | 'resumeTransport'
+    >;
+
+    const managerStore = createManagerStore(orchestrator as GenerationOrchestratorStore);
+
+    const lifecycle = useOrchestratorLifecycle({
+      managerStore: managerStore as GenerationOrchestratorManagerStore,
+      historyLimit: computed(() => 10),
+      getBackendUrl: () => 'http://localhost',
+      ensureOrchestrator: () => orchestrator as GenerationOrchestratorStore,
+      notifyAll: vi.fn(),
+      debugAll: vi.fn(),
+    });
+
+    await expect(lifecycle.ensureInitialized({})).rejects.toThrow(error);
+    expect(managerStore.isInitialized.value).toBe(false);
+    expect(managerStore.initializationPromise.value).toBeNull();
+  });
+});
+

--- a/tests/vue/orchestrator/facade.spec.ts
+++ b/tests/vue/orchestrator/facade.spec.ts
@@ -8,7 +8,7 @@ import {
   type GenerationHistoryLimit,
   type ImmutableGenerationJob,
   type ImmutableGenerationResult,
-} from '@/features/generation/orchestrator/facade';
+} from '@/features/generation/orchestrator';
 import type { DeepReadonly } from '@/utils/freezeDeep';
 import type { SystemStatusState } from '@/types';
 import type {

--- a/tests/vue/stores/orchestrator/transportActions.spec.ts
+++ b/tests/vue/stores/orchestrator/transportActions.spec.ts
@@ -22,6 +22,9 @@ describe('transportActions', () => {
       enqueueJob: vi.fn(),
       removeJob: vi.fn(),
       getCancellableJobs: vi.fn(() => [{ id: 'job-1' }, { id: 'job-2' }]),
+      getJobByIdentifier: vi.fn((identifier: string) =>
+        identifier === 'job-1' ? { backendId: 'job-1' } : undefined,
+      ),
     } as any;
     const results = {
       historyLimit: { value: 5 },


### PR DESCRIPTION
## Summary
- split `useGenerationOrchestratorManager` into a thin composer that delegates consumer tracking, lifecycle, effects, and commands to dedicated composables for better reuse and testability
- add focused unit tests for each new composable and update existing integration specs to exercise the shared manager wiring
- simplify the deep freeze helper now that we no longer rely on proxy-based mutation guards

## Testing
- `npm run test -- --runInBand orchestrator`
- `npm run test` *(fails across unrelated suites because numerous existing specs require additional mocks; run aborted)*

------
https://chatgpt.com/codex/tasks/task_e_68ddf82cabb08329892e5a738ab250fe