### PR TITLE
Virtualize generation results gallery

### DIFF
--- a/app/frontend/src/features/generation/components/GenerationResultsGallery.vue
+++ b/app/frontend/src/features/generation/components/GenerationResultsGallery.vue
@@ -6,63 +6,55 @@
           {{ showHistory ? 'Generation History' : 'Recent Results' }}
         </h3>
         <button
-          @click="emit('refresh-results')"
           class="text-gray-400 hover:text-gray-600"
           type="button"
+          @click="emit('refresh-results')"
         >
           <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"></path>
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
           </svg>
         </button>
       </div>
     </div>
     <div class="card-body">
-      <div class="space-y-4 max-h-96 overflow-y-auto">
-        <div
-          v-for="result in recentResults"
-          :key="result.id"
-          class="border border-gray-200 rounded-lg overflow-hidden"
-        >
-          <!-- Image Thumbnail -->
-          <img
-            v-if="result.image_url"
-            :src="result.image_url"
-            :alt="result.prompt ?? undefined"
-            class="w-full h-32 object-cover cursor-pointer"
-            @click="emit('show-image-modal', result)"
-          >
-
-          <!-- Result Info -->
-          <div class="p-3">
-            <div class="text-sm text-gray-900 mb-1 line-clamp-2">
-              {{ result.prompt ?? 'Untitled Generation' }}
-            </div>
-            <div class="flex items-center justify-between text-xs text-gray-500">
-              <span>{{ formatTime(result.created_at) }}</span>
-              <div class="flex space-x-2">
-                <button
-                  @click="emit('reuse-parameters', result)"
-                  class="text-blue-500 hover:text-blue-700"
-                  type="button"
-                >
-                  Reuse
-                </button>
-                <button
-                  @click="emit('delete-result', result.id)"
-                  class="text-red-500 hover:text-red-700"
-                  type="button"
-                >
-                  Delete
-                </button>
-              </div>
-            </div>
+      <RecycleScroller
+        v-if="hasResults"
+        class="max-h-96 overflow-y-auto pr-1"
+        :items="virtualizedItems"
+        :item-size="ITEM_SIZE"
+        :buffer="SCROLLER_BUFFER"
+        key-field="id"
+      >
+        <template #default="{ item }">
+          <div class="pb-4 last:pb-0">
+            <HistoryRecentResultCard
+              :result="item.history"
+              :formatted-date="formatTime(item.history.created_at)"
+              @view="emit('show-image-modal', item.original)"
+              @reuse="emit('reuse-parameters', item.original)"
+              @delete="emit('delete-result', item.id)"
+            />
           </div>
-        </div>
+        </template>
 
-        <!-- Empty State -->
-        <div v-if="recentResults.length === 0" class="empty-state-container">
+        <template #placeholder>
+          <div class="pb-4 last:pb-0">
+            <HistoryRecentResultCard loading />
+          </div>
+        </template>
+      </RecycleScroller>
+
+      <div v-else>
+        <div v-if="showSkeletons" class="space-y-4">
+          <HistoryRecentResultCard
+            v-for="index in SKELETON_COUNT"
+            :key="`results-skeleton-${index}`"
+            loading
+          />
+        </div>
+        <div v-else class="empty-state-container">
           <svg class="empty-state-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"></path>
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" />
           </svg>
           <div class="empty-state-title">No results yet</div>
           <div class="empty-state-message">Generated images will appear here</div>
@@ -73,10 +65,15 @@
 </template>
 
 <script setup lang="ts">
-import { toRefs } from 'vue'
+import { computed, onMounted, ref, toRefs } from 'vue'
+
+import { HistoryRecentResultCard } from '@/features/history'
+import { toHistoryResult } from '@/utils/generationHistory'
+import { RecycleScroller } from 'vue-virtual-scroller'
 
 import type { UseGenerationStudioReturn } from '../composables/useGenerationStudio'
 import type { ResultItemView, ReadonlyResults } from '@/features/generation/orchestrator'
+import type { GenerationHistoryResult } from '@/types'
 
 const props = defineProps<{
   recentResults: ReadonlyResults
@@ -91,5 +88,35 @@ const emit = defineEmits<{
   (event: 'show-image-modal', result: ResultItemView): void
 }>()
 
+const ITEM_SIZE = 184
+const SCROLLER_BUFFER = 600
+const SKELETON_COUNT = 3
+
 const { recentResults, showHistory, formatTime } = toRefs(props)
+
+type VirtualizedResultItem = {
+  readonly id: ResultItemView['id']
+  readonly original: ResultItemView
+  readonly history: GenerationHistoryResult
+}
+
+const hasHydrated = ref(false)
+
+onMounted(() => {
+  requestAnimationFrame(() => {
+    hasHydrated.value = true
+  })
+})
+
+const virtualizedItems = computed<VirtualizedResultItem[]>(() =>
+  recentResults.value.map((result) => ({
+    id: result.id,
+    original: result,
+    history: toHistoryResult(result),
+  })),
+)
+
+const hasResults = computed(() => virtualizedItems.value.length > 0)
+
+const showSkeletons = computed(() => !hasResults.value && !hasHydrated.value)
 </script>

--- a/app/frontend/src/features/history/components/HistoryRecentResultCard.vue
+++ b/app/frontend/src/features/history/components/HistoryRecentResultCard.vue
@@ -1,0 +1,106 @@
+<template>
+  <div class="border border-gray-200 rounded-lg overflow-hidden" :class="{ 'pointer-events-none opacity-80': loading }">
+    <div v-if="loading" class="animate-pulse">
+      <div class="w-full h-32 bg-gray-200" />
+      <div class="p-3 space-y-3">
+        <div class="h-4 bg-gray-200 rounded" />
+        <div class="flex items-center justify-between">
+          <div class="h-3 w-24 bg-gray-200 rounded" />
+          <div class="flex space-x-2">
+            <div class="h-3 w-12 bg-gray-200 rounded" />
+            <div class="h-3 w-12 bg-gray-200 rounded" />
+          </div>
+        </div>
+      </div>
+    </div>
+    <template v-else-if="result">
+      <button class="block w-full" type="button" @click="handleView">
+        <img
+          v-if="result.image_url"
+          :src="result.image_url"
+          :alt="result.prompt ?? 'Generated image'"
+          class="w-full h-32 object-cover"
+        >
+        <div v-else class="w-full h-32 bg-gray-100 flex items-center justify-center text-gray-400 text-sm">
+          No preview available
+        </div>
+      </button>
+      <div class="p-3 space-y-2">
+        <div class="text-sm text-gray-900 line-clamp-2">
+          {{ result.prompt ?? 'Untitled Generation' }}
+        </div>
+        <div class="flex items-center justify-between text-xs text-gray-500">
+          <span>{{ formattedDate }}</span>
+          <div class="flex space-x-2">
+            <button class="text-blue-500 hover:text-blue-700" type="button" @click="handleReuse">
+              Reuse
+            </button>
+            <button class="text-red-500 hover:text-red-700" type="button" @click="handleDelete">
+              Delete
+            </button>
+          </div>
+        </div>
+      </div>
+    </template>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue';
+
+import type { GenerationHistoryResult } from '@/types';
+
+const props = withDefaults(
+  defineProps<{
+    result?: GenerationHistoryResult | null;
+    formattedDate?: string;
+    loading?: boolean;
+  }>(),
+  {
+    result: null,
+    formattedDate: '',
+    loading: false,
+  },
+);
+
+const emit = defineEmits<{
+  (event: 'view'): void;
+  (event: 'reuse'): void;
+  (event: 'delete'): void;
+}>();
+
+const canInteract = computed(() => !props.loading && !!props.result);
+
+const handleView = (): void => {
+  if (!canInteract.value) {
+    return;
+  }
+
+  emit('view');
+};
+
+const handleReuse = (): void => {
+  if (!canInteract.value) {
+    return;
+  }
+
+  emit('reuse');
+};
+
+const handleDelete = (): void => {
+  if (!canInteract.value) {
+    return;
+  }
+
+  emit('delete');
+};
+</script>
+
+<style scoped>
+.line-clamp-2 {
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+</style>

--- a/app/frontend/src/features/history/components/index.ts
+++ b/app/frontend/src/features/history/components/index.ts
@@ -9,6 +9,7 @@ export { default as HistoryGrid } from './HistoryGrid.vue';
 export { default as HistoryGridItem } from './HistoryGridItem.vue';
 export { default as HistoryList } from './HistoryList.vue';
 export { default as HistoryListItem } from './HistoryListItem.vue';
+export { default as HistoryRecentResultCard } from './HistoryRecentResultCard.vue';
 export { default as HistoryModal } from './HistoryModal.vue';
 export { default as HistoryModalController } from './HistoryModalController.vue';
 export { default as HistoryModalLauncher } from './HistoryModalLauncher.vue';


### PR DESCRIPTION
## Summary
- virtualize the generation results gallery with vue-virtual-scroller for smoother scrolling
- reuse a shared history card widget for recent results, including skeleton placeholders

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ddfde873808329b3abc044fc597cdd