### PR TITLE
Refine history public API surface

### DIFF
--- a/app/frontend/src/features/generation/components/GenerationResultsGallery.vue
+++ b/app/frontend/src/features/generation/components/GenerationResultsGallery.vue
@@ -67,7 +67,7 @@
 <script setup lang="ts">
 import { computed, onMounted, ref, toRefs } from 'vue'
 
-import { HistoryRecentResultCard } from '@/features/history'
+import { HistoryRecentResultCard } from '@/features/history/public'
 import { toHistoryResult } from '@/utils/generationHistory'
 import { RecycleScroller } from 'vue-virtual-scroller'
 

--- a/app/frontend/src/features/history/components/GenerationHistoryController.vue
+++ b/app/frontend/src/features/history/components/GenerationHistoryController.vue
@@ -13,16 +13,18 @@ import { useRouter } from 'vue-router';
 
 import {
   useGenerationHistory,
-  useHistoryActions,
-  useHistorySelection,
-  useHistoryShortcuts,
-  useHistoryModalCoordinator,
-  type HistorySelectionChangePayload,
-  type HistorySortOption,
   type DateFilterOption,
-  type RatingFilterOption,
   type DimensionFilterOption,
-} from '@/features/history/public';
+  type HistorySortOption,
+  type RatingFilterOption,
+} from '../composables/useGenerationHistory';
+import {
+  useHistorySelection,
+  type HistorySelectionChangePayload,
+} from '../composables/useHistorySelection';
+import { useHistoryShortcuts } from '../composables/useHistoryShortcuts';
+import { useHistoryActions } from '../composables/useHistoryActions';
+import { useHistoryModalCoordinator } from '../composables/useHistoryModalCoordinator';
 import { PERSISTENCE_KEYS, useAsyncLifecycleTask, usePersistence } from '@/composables/shared';
 import { useBackendRefresh } from '@/services';
 import { useBackendBase } from '@/utils/backend';

--- a/app/frontend/src/features/history/components/GenerationHistoryView.vue
+++ b/app/frontend/src/features/history/components/GenerationHistoryView.vue
@@ -109,10 +109,10 @@ import type { PropType } from 'vue';
 import type {
   DateFilterOption,
   DimensionFilterOption,
-  HistorySelectionChangePayload,
   HistorySortOption,
   RatingFilterOption,
-} from '@/features/history/public';
+} from '../composables/useGenerationHistory';
+import type { HistorySelectionChangePayload } from '../composables/useHistorySelection';
 import type { GenerationHistoryResult, GenerationHistoryStats } from '@/types';
 
 import HistoryActionToolbar, { type HistoryViewMode } from './HistoryActionToolbar.vue';

--- a/app/frontend/src/features/history/components/HistoryActionToolbar.vue
+++ b/app/frontend/src/features/history/components/HistoryActionToolbar.vue
@@ -63,7 +63,7 @@
 </template>
 
 <script setup lang="ts">
-import type { HistorySortOption } from '@/features/history/public';
+import type { HistorySortOption } from '../composables/useGenerationHistory';
 
 export type HistoryViewMode = 'grid' | 'list';
 

--- a/app/frontend/src/features/history/components/HistoryFilters.vue
+++ b/app/frontend/src/features/history/components/HistoryFilters.vue
@@ -54,7 +54,7 @@ import type {
   DateFilterOption,
   DimensionFilterOption,
   RatingFilterOption,
-} from '@/features/history/public';
+} from '../composables/useGenerationHistory';
 
 const DATE_FILTER_OPTIONS = ['all', 'today', 'week', 'month'] as const;
 const RATING_FILTER_OPTIONS = [0, 1, 2, 3, 4, 5] as const;

--- a/app/frontend/src/features/history/composables/useGenerationHistory.ts
+++ b/app/frontend/src/features/history/composables/useGenerationHistory.ts
@@ -3,7 +3,7 @@ import type { MaybeRefOrGetter } from 'vue';
 
 import { debounce, type DebouncedFunction } from '@/utils/async';
 import { useBackendClient } from '@/services/backendClient';
-import { listResults as listHistoryResults } from '@/features/history/services';
+import { listResults as listHistoryResults } from '../services/historyService';
 import type {
   GenerationHistoryQuery,
   GenerationHistoryResult,

--- a/app/frontend/src/features/history/composables/useHistoryActions.ts
+++ b/app/frontend/src/features/history/composables/useHistoryActions.ts
@@ -12,7 +12,7 @@ import {
   favoriteResult as favoriteHistoryResult,
   favoriteResults as favoriteHistoryResults,
   rateResult as rateHistoryResult,
-} from '@/features/history/services';
+} from '../services/historyService';
 import type { GenerationHistoryResult, NotificationType } from '@/types';
 
 export interface UseHistoryActionsOptions {

--- a/app/frontend/src/features/history/index.ts
+++ b/app/frontend/src/features/history/index.ts
@@ -1,3 +1,6 @@
-export * from './components';
-export * from './composables';
-export * from './services';
+export {
+  GenerationHistory,
+  HistoryRecentResultCard,
+  listResults,
+} from './public';
+export type { ListResultsOptions, ListResultsOutput } from './public';

--- a/app/frontend/src/features/history/public.ts
+++ b/app/frontend/src/features/history/public.ts
@@ -1,3 +1,10 @@
-export * from './components';
-export * from './composables';
-export * from './services';
+/**
+ * Public surface for the history feature. Consumers outside the feature should import from
+ * this module instead of reaching into nested folders.
+ */
+export { default as GenerationHistory } from './components/GenerationHistory.vue';
+/** @internal */
+export { default as HistoryRecentResultCard } from './components/HistoryRecentResultCard.vue';
+
+export { listResults } from './services/historyService';
+export type { ListResultsOptions, ListResultsOutput } from './services/historyService';


### PR DESCRIPTION
## Summary
- replace the history public entrypoint with explicit exports and mark the recent-result card as internal
- update history components and composables to consume local modules instead of the public surface
- ensure cross-feature consumers import history widgets through the public entrypoint

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68de0002b698832993a153cf701c4ce5